### PR TITLE
Set prediction_job_id to empty string instead of 'undefined'

### DIFF
--- a/ui/src/components/logs/ContainerLogsView.js
+++ b/ui/src/components/logs/ContainerLogsView.js
@@ -145,7 +145,7 @@ export const ContainerLogsView = ({
             model_id: model.id,
             model_name: model.name,
             version_id: versionId,
-            prediction_job_id: jobId
+            prediction_job_id: jobId ? jobId : ""
           };
           const logParams = new URLSearchParams(containerQuery).toString();
           const newLogUrl = config.MERLIN_API + "/logs?" + logParams;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Getting image builder logs for real time model is broken due to unexpected value in API's query parameter namely `prediction_job_id`.

This query parameter is used to differentiate image builder logs from real time and batch job model as you can see [here](
https://github.com/caraml-dev/merlin/blob/main/api/service/log_service.go#L204). For real time model, it expects the value to be empty string, but the UI set the value to be `undefined`.

<img width="1912" alt="image" src="https://user-images.githubusercontent.com/8122852/232712695-f741e132-ba8a-4e08-9e3a-00f0ddbf5783.png">

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
