### PR TITLE
Force pyfunc server to use mlflow 1.6.0

### DIFF
--- a/python/pyfunc-server/Dockerfile
+++ b/python/pyfunc-server/Dockerfile
@@ -28,6 +28,7 @@ RUN conda env create -f ./environment.yaml && \
 
 RUN gsutil cp -r ${MODEL_URL} .
 RUN /bin/bash -c ". activate merlin-model && \
+    sed -i 's/mlflow$/mlflow==1.6.0/' /model/conda.yaml && \
     conda env update --name merlin-model --file /model/conda.yaml && \
     python -m pyfuncserver --model_dir /model --dry_run"
 

--- a/python/pyfunc-server/local.Dockerfile
+++ b/python/pyfunc-server/local.Dockerfile
@@ -24,6 +24,7 @@ RUN conda env create -f ./environment.yaml && \
     rm -rf /root/.cache
 
 RUN /bin/bash -c ". activate merlin-model && \
+    sed -i 's/mlflow$/mlflow==1.6.0/' /model/conda.yaml && \
     conda env update --name merlin-model --file /model/conda.yaml && \
     python -m pyfuncserver --model_dir /model --dry_run"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
Our implementation of pyfunc server depend on ML Flow internal implementation, particularly this line (https://github.com/gojek/merlin/blob/0e06da707a027d929e603f87bbfebec60bec37ef/python/pyfunc-server/pyfuncserver/model.py#L33) .
Recent mlflow release (1.20 and 1.20.1) introduce internal changes which breaks our assumption. 
This PR is to force mlflow version to 1.6.0 so that it won't trigger this issue.
This is temporary fix until we implement modification to be compatible with 1.20


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes issue when using mlflow version 1.20 or 1.20.1
```
2021-08-26T09:08:14Z Traceback (most recent call last):
2021-08-26T09:08:14Z   File "/opt/conda/envs/merlin-model/lib/python3.7/site-packages/tornado/web.py", line 1702, in _execute
2021-08-26T09:08:14Z     result = method(*self.path_args, **self.path_kwargs)
2021-08-26T09:08:14Z   File "/pyfuncserver/http.py", line 62, in post
2021-08-26T09:08:14Z     response = model.predict(request, headers=headers)
2021-08-26T09:08:14Z   File "/pyfuncserver/model.py", line 33, in predict
2021-08-26T09:08:14Z     return self._model.python_model.predict(inputs, **kwargs)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Tested locally

