### PR TITLE
Enable Read the Docs Integration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,7 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
+#TODO: After github.com/gojek/merlin is published, move to Read the Docs Community edition
 # Required
 version: 1
 

--- a/python/sdk/docs/conf.py
+++ b/python/sdk/docs/conf.py
@@ -69,6 +69,7 @@ html_static_path = ['_static']
 
 nbsphinx_execute = 'never'
 
+# The master toctree document.
 master_doc = 'index'
 
 apidoc_module_dir = '../merlin'


### PR DESCRIPTION
## Modification:

- Added `.readthedocs.yml` configuration file
- Linked `master` file to `index.rst`

## Result:

- Enable CI/CD publishing of documentation via Read the Docs
- Documentation for `latest` commit is here: https://dsp-merlin-merlin.readthedocs-hosted.com/en/latest/. I will work on linking documentation for `release` tags manually via webhooks.

## Checklist

- [x] Tested locally or in dev