### PR TITLE
Improve Image Builder Jobs Label and Annotation

### DIFF
--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -144,6 +144,7 @@ func initImageBuilder(cfg *config.Config) (webserviceBuilder imagebuilder.ImageB
 		Tolerations:          cfg.ImageBuilderConfig.Tolerations,
 		NodeSelectors:        cfg.ImageBuilderConfig.NodeSelectors,
 		MaximumRetry:         cfg.ImageBuilderConfig.MaximumRetry,
+		JobSafeToEvict:       cfg.ImageBuilderConfig.JobSafeToEvict,
 
 		ClusterName: cfg.ImageBuilderConfig.ClusterName,
 		GcpProject:  cfg.ImageBuilderConfig.GcpProject,
@@ -164,6 +165,7 @@ func initImageBuilder(cfg *config.Config) (webserviceBuilder imagebuilder.ImageB
 		Tolerations:          cfg.ImageBuilderConfig.Tolerations,
 		NodeSelectors:        cfg.ImageBuilderConfig.NodeSelectors,
 		MaximumRetry:         cfg.ImageBuilderConfig.MaximumRetry,
+		JobSafeToEvict:       cfg.ImageBuilderConfig.JobSafeToEvict,
 
 		ClusterName: cfg.ImageBuilderConfig.ClusterName,
 		GcpProject:  cfg.ImageBuilderConfig.GcpProject,

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -197,11 +197,12 @@ type ImageBuilderConfig struct {
 	KanikoServiceAccount         string                 `envconfig:"IMG_BUILDER_KANIKO_SERVICE_ACCOUNT"`
 	Resources                    ResourceRequestsLimits `envconfig:"IMG_BUILDER_RESOURCES"`
 	// How long to keep the image building job resource in the Kubernetes cluster. Default: 2 days (48 hours).
-	Retention     time.Duration        `envconfig:"IMG_BUILDER_RETENTION" default:"48h"`
-	Tolerations   Tolerations          `envconfig:"IMG_BUILDER_TOLERATIONS"`
-	NodeSelectors DictEnv              `envconfig:"IMG_BUILDER_NODE_SELECTORS"`
-	MaximumRetry  int32                `envconfig:"IMG_BUILDER_MAX_RETRY" default:"3"`
-	K8sConfig     mlpcluster.K8sConfig `envconfig:"IMG_BUILDER_K8S_CONFIG"`
+	Retention      time.Duration        `envconfig:"IMG_BUILDER_RETENTION" default:"48h"`
+	Tolerations    Tolerations          `envconfig:"IMG_BUILDER_TOLERATIONS"`
+	NodeSelectors  DictEnv              `envconfig:"IMG_BUILDER_NODE_SELECTORS"`
+	MaximumRetry   int32                `envconfig:"IMG_BUILDER_MAX_RETRY" default:"3"`
+	K8sConfig      mlpcluster.K8sConfig `envconfig:"IMG_BUILDER_K8S_CONFIG"`
+	JobSafeToEvict bool                 `envconfig:"IMG_BUILDER_JOB_SAFE_TO_EVICT" default:"false"`
 }
 
 type Tolerations []v1.Toleration

--- a/api/pkg/imagebuilder/config.go
+++ b/api/pkg/imagebuilder/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	NodeSelectors map[string]string
 	// Maximum number of retry of image builder job
 	MaximumRetry int32
+	// Value for cluster-autoscaler.kubernetes.io/safe-to-evict annotation
+	JobSafeToEvict bool
 
 	// Cluster Name
 	ClusterName string

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -336,6 +336,11 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 		Component: models.ComponentImageBuilder,
 		Stream:    project.Stream,
 		Team:      project.Team,
+		Labels:    models.MergeProjectVersionLabels(project.Labels, version.Labels),
+	}
+
+	annotations := map[string]string{
+		"cluster-autoscaler.kubernetes.io/safe-to-evict": fmt.Sprint(c.config.JobSafeToEvict),
 	}
 
 	baseImageTag, ok := c.config.BaseImages[version.PythonVersion]
@@ -411,9 +416,10 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kanikoPodName,
-			Namespace: c.config.BuildNamespace,
-			Labels:    metadata.ToLabel(),
+			Name:        kanikoPodName,
+			Namespace:   c.config.BuildNamespace,
+			Labels:      metadata.ToLabel(),
+			Annotations: annotations,
 		},
 		Spec: batchv1.JobSpec{
 			Completions:             &jobCompletions,
@@ -422,7 +428,8 @@ func (c *imageBuilder) createKanikoJobSpec(project mlp.Project, model *models.Mo
 			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: metadata.ToLabel(),
+					Labels:      metadata.ToLabel(),
+					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
 					// https://stackoverflow.com/questions/54091659/kubernetes-pods-disappear-after-failed-jobs

--- a/api/pkg/imagebuilder/imagebuilder_test.go
+++ b/api/pkg/imagebuilder/imagebuilder_test.go
@@ -76,6 +76,9 @@ var (
 		ID:            models.ID(1),
 		ArtifactURI:   testArtifactURI,
 		PythonVersion: "3.10.*",
+		Labels: models.KV{
+			"test": "true",
+		},
 	}
 
 	timeout, _      = time.ParseDuration("10s")
@@ -246,6 +249,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -262,6 +270,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -346,6 +359,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/team":         project.Team,
 						"gojek.com/environment":  config.Environment,
 						"gojek.com/component":    "image-builder",
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -362,6 +380,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/team":         project.Team,
 								"gojek.com/environment":  config.Environment,
 								"gojek.com/component":    "image-builder",
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -424,6 +447,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -440,6 +468,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -552,6 +585,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -568,6 +606,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -690,6 +733,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -706,6 +754,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -822,6 +875,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -838,6 +896,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -921,6 +984,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -937,6 +1005,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -1023,6 +1096,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -1039,6 +1117,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -1113,6 +1196,11 @@ func TestBuildImage(t *testing.T) {
 						"gojek.com/orchestrator": testOrchestratorName,
 						"gojek.com/stream":       project.Stream,
 						"gojek.com/team":         project.Team,
+						"sample":                 "true",
+						"test":                   "true",
+					},
+					Annotations: map[string]string{
+						"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 					},
 				},
 				Spec: batchv1.JobSpec{
@@ -1129,6 +1217,11 @@ func TestBuildImage(t *testing.T) {
 								"gojek.com/orchestrator": testOrchestratorName,
 								"gojek.com/stream":       project.Stream,
 								"gojek.com/team":         project.Team,
+								"sample":                 "true",
+								"test":                   "true",
+							},
+							Annotations: map[string]string{
+								"cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
 							},
 						},
 						Spec: v1.PodSpec{

--- a/charts/merlin/templates/merlin-deployment.yaml
+++ b/charts/merlin/templates/merlin-deployment.yaml
@@ -289,6 +289,8 @@ spec:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcp_service_account/service-account.json
           {{- end }}
+          - name: IMG_BUILDER_JOB_SAFE_TO_EVICT
+            value: "{{ .Values.merlin.imageBuilder.jobSafeToEvict }}"
         volumeMounts:
         - mountPath: /opt/config
           name: config

--- a/charts/merlin/values.yaml
+++ b/charts/merlin/values.yaml
@@ -30,7 +30,7 @@ merlin:
 
   environment: dev
   deploymentLabelPrefix: "gojek.com/"
-  pyfuncGRPCOptions : "{}"
+  pyfuncGRPCOptions: "{}"
 
   loggerDestinationURL: "http://yourDestinationLogger"
 
@@ -82,6 +82,7 @@ merlin:
     nodeSelectors: {}
     maxRetry: 3
     k8sConfig: ""
+    jobSafeToEvict: false
 
   gitlab:
     baseURL: https://gitlab.com/
@@ -172,7 +173,7 @@ merlin:
         keepAliveTime: 60s
         keepAliveTimeout: 5s
     kafka:
-      # brokers: 
+      # brokers:
       maxMessageSize: "1048588"
 
   # Google service account used to access GCP's resources.
@@ -425,7 +426,7 @@ swagger:
     externalPort: 8080
 
 mlp:
-  environmentConfigSecret: 
+  environmentConfigSecret:
     name: ""
     envKey: environment.yaml
     imageBuilderKey: imageBuilderK8sConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

The image-building jobs in Merlin are timing out. After some investigation, we found that one of the root causes is the node pool got scaled down resulting in the image building pods to be rescheduled.

This PR adds "cluster-autoscaler.kubernetes.io/safe-to-evict": "false" to avoid the pod get killed and rescheduled.

In Refactor deployed model labels #346, we managed to propagate user labels to models and batch prediction jobs, but not to image builder jobs (here). This PR includes adding project + model version labels to image builder job.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
