### PR TITLE
Replace id token with a more realistic dummy token

### DIFF
--- a/python/sdk/test/client_test.py
+++ b/python/sdk/test/client_test.py
@@ -361,7 +361,7 @@ def mock_oauth():
         "expires_in": 3600,
         "scope": "openid https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email",
         "token_type": "Bearer",
-        "id_token": "thisisnotarealtoken"
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZfV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5NzAKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6qJp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJNqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7TpdQyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoSK5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
     }
     """, status=200, content_type='application/json')
     responses.add('POST', '/token', body="""
@@ -370,6 +370,6 @@ def mock_oauth():
         "expires_in": 3600,
         "scope": "openid https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email",
         "token_type": "Bearer",
-        "id_token": "thisisnotarealtoken"
+        "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzcyI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZfV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5NzAKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6qJp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJNqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7TpdQyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoSK5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
     }
     """, status=200, content_type='application/json')


### PR DESCRIPTION
**What this PR does / why we need it**:
With the change in #358 to make the Merlin SDK use ID tokens for all requests made to the Merlin API, there is a need to update the dummy tokens returned by the mocked Google Identity Services (since we would now expect ID tokens to be returned from them instead of access tokens). 

If these are not updated, we would expect the SDK tests that involve initialising a Merlin client to fail since the returned credentials would contain an access token instead of an ID token. This creates errors in instances like [these](https://github.com/caraml-dev/merlin/blob/cddaf6c3b56cb2ef2adedc28389a75f64d95e270/python/sdk/test/client_test.py#L199), which use a mocked `mock_oauth` [response](https://github.com/caraml-dev/merlin/blob/cddaf6c3b56cb2ef2adedc28389a75f64d95e270/python/sdk/test/client_test.py#L364) that returns credentials with an access token. These errors would then surface as messages such as `google.auth.exceptions.MalformedError: Wrong number of segments in token: b'thisisnotarealtoken'` when the client initialisation fails.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
