### PR TITLE
Update Google client initialisation to use MLP helper method

### DIFF
--- a/api/client/examples/model-endpoints/main.go
+++ b/api/client/examples/model-endpoints/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/caraml-dev/merlin/client"
-	"golang.org/x/oauth2/google"
+	"github.com/gojek/mlp/api/pkg/auth"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 
 	// Create an HTTP client with Google default credential
 	httpClient := http.DefaultClient
-	googleClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/userinfo.email")
+	googleClient, err := auth.InitGoogleClient(context.Background())
 	if err == nil {
 		httpClient = googleClient
 	} else {

--- a/api/client/examples/project-endpoints/main.go
+++ b/api/client/examples/project-endpoints/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/caraml-dev/merlin/client"
-	"golang.org/x/oauth2/google"
+	"github.com/gojek/mlp/api/pkg/auth"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 
 	// Create an HTTP client with Google default credential
 	httpClient := http.DefaultClient
-	googleClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/userinfo.email")
+	googleClient, err := auth.InitGoogleClient(context.Background())
 	if err == nil {
 		httpClient = googleClient
 	} else {

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -10,10 +10,10 @@ import (
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 	feast "github.com/feast-dev/feast/sdk/go"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/core"
+	"github.com/gojek/mlp/api/pkg/auth"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/jinzhu/gorm"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -86,7 +86,7 @@ func runDBMigration(db *gorm.DB, migrationPath string) {
 
 func initMLPAPIClient(ctx context.Context, cfg config.MlpAPIConfig) mlp.APIClient {
 	mlpHTTPClient := http.DefaultClient
-	googleClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/userinfo.email")
+	googleClient, err := auth.InitGoogleClient(context.Background())
 	if err == nil {
 		mlpHTTPClient = googleClient
 	} else {

--- a/api/go.mod
+++ b/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/antonmedv/expr v1.8.9
 	github.com/bboughton/gcp-helpers v0.1.0
 	github.com/buger/jsonparser v1.1.1
+	github.com/caraml-dev/merlin-pyspark-app v0.0.3
 	github.com/caraml-dev/protopath v0.1.0
 	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/cespare/xxhash v1.1.0
@@ -24,8 +25,7 @@ require (
 	github.com/go-playground/validator v9.30.0+incompatible
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gogo/protobuf v1.3.2
-	github.com/caraml-dev/merlin-pyspark-app v0.0.3
-	github.com/gojek/mlp v1.7.5-0.20230117024729-05ede139570e
+	github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7
 	github.com/gojekfarm/jsonpath v0.1.1
 	github.com/golang-migrate/migrate/v4 v4.11.0
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
@@ -192,8 +192,8 @@ require (
 )
 
 replace (
-	github.com/go-gota/gota => github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598
 	github.com/caraml-dev/merlin-pyspark-app => ../python/batch-predictor
+	github.com/go-gota/gota => github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598
 	github.com/googleapis/gnostic => github.com/google/gnostic v0.5.5
 	github.com/prometheus/tsdb => github.com/prometheus/tsdb v0.3.1
 	k8s.io/api => k8s.io/api v0.21.3

--- a/api/go.mod
+++ b/api/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/go-playground/validator v9.30.0+incompatible
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gogo/protobuf v1.3.2
-	github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7
+	github.com/gojek/mlp v1.7.6-0.20230329030735-c28dca2aeef9
 	github.com/gojekfarm/jsonpath v0.1.1
 	github.com/golang-migrate/migrate/v4 v4.11.0
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551

--- a/api/go.sum
+++ b/api/go.sum
@@ -697,8 +697,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7 h1:XFvsVUhisSoJDFlqlvIMb+us0ylMaUbgoeF7zdOYEaM=
-github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7/go.mod h1:HJDSyFXHB9FG479T0mrQ6cBDdftZ7an/3HfFxRGu3BA=
+github.com/gojek/mlp v1.7.6-0.20230329030735-c28dca2aeef9 h1:R6sFh5lqE8ulke5nDQrLTQPbsNhk80gMeBC7qcOoBeo=
+github.com/gojek/mlp v1.7.6-0.20230329030735-c28dca2aeef9/go.mod h1:HJDSyFXHB9FG479T0mrQ6cBDdftZ7an/3HfFxRGu3BA=
 github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598 h1:8bCbLeuGwgFxWeP6zl2B8dOIpWKQzZcXM7PRg2IANPk=
 github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598/go.mod h1:0N1RwZc60ImjH0LMLUTDCvPWdtxk419HJScoigjR66k=
 github.com/gojekfarm/jsonpath v0.1.1 h1:6GPJ+dBF6pPAQ536FmZw6trUD8uMXEeK//LZ7icgIy0=

--- a/api/go.sum
+++ b/api/go.sum
@@ -697,8 +697,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/gojek/mlp v1.7.5-0.20230117024729-05ede139570e h1:BYJjaOyOz4RUp7BBjC++2bmObXotofCfWLQwgTYC9qE=
-github.com/gojek/mlp v1.7.5-0.20230117024729-05ede139570e/go.mod h1:DB01k2VspsGMfMECAonbyHqa/c8ij9RQ13FkHV19pe4=
+github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7 h1:XFvsVUhisSoJDFlqlvIMb+us0ylMaUbgoeF7zdOYEaM=
+github.com/gojek/mlp v1.7.6-0.20230328080720-45464eaa4bc7/go.mod h1:HJDSyFXHB9FG479T0mrQ6cBDdftZ7an/3HfFxRGu3BA=
 github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598 h1:8bCbLeuGwgFxWeP6zl2B8dOIpWKQzZcXM7PRg2IANPk=
 github.com/gojekfarm/gota v0.12.1-0.20230221101638-6cd9260bd598/go.mod h1:0N1RwZc60ImjH0LMLUTDCvPWdtxk419HJScoigjR66k=
 github.com/gojekfarm/jsonpath v0.1.1 h1:6GPJ+dBF6pPAQ536FmZw6trUD8uMXEeK//LZ7icgIy0=
@@ -1160,7 +1160,7 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
-github.com/mitchellh/protoc-gen-go-json v1.0.0/go.mod h1:RB1NY3ZteDVJDkCF+RJz0/zRd/FV5XR7RGRp4OIkIFI=
+github.com/mitchellh/protoc-gen-go-json v1.1.0/go.mod h1:pACAKlMtBf4SMFbVswcjwNwWwlci6Vn841H5jPRcE9I=
 github.com/mmcloughlin/geohash v0.10.0 h1:9w1HchfDfdeLc+jFEf/04D27KP7E2QmpDu52wPbJWRE=
 github.com/mmcloughlin/geohash v0.10.0/go.mod h1:oNZxQo5yWJh0eMQEP/8hwQuVx9Z9tjwFUqcTB1SmG0c=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=


### PR DESCRIPTION
**What this PR does / why we need it**:
With the introduction of a helper method in MLP (https://github.com/gojek/mlp/pull/78) to abstract away the creation of a Google client to append ID tokens to the headers of outgoing requests, that is authenticated with service or user accounts, this PR imports the said helper method and uses it to initialise its Google client. 

This ensures that all outgoing requests from the Turing API server contain ID tokens in their headers.

**Which issue(s) this PR fixes**:

Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
