### PR TITLE
Add topology spread constraints to deployments

### DIFF
--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -149,7 +149,7 @@ func (k *controller) Deploy(ctx context.Context, modelService *models.Service) (
 
 	isvcName := modelService.Name
 	s, err := k.servingClient.InferenceServices(modelService.Namespace).Get(isvcName, metav1.GetOptions{})
-	if err != nil {
+	if err != nil { // service to deploy is either a new inference service or a new or existing raw deployment
 		if !kerrors.IsNotFound(err) {
 			log.Errorf("unable to check inference service %s %v", isvcName, err)
 			return nil, ErrUnableToGetInferenceServiceStatus
@@ -167,7 +167,7 @@ func (k *controller) Deploy(ctx context.Context, modelService *models.Service) (
 			log.Errorf("unable to create inference service %s %v", isvcName, err)
 			return nil, ErrUnableToCreateInferenceService
 		}
-	} else {
+	} else { // service to deploy is an inference service to be updated
 		patchedSpec, err := k.kfServingResourceTemplater.PatchInferenceServiceSpec(s, modelService, k.deploymentConfig)
 		if err != nil {
 			log.Errorf("unable to update inference service %s %v", isvcName, err)

--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -149,7 +149,7 @@ func (k *controller) Deploy(ctx context.Context, modelService *models.Service) (
 
 	isvcName := modelService.Name
 	s, err := k.servingClient.InferenceServices(modelService.Namespace).Get(isvcName, metav1.GetOptions{})
-	if err != nil { // service to deploy is either a new inference service or a new or existing raw deployment
+	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			log.Errorf("unable to check inference service %s %v", isvcName, err)
 			return nil, ErrUnableToGetInferenceServiceStatus
@@ -167,7 +167,7 @@ func (k *controller) Deploy(ctx context.Context, modelService *models.Service) (
 			log.Errorf("unable to create inference service %s %v", isvcName, err)
 			return nil, ErrUnableToCreateInferenceService
 		}
-	} else { // service to deploy is an inference service to be updated
+	} else {
 		patchedSpec, err := k.kfServingResourceTemplater.PatchInferenceServiceSpec(s, modelService, k.deploymentConfig)
 		if err != nil {
 			log.Errorf("unable to update inference service %s %v", isvcName, err)

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -640,7 +640,7 @@ func updateExistingInferenceServiceTopologySpreadConstraints(
 	} else if modelService.DeploymentMode == deployment.ServerlessDeploymentMode ||
 		modelService.DeploymentMode == deployment.EmptyDeploymentMode {
 		var err error
-		newRevisionName, err = getNewRevisionNameForExistingSeverlessDeployment(
+		newRevisionName, err = getNewRevisionNameForExistingServerlessDeployment(
 			orig.Status.Components[component].LatestCreatedRevision,
 		)
 		if err != nil {
@@ -696,11 +696,15 @@ func copyTopologySpreadConstraints(
 	return topologySpreadConstraints, nil
 }
 
-// getNewRevisionNameForExistingSeverlessDeployment examines the current revision name of an inference service (
+// getNewRevisionNameForExistingServerlessDeployment examines the current revision name of an inference service (
 // serverless deployment) app name that is given to it and increments the last value of the revision number by 1, e.g.
 // sklearn-sample-predictor-default-00001 -> sklearn-sample-predictor-default-00002
-func getNewRevisionNameForExistingSeverlessDeployment(currentRevisionName string) (string, error) {
+func getNewRevisionNameForExistingServerlessDeployment(currentRevisionName string) (string, error) {
 	revisionNameElements := strings.Split(currentRevisionName, "-")
+	if len(revisionNameElements) < 5 {
+		return "", fmt.Errorf("unexpected revision name format that is not in at least 4 parts: %s",
+			currentRevisionName)
+	}
 	currentRevisionNumber, err := strconv.Atoi(revisionNameElements[len(revisionNameElements)-1])
 	if err != nil {
 		return "", err

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -147,7 +147,7 @@ func (t *InferenceServiceTemplater) CreateInferenceServiceSpec(modelService *mod
 	}
 
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
-		inferenceService.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer, config)
+		inferenceService.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create transformer spec: %w", err)
 		}
@@ -188,7 +188,7 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 
 	orig.Spec.Transformer = nil
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
-		orig.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer, config)
+		orig.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create transformer spec: %w", err)
 		}
@@ -332,7 +332,7 @@ func createPredictorSpec(modelService *models.Service, config *config.Deployment
 	return predictorSpec
 }
 
-func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.Service, transformer *models.Transformer, config *config.DeploymentConfig) *kservev1beta1.TransformerSpec {
+func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.Service, transformer *models.Transformer) *kservev1beta1.TransformerSpec {
 	// Set cpu limit and memory limit to be 2x of the requests
 	cpuLimit := transformer.ResourceRequest.CPURequest.DeepCopy()
 	cpuLimit.Add(transformer.ResourceRequest.CPURequest)

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -602,7 +602,8 @@ func createNewInferenceServiceTopologySpreadConstraints(
 	component kservev1beta1.ComponentType,
 ) ([]corev1.TopologySpreadConstraint, error) {
 	if len(config.TopologySpreadConstraints) == 0 {
-		return nil, nil
+		var topologySpreadConstraints []corev1.TopologySpreadConstraint
+		return topologySpreadConstraints, nil
 	}
 	var newRevisionName string
 	if modelService.DeploymentMode == deployment.RawDeploymentMode {
@@ -627,7 +628,8 @@ func updateExistingInferenceServiceTopologySpreadConstraints(
 	component kservev1beta1.ComponentType,
 ) ([]corev1.TopologySpreadConstraint, error) {
 	if len(config.TopologySpreadConstraints) == 0 {
-		return nil, nil
+		var topologySpreadConstraints []corev1.TopologySpreadConstraint
+		return topologySpreadConstraints, nil
 	}
 	newRevisionName, err := getNewRevisionNameForExistingInferenceService(
 		orig.Status.Components[component].LatestReadyRevision,

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -609,10 +609,10 @@ func createNewInferenceServiceTopologySpreadConstraints(
 	}
 	var newRevisionName string
 	if modelService.DeploymentMode == deployment.RawDeploymentMode {
-		newRevisionName = fmt.Sprintf("isvc.%s-%s-%s-default", modelService.Name, modelService.ModelVersion, component)
+		newRevisionName = fmt.Sprintf("isvc.%s-%s-default", modelService.Name, component)
 	} else if modelService.DeploymentMode == deployment.ServerlessDeploymentMode ||
 		modelService.DeploymentMode == deployment.EmptyDeploymentMode {
-		newRevisionName = fmt.Sprintf("%s-%s-%s-default-00001", modelService.Name, modelService.ModelVersion, component)
+		newRevisionName = fmt.Sprintf("%s-%s-default-00001", modelService.Name, component)
 	} else {
 		return nil, fmt.Errorf("invalid deployment mode: %s", modelService.DeploymentMode)
 	}
@@ -636,7 +636,7 @@ func updateExistingInferenceServiceTopologySpreadConstraints(
 	}
 	var newRevisionName string
 	if modelService.DeploymentMode == deployment.RawDeploymentMode {
-		newRevisionName = fmt.Sprintf("isvc.%s-%s-%s-default", modelService.Name, modelService.ModelVersion, component)
+		newRevisionName = fmt.Sprintf("isvc.%s-%s-default", modelService.Name, component)
 	} else if modelService.DeploymentMode == deployment.ServerlessDeploymentMode ||
 		modelService.DeploymentMode == deployment.EmptyDeploymentMode {
 		var err error

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -204,10 +204,7 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 	return orig, nil
 }
 
-func createPredictorSpec(
-	modelService *models.Service,
-	config *config.DeploymentConfig,
-) kservev1beta1.PredictorSpec {
+func createPredictorSpec(modelService *models.Service, config *config.DeploymentConfig) kservev1beta1.PredictorSpec {
 	envVars := modelService.EnvVars
 
 	// Set cpu limit and memory limit to be 2x of the requests
@@ -335,11 +332,7 @@ func createPredictorSpec(
 	return predictorSpec
 }
 
-func (t *InferenceServiceTemplater) createTransformerSpec(
-	modelService *models.Service,
-	transformer *models.Transformer,
-	config *config.DeploymentConfig,
-) *kservev1beta1.TransformerSpec {
+func (t *InferenceServiceTemplater) createTransformerSpec(modelService *models.Service, transformer *models.Transformer, config *config.DeploymentConfig) *kservev1beta1.TransformerSpec {
 	// Set cpu limit and memory limit to be 2x of the requests
 	cpuLimit := transformer.ResourceRequest.CPURequest.DeepCopy()
 	cpuLimit.Add(transformer.ResourceRequest.CPURequest)

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -174,9 +174,6 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 	}
 	orig.ObjectMeta.Annotations = utils.MergeMaps(utils.ExcludeKeys(orig.ObjectMeta.Annotations, configAnnotationKeys), annotations)
 	orig.Spec.Predictor = createPredictorSpec(modelService, config)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create predictor spec: %w", err)
-	}
 	orig.Spec.Predictor.TopologySpreadConstraints, err = updateExistingInferenceServiceTopologySpreadConstraints(
 		orig,
 		modelService,
@@ -190,9 +187,6 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 	orig.Spec.Transformer = nil
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
 		orig.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer)
-		if err != nil {
-			return nil, fmt.Errorf("unable to create transformer spec: %w", err)
-		}
 		orig.Spec.Transformer.TopologySpreadConstraints, err = updateExistingInferenceServiceTopologySpreadConstraints(
 			orig,
 			modelService,

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -641,7 +641,7 @@ func updateExistingInferenceServiceTopologySpreadConstraints(
 		modelService.DeploymentMode == deployment.EmptyDeploymentMode {
 		var err error
 		newRevisionName, err = getNewRevisionNameForExistingSeverlessDeployment(
-			orig.Status.Components[component].LatestReadyRevision,
+			orig.Status.Components[component].LatestCreatedRevision,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate new revision name: %w", err)

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -3599,7 +3599,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tpl := NewInferenceServiceTemplater(standardTransformerConfig)
-			got := tpl.createTransformerSpec(tt.args.modelService, tt.args.transformer, tt.args.config)
+			got := tpl.createTransformerSpec(tt.args.modelService, tt.args.transformer)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -2835,7 +2835,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 									},
 								},
@@ -2845,7 +2845,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -2863,7 +2863,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00001",
+											"app":       "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -2937,7 +2937,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 									},
 								},
@@ -2947,7 +2947,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -2965,7 +2965,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00001",
+											"app":       "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3039,7 +3039,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 									},
 								},
@@ -3049,7 +3049,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3067,7 +3067,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-predictor-default",
+											"app":       "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3146,7 +3146,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 									},
 								},
@@ -3156,7 +3156,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3174,7 +3174,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00001",
+											"app":       "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3208,7 +3208,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00001",
+											"app": "model-1-transformer-default-00001",
 										},
 									},
 								},
@@ -3218,7 +3218,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00001",
+											"app": "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3236,7 +3236,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-transformer-default-00001",
+											"app":       "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3320,7 +3320,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 									},
 								},
@@ -3330,7 +3330,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00001",
+											"app": "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3348,7 +3348,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00001",
+											"app":       "model-1-predictor-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3382,7 +3382,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00001",
+											"app": "model-1-transformer-default-00001",
 										},
 									},
 								},
@@ -3392,7 +3392,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00001",
+											"app": "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3410,7 +3410,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-transformer-default-00001",
+											"app":       "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3494,7 +3494,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 									},
 								},
@@ -3504,7 +3504,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3522,7 +3522,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-predictor-default",
+											"app":       "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3556,7 +3556,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-transformer-default",
+											"app": "isvc.model-1-transformer-default",
 										},
 									},
 								},
@@ -3566,7 +3566,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-transformer-default",
+											"app": "isvc.model-1-transformer-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -3584,7 +3584,7 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-transformer-default",
+											"app":       "isvc.model-1-transformer-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4478,8 +4478,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4527,7 +4526,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 									},
 								},
@@ -4537,7 +4536,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4555,7 +4554,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00002",
+											"app":       "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4573,8 +4572,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4625,8 +4623,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4674,7 +4671,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 									},
 								},
@@ -4684,7 +4681,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4702,7 +4699,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00002",
+											"app":       "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4720,8 +4717,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4813,7 +4809,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 									},
 								},
@@ -4823,7 +4819,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4841,7 +4837,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-predictor-default",
+											"app":       "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4914,12 +4910,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4967,7 +4961,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 									},
 								},
@@ -4977,7 +4971,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -4995,7 +4989,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00002",
+											"app":       "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5038,7 +5032,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00002",
 										},
 									},
 								},
@@ -5048,7 +5042,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5066,7 +5060,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-transformer-default-00002",
+											"app":       "model-1-transformer-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5088,12 +5082,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5156,12 +5148,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5209,7 +5199,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 									},
 								},
@@ -5219,7 +5209,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-predictor-default-00002",
+											"app": "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5237,7 +5227,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-predictor-default-00002",
+											"app":       "model-1-predictor-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5280,7 +5270,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00002",
 										},
 									},
 								},
@@ -5290,7 +5280,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5308,7 +5298,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-1-transformer-default-00002",
+											"app":       "model-1-transformer-default-00002",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5330,12 +5320,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
-								modelSvc.ModelVersion),
+							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5439,7 +5427,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 									},
 								},
@@ -5449,7 +5437,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-predictor-default",
+											"app": "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5467,7 +5455,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-predictor-default",
+											"app":       "isvc.model-1-predictor-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5510,7 +5498,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-transformer-default",
+											"app": "isvc.model-1-transformer-default",
 										},
 									},
 								},
@@ -5520,7 +5508,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "isvc.model-1-1-transformer-default",
+											"app": "isvc.model-1-transformer-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5538,7 +5526,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "isvc.model-1-1-transformer-default",
+											"app":       "isvc.model-1-transformer-default",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -2731,6 +2731,940 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	}
 }
 
+func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
+	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = models.InitKubernetesLabeller("", "")
+	}()
+
+	project := mlp.Project{
+		Name: "project",
+	}
+
+	modelSvc := &models.Service{
+		Name:         "model-1",
+		ModelName:    "model",
+		Namespace:    project.Name,
+		ModelVersion: "1",
+		ArtifactURI:  "gs://my-artifacet",
+		Metadata: models.Metadata{
+			App:       "model",
+			Component: models.ComponentModelVersion,
+			Stream:    "dsp",
+			Team:      "dsp",
+			Labels: mlp.Labels{
+				{
+					Key:   "sample",
+					Value: "true",
+				},
+			},
+		},
+		Protocol: protocol.HttpJson,
+	}
+
+	queueResourcePercentage := "2"
+	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
+
+	// Liveness probe config for the model containers
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+
+	// Liveness probe config for the transformers
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+
+	tests := []struct {
+		name     string
+		modelSvc *models.Service
+		exp      *kservev1beta1.InferenceService
+		wantErr  bool
+	}{
+		{
+			name: "predictor with unspecified deployment mode (serverless)",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Protocol:     protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor with serverless deployment mode",
+			modelSvc: &models.Service{
+				Name:           modelSvc.Name,
+				ModelName:      modelSvc.ModelName,
+				ModelVersion:   modelSvc.ModelVersion,
+				Namespace:      project.Name,
+				ArtifactURI:    modelSvc.ArtifactURI,
+				Type:           models.ModelTypeTensorflow,
+				Options:        &models.ModelOption{},
+				Metadata:       modelSvc.Metadata,
+				DeploymentMode: deployment.ServerlessDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor with raw deployment mode",
+			modelSvc: &models.Service{
+				Name:           modelSvc.Name,
+				ModelName:      modelSvc.ModelName,
+				ModelVersion:   modelSvc.ModelVersion,
+				Namespace:      project.Name,
+				ArtifactURI:    modelSvc.ArtifactURI,
+				Type:           models.ModelTypeTensorflow,
+				Options:        &models.ModelOption{},
+				Metadata:       modelSvc.Metadata,
+				DeploymentMode: deployment.RawDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.RawDeployment),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-predictor-default",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-predictor-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "isvc.model-1-1-predictor-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor and transformer with unspecified deployment mode (serverless)",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Transformer: &models.Transformer{
+					Enabled: true,
+					Image:   "ghcr.io/gojek/merlin-transformer-test",
+					Command: "python",
+					Args:    "main.py",
+				},
+				Protocol: protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Transformer: &kservev1beta1.TransformerSpec{
+						PodSpec: kservev1beta1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:          "transformer",
+									Image:         "ghcr.io/gojek/merlin-transformer-test",
+									Command:       []string{"python"},
+									Args:          []string{"main.py"},
+									Env:           createDefaultTransformerEnvVars(modelSvc).ToKubernetesEnvVars(),
+									Resources:     expDefaultTransformerResourceRequests,
+									LivenessProbe: transformerProbeConfig,
+								},
+							},
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-transformer-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultTransformerResourceRequests.MinReplica,
+							MaxReplicas: defaultTransformerResourceRequests.MaxReplica,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor and transformer with serverless deployment mode",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Transformer: &models.Transformer{
+					Enabled: true,
+					Image:   "ghcr.io/gojek/merlin-transformer-test",
+					Command: "python",
+					Args:    "main.py",
+				},
+				DeploymentMode: deployment.ServerlessDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Transformer: &kservev1beta1.TransformerSpec{
+						PodSpec: kservev1beta1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:          "transformer",
+									Image:         "ghcr.io/gojek/merlin-transformer-test",
+									Command:       []string{"python"},
+									Args:          []string{"main.py"},
+									Env:           createDefaultTransformerEnvVars(modelSvc).ToKubernetesEnvVars(),
+									Resources:     expDefaultTransformerResourceRequests,
+									LivenessProbe: transformerProbeConfig,
+								},
+							},
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00001",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-transformer-default-00001",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultTransformerResourceRequests.MinReplica,
+							MaxReplicas: defaultTransformerResourceRequests.MaxReplica,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor and transformer with raw deployment mode",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Transformer: &models.Transformer{
+					Enabled: true,
+					Image:   "ghcr.io/gojek/merlin-transformer-test",
+					Command: "python",
+					Args:    "main.py",
+				},
+				DeploymentMode: deployment.RawDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.RawDeployment),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     expDefaultModelResourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultModelResourceRequests.MinReplica,
+							MaxReplicas: defaultModelResourceRequests.MaxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-predictor-default",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-predictor-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "isvc.model-1-1-predictor-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Transformer: &kservev1beta1.TransformerSpec{
+						PodSpec: kservev1beta1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:          "transformer",
+									Image:         "ghcr.io/gojek/merlin-transformer-test",
+									Command:       []string{"python"},
+									Args:          []string{"main.py"},
+									Env:           createDefaultTransformerEnvVars(modelSvc).ToKubernetesEnvVars(),
+									Resources:     expDefaultTransformerResourceRequests,
+									LivenessProbe: transformerProbeConfig,
+								},
+							},
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-transformer-default",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "isvc.model-1-1-transformer-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "isvc.model-1-1-transformer-default",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &defaultTransformerResourceRequests.MinReplica,
+							MaxReplicas: defaultTransformerResourceRequests.MaxReplica,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployConfig := &config.DeploymentConfig{
+				DefaultModelResourceRequests:       defaultModelResourceRequests,
+				DefaultTransformerResourceRequests: defaultTransformerResourceRequests,
+				QueueResourcePercentage:            queueResourcePercentage,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           2,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
+							},
+						},
+					},
+					{
+						MaxSkew:           3,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app-label": "spread",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			tpl := NewInferenceServiceTemplater(standardTransformerConfig)
+			infSvcSpec, err := tpl.CreateInferenceServiceSpec(tt.modelSvc, deployConfig)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.exp, infSvcSpec)
+		})
+	}
+}
+
 func TestPatchInferenceServiceSpec(t *testing.T) {
 	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
 	assert.NoError(t, err)
@@ -3416,6 +4350,916 @@ func TestPatchInferenceServiceSpec(t *testing.T) {
 					MemoryRequest: memoryRequest,
 				},
 				QueueResourcePercentage: queueResourcePercentage,
+			}
+
+			tpl := NewInferenceServiceTemplater(standardTransformerConfig)
+			infSvcSpec, err := tpl.PatchInferenceServiceSpec(tt.original, tt.modelSvc, deployConfig)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.exp, infSvcSpec)
+		})
+	}
+}
+
+func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
+	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = models.InitKubernetesLabeller("", "")
+	}()
+
+	project := mlp.Project{
+		Name: "project",
+	}
+
+	modelSvc := &models.Service{
+		Name:         "model-1",
+		ModelName:    "model",
+		ModelVersion: "1",
+		Namespace:    project.Name,
+		ArtifactURI:  "gs://my-artifacet",
+		Metadata: models.Metadata{
+			App:       "model",
+			Component: models.ComponentModelVersion,
+			Stream:    "dsp",
+			Team:      "dsp",
+			Labels: mlp.Labels{
+				{
+					Key:   "sample",
+					Value: "true",
+				},
+			},
+		},
+		Protocol: protocol.HttpJson,
+	}
+
+	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
+
+	// Liveness probe config for the model containers
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+
+	// Liveness probe config for the transformers
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+
+	one := 1
+	minReplica := 1
+	maxReplica := 10
+	cpuRequest := resource.MustParse("1")
+	memoryRequest := resource.MustParse("1Gi")
+	cpuLimit := cpuRequest.DeepCopy()
+	cpuLimit.Add(cpuRequest)
+	memoryLimit := memoryRequest.DeepCopy()
+	memoryLimit.Add(memoryRequest)
+	queueResourcePercentage := "2"
+
+	resourceRequests := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    cpuRequest,
+			corev1.ResourceMemory: memoryRequest,
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    cpuLimit,
+			corev1.ResourceMemory: memoryLimit,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		modelSvc *models.Service
+		original *kservev1beta1.InferenceService
+		exp      *kservev1beta1.InferenceService
+		wantErr  bool
+	}{
+		{
+			name: "predictor with unspecified deployment mode (serverless)",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Protocol:     protocol.HttpJson,
+			},
+			original: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor with serverless deployment mode",
+			modelSvc: &models.Service{
+				Name:           modelSvc.Name,
+				ModelName:      modelSvc.ModelName,
+				ModelVersion:   modelSvc.ModelVersion,
+				Namespace:      project.Name,
+				ArtifactURI:    modelSvc.ArtifactURI,
+				Type:           models.ModelTypeTensorflow,
+				Options:        &models.ModelOption{},
+				Metadata:       modelSvc.Metadata,
+				DeploymentMode: deployment.ServerlessDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			original: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor and transformer with unspecified deployment mode (serverless)",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Transformer: &models.Transformer{
+					Enabled: true,
+					Image:   "ghcr.io/gojek/merlin-transformer-test",
+					Command: "python",
+					Args:    "main.py",
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    1,
+						MaxReplica:    1,
+						CPURequest:    cpuRequest,
+						MemoryRequest: memoryRequest,
+					},
+				},
+				Protocol: protocol.HttpJson,
+			},
+			original: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+						kservev1beta1.TransformerComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Transformer: &kservev1beta1.TransformerSpec{
+						PodSpec: kservev1beta1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "transformer",
+									Image:   "ghcr.io/gojek/merlin-transformer-test",
+									Command: []string{"python"},
+									Args:    []string{"main.py"},
+									Env:     createDefaultTransformerEnvVars(modelSvc).ToKubernetesEnvVars(),
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    cpuRequest,
+											corev1.ResourceMemory: memoryRequest,
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    cpuLimit,
+											corev1.ResourceMemory: memoryLimit,
+										},
+									},
+									LivenessProbe: transformerProbeConfig,
+								},
+							},
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-transformer-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &one,
+							MaxReplicas: one,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+						kservev1beta1.TransformerComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "predictor and transformer with serverless deployment mode",
+			modelSvc: &models.Service{
+				Name:         modelSvc.Name,
+				ModelName:    modelSvc.ModelName,
+				ModelVersion: modelSvc.ModelVersion,
+				Namespace:    project.Name,
+				ArtifactURI:  modelSvc.ArtifactURI,
+				Type:         models.ModelTypeTensorflow,
+				Options:      &models.ModelOption{},
+				Metadata:     modelSvc.Metadata,
+				Transformer: &models.Transformer{
+					Enabled: true,
+					Image:   "ghcr.io/gojek/merlin-transformer-test",
+					Command: "python",
+					Args:    "main.py",
+					ResourceRequest: &models.ResourceRequest{
+						MinReplica:    1,
+						MaxReplica:    1,
+						CPURequest:    cpuRequest,
+						MemoryRequest: memoryRequest,
+					},
+				},
+				DeploymentMode: deployment.ServerlessDeploymentMode,
+				Protocol:       protocol.HttpJson,
+			},
+			original: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+						kservev1beta1.TransformerComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+			exp: &kservev1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelSvc.Name,
+					Namespace: project.Name,
+					Annotations: map[string]string{
+						knserving.QueueSidecarResourcePercentageAnnotationKey: queueResourcePercentage,
+						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
+					},
+					Labels: map[string]string{
+						"gojek.com/app":          modelSvc.Metadata.App,
+						"gojek.com/component":    models.ComponentModelVersion,
+						"gojek.com/environment":  testEnvironmentName,
+						"gojek.com/orchestrator": testOrchestratorName,
+						"gojek.com/stream":       modelSvc.Metadata.Stream,
+						"gojek.com/team":         modelSvc.Metadata.Team,
+						"sample":                 "true",
+					},
+				},
+				Spec: kservev1beta1.InferenceServiceSpec{
+					Predictor: kservev1beta1.PredictorSpec{
+						Tensorflow: &kservev1beta1.TFServingSpec{
+							PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
+								StorageURI: &storageUri,
+								Container: corev1.Container{
+									Name:          kserveconstant.InferenceServiceContainerName,
+									Resources:     resourceRequests,
+									LivenessProbe: probeConfig,
+									Env:           []corev1.EnvVar{},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &minReplica,
+							MaxReplicas: maxReplica,
+						},
+						PodSpec: kservev1beta1.PodSpec{
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-predictor-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Transformer: &kservev1beta1.TransformerSpec{
+						PodSpec: kservev1beta1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:    "transformer",
+									Image:   "ghcr.io/gojek/merlin-transformer-test",
+									Command: []string{"python"},
+									Args:    []string{"main.py"},
+									Env:     createDefaultTransformerEnvVars(modelSvc).ToKubernetesEnvVars(),
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU:    cpuRequest,
+											corev1.ResourceMemory: memoryRequest,
+										},
+										Limits: corev1.ResourceList{
+											corev1.ResourceCPU:    cpuLimit,
+											corev1.ResourceMemory: memoryLimit,
+										},
+									},
+									LivenessProbe: transformerProbeConfig,
+								},
+							},
+							TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+								{
+									MaxSkew:           1,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.ScheduleAnyway,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00002",
+										},
+									},
+								},
+								{
+									MaxSkew:           2,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app": "model-1-1-transformer-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+								{
+									MaxSkew:           3,
+									TopologyKey:       "kubernetes.io/hostname",
+									WhenUnsatisfiable: corev1.DoNotSchedule,
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"app-label": "spread",
+											"app":       "model-1-1-transformer-default-00002",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "app-expression",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"1"},
+											},
+										},
+									},
+								},
+							},
+						},
+						ComponentExtensionSpec: kservev1beta1.ComponentExtensionSpec{
+							MinReplicas: &one,
+							MaxReplicas: one,
+						},
+					},
+				},
+				Status: kservev1beta1.InferenceServiceStatus{
+					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
+						kservev1beta1.PredictorComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-predictor-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+						kservev1beta1.TransformerComponent: {
+							LatestReadyRevision: fmt.Sprintf("%s-%s-transformer-default-00001", modelSvc.Name,
+								modelSvc.ModelVersion),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployConfig := &config.DeploymentConfig{
+				DefaultModelResourceRequests: &config.ResourceRequests{
+					MinReplica:    minReplica,
+					MaxReplica:    maxReplica,
+					CPURequest:    cpuRequest,
+					MemoryRequest: memoryRequest,
+				},
+				QueueResourcePercentage: queueResourcePercentage,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           2,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
+							},
+						},
+					},
+					{
+						MaxSkew:           3,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"app-label": "spread",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app-expression",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"1"},
+								},
+							},
+						},
+					},
+				},
 			}
 
 			tpl := NewInferenceServiceTemplater(standardTransformerConfig)

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -4478,7 +4478,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4572,7 +4572,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4623,7 +4623,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4717,7 +4717,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -4910,10 +4910,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5082,10 +5082,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5148,10 +5148,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5320,10 +5320,10 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 				Status: kservev1beta1.InferenceServiceStatus{
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
 						kservev1beta1.TransformerComponent: {
-							LatestReadyRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
+							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},

--- a/api/config/deployment.go
+++ b/api/config/deployment.go
@@ -17,6 +17,7 @@ package config
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -34,6 +35,8 @@ type DeploymentConfig struct {
 	MaxCPU resource.Quantity
 	// Max Memory of machine
 	MaxMemory resource.Quantity
+	// TopologySpreadConstraints to be applied on the pods of each model deployment
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 	// Percentage of knative's queue proxy resource request from the inference service resource request
 	QueueResourcePercentage string
 	// GRPC Options for Pyfunc server

--- a/api/config/environment.go
+++ b/api/config/environment.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"encoding/json"
 	"log"
 	"os"
 	"time"
@@ -72,16 +71,6 @@ func (t *TopologySpreadConstraints) UnmarshalYAML(unmarshal func(interface{}) er
 	if err := sigyaml.Unmarshal(byteForm, t); err != nil {
 		return err
 	}
-	return nil
-}
-
-// Decode provides topologySpreadConstraints steps to parse env var to TopologySpreadConstraints struct
-func (t *TopologySpreadConstraints) Decode(value string) error {
-	var topologySpreadConstraints TopologySpreadConstraints
-	if err := json.Unmarshal([]byte(value), &topologySpreadConstraints); err != nil {
-		return err
-	}
-	*t = topologySpreadConstraints
 	return nil
 }
 

--- a/api/config/environment.go
+++ b/api/config/environment.go
@@ -58,13 +58,13 @@ type TopologySpreadConstraints []corev1.TopologySpreadConstraint
 // to unmarshal all the fields. This method reads TopologySpreadConstraint into a map[string]interface{},
 // marshals it into a byte for, before passing to sigyaml.Unmarshal
 func (t *TopologySpreadConstraints) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var kubeconfig []map[string]interface{}
+	var topologySpreadConstraints []map[string]interface{}
 	// Unmarshal into map[string]interface{}
-	if err := unmarshal(&kubeconfig); err != nil {
+	if err := unmarshal(&topologySpreadConstraints); err != nil {
 		return err
 	}
 	// convert back to byte string
-	byteForm, err := yaml.Marshal(kubeconfig)
+	byteForm, err := yaml.Marshal(topologySpreadConstraints)
 	if err != nil {
 		return err
 	}

--- a/api/config/environment_test.go
+++ b/api/config/environment_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUnmarshalTopologySpreadConstraints(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		exp       TopologySpreadConstraints
+		errString string
+	}{
+		"valid configs": {
+			input: `- maxSkew: 1
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: ScheduleAnyway
+- maxSkew: 2
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: DoNotSchedule
+  labelSelector:
+    matchLabels:
+      app-label: spread
+- maxSkew: 3
+  topologyKey: kubernetes.io/hostname
+  whenUnsatisfiable: DoNotSchedule
+  labelSelector:
+    matchLabels:
+      app-label: spread
+    matchExpressions:
+      - key: app-expression
+        operator: In
+        values:
+          - 1`,
+			exp: []corev1.TopologySpreadConstraint{
+				{
+					MaxSkew:           1,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: corev1.ScheduleAnyway,
+				},
+				{
+					MaxSkew:           2,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app-expression",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"1"},
+							},
+						},
+					},
+				},
+				{
+					MaxSkew:           3,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app-label": "spread",
+						},
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "app-expression",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"1"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, tC := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			var configs TopologySpreadConstraints
+			inputByte := []byte(tC.input)
+			err := yaml.Unmarshal(inputByte, &configs)
+
+			if tC.errString == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tC.exp, configs)
+			} else {
+				assert.EqualError(t, err, tC.errString)
+			}
+		})
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kserve/kserve v0.8.0
 	github.com/linkedin/goavro/v2 v2.11.1
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/mmcloughlin/geohash v0.10.0
 	github.com/newrelic/newrelic-client-go/v2 v2.17.0
 	github.com/opentracing-contrib/go-stdlib v1.0.0
@@ -157,6 +158,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/newrelic/go-agent v3.19.2+incompatible // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -1177,6 +1177,8 @@ github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pR
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -1193,6 +1195,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/protoc-gen-go-json v1.1.0/go.mod h1:pACAKlMtBf4SMFbVswcjwNwWwlci6Vn841H5jPRcE9I=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmcloughlin/geohash v0.10.0 h1:9w1HchfDfdeLc+jFEf/04D27KP7E2QmpDu52wPbJWRE=
 github.com/mmcloughlin/geohash v0.10.0/go.mod h1:oNZxQo5yWJh0eMQEP/8hwQuVx9Z9tjwFUqcTB1SmG0c=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to how https://github.com/caraml-dev/turing/pull/332 allows an operator to define topology spread constraints for pods deployed by the API server, this PR also introduces changes the Merlin API server operator to specify topology spread constraints within the `environmentConfigs` of its chart values `.yaml` file, that will be propagated to all the model service pods deployed via the the API server: 
```yaml
environmentConfigs:
  - name: "merlin-dev"
    is_default: true
    cluster: "dev-cluster"
    deployment_timeout: "10m"
    namespace_timeout: "2m"
    max_cpu: "8"
    max_memory: "8Gi"
    topology_spread_constraints:
      - maxSkew: 1
        topologyKey: kubernetes.io/hostname
        whenUnsatisfiable: ScheduleAnyway
   ...
```

Similarly,  in order to encourage pods of the same Knative service deployed by the Merlin API server to be scheduled on a largest variety of nodes wherever possible to encourage high availability, an additional match label is added by default to all constraints specified in the Turing API configuration:
```yaml
matchLabels:
    app: [knative-service-name]
```
The above behaviour occurs for all constraints, even those without any other match labels or label selectors specified.

### Some extra details
Since Merlin model service deployments (both predictors and transformers) are deployed as KServe `InferenceService`-s, which themselves are built upon Knative services (see [here](https://kserve.github.io/website/0.10/get_started/first_isvc/) for more info) that can be either of the `Serverless` or `RawDeployment` type, both of which generate different values for the `metadata.labels.app` field (label) in the pod configuration (pod manifest file), based on the `InfererenceService` names:

`Serverless` type:
- `InferenceService` name: `sklearn-sample`
  Autogenerated label: `app=sklearn-sample-1-predictor-default-00001`
  Schema: `[isvc name]-[predictor/transformer]-default-[6 digit 0-padded revision number]`

`RawDeployment` type:
- `InferenceService` name: `sklearn-sample`
  Autogenerated label: `isvc.sklearn-sample-1-predictor-default`
  Schema: `isvc.[isvc name]-[predictor/transformer]-default`

where the `isvc name` includes the version number (of the model service) automatically [generated](https://github.com/caraml-dev/merlin/blob/d455cad616a89093c7db81de9580324f0cf64fe5/api/models/service.go#L52) by the API server.

Hence separate methods are defined to handle these two cases differently. Note in particular that any model redeployment of a `RawDeployment`-type `InferenceService` does not change the `app` label value, though it would change a `Serverless`-type's label, via the increment in the Knative service revision number. As such, whenever a `Severless` deployment is redeployed, we need to determine the to-be-deployed revision number (that will be automatically created by the Knative controller/webhook) by retrieving the `LatestReadyRevision` of the existing deployment and then incrementing it by 1.

This is slightly different from how the Turing API server sets the `app` label value to be exactly the same as that of the Knative service name (the Turing API server deploys routers directly as Knative services).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
