### PR TITLE
Log should be able to display Transformer logs

### DIFF
--- a/ui/src/components/logs/ContainerLogsView.js
+++ b/ui/src/components/logs/ContainerLogsView.js
@@ -66,8 +66,6 @@ export const ContainerLogsView = ({
   useEffect(
     () => {
       if (containersLoaded && params.component_type === "") {
-        console.log(params);
-        console.log(containers);
         if (
           containers.find(
             container => container.component_type === "image_builder"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2015748/139365072-97ac6d9a-ece3-4dd1-883a-4299cd7949f4.png)

**What this PR does / why we need it**:
Fix Bug in log display where transformer log is not shown when model pod running is 0, although transformer pod running is > 0

**Which issue(s) this PR fixes**:
As per above

Fixes #1372

**Does this PR introduce a user-facing change?**:
No



**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
