### PR TITLE
Fix regression when redeploying UPI model

### DIFF
--- a/ui/src/pages/version/components/forms/components/transformer/components/PredictionLoggerPanel.js
+++ b/ui/src/pages/version/components/forms/components/transformer/components/PredictionLoggerPanel.js
@@ -1,78 +1,85 @@
 import React from "react";
-import { 
-    EuiFieldText, 
-    EuiFlexGroup, 
-    EuiFlexItem, 
-    EuiFormRow, 
-    EuiSpacer, 
-    EuiSwitch, 
-    EuiText
+import {
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiSpacer,
+  EuiSwitch,
+  EuiText,
 } from "@elastic/eui";
 
 import { useOnChangeHandler, FormLabelWithToolTip } from "@gojek/mlp-ui";
 import { Panel } from "../../Panel";
 
-export const PredictionLoggerPanel = ({ predictionLogger, onChangeHandler, errors = {} }) => {
+export const PredictionLoggerPanel = ({
+  predictionLogger,
+  onChangeHandler,
+  errors = {},
+}) => {
   const { onChange } = useOnChangeHandler(onChangeHandler);
   return (
     <Panel>
-        <EuiFlexGroup direction="column" gutterSize="m">
-            <EuiSpacer size="s"/>
-            <EuiFlexItem>
-                <EuiFormRow
-                    fullWidth
-                    display="row">
-                    <EuiSwitch
-                        id="enable-prediction-logging"
-                        label={
-                            <EuiText size="s" color="subdued"> Enable Prediction Logging </EuiText>
-                        }
-                        checked={predictionLogger.enabled}
-                        onChange={e => onChange("enabled")(e.target.checked)}
-                    />
-                </EuiFormRow>
-            </EuiFlexItem>
-            <EuiSpacer size="s"/>
-            <EuiFlexItem>
-                <EuiFormRow
-                    fullWidth
-                    label={
-                        <FormLabelWithToolTip 
-                            label="Raw Features Table"
-                            content="Table that has pre transformed feature value"
-                        />
-                    }
-                    error={errors.raw_features_table}
-                    isInvalid={!!errors.raw_features_table}
-                    display="columnCompressed"
-                >
-                    <EuiFieldText 
-                        value={!!predictionLogger ? predictionLogger.raw_features_table : ""}
-                        onChange={(e) => onChange("raw_features_table")(e.target.value)}
-                    />
-                </EuiFormRow>
-            </EuiFlexItem>
-            <EuiSpacer size="s"/>
-            <EuiFlexItem>
-                <EuiFormRow
-                    fullWidth
-                    label={
-                        <FormLabelWithToolTip 
-                            label="Entities Table"
-                            content="Table that has entities information which are involve in the prediction process"
-                        />
-                    }
-                    error={errors.entities_table}
-                    isInvalid={!!errors.entities_table}
-                    display="columnCompressed"
-                >
-                    <EuiFieldText 
-                        value={!!predictionLogger ? predictionLogger.entities_table : ""}
-                        onChange={(e) => onChange("entities_table")(e.target.value)}
-                    />
-                </EuiFormRow>
-            </EuiFlexItem>
-        </EuiFlexGroup>
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiSpacer size="s" />
+        <EuiFlexItem>
+          <EuiFormRow fullWidth display="row">
+            <EuiSwitch
+              id="enable-prediction-logging"
+              label={
+                <EuiText size="s" color="subdued">
+                  {" "}
+                  Enable Prediction Logging{" "}
+                </EuiText>
+              }
+              checked={predictionLogger && predictionLogger.enabled}
+              onChange={(e) => onChange("enabled")(e.target.checked)}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiSpacer size="s" />
+        <EuiFlexItem>
+          <EuiFormRow
+            fullWidth
+            label={
+              <FormLabelWithToolTip
+                label="Raw Features Table"
+                content="Table that has pre transformed feature value"
+              />
+            }
+            error={errors.raw_features_table}
+            isInvalid={!!errors.raw_features_table}
+            display="columnCompressed"
+          >
+            <EuiFieldText
+              value={
+                !!predictionLogger ? predictionLogger.raw_features_table : ""
+              }
+              onChange={(e) => onChange("raw_features_table")(e.target.value)}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiSpacer size="s" />
+        <EuiFlexItem>
+          <EuiFormRow
+            fullWidth
+            label={
+              <FormLabelWithToolTip
+                label="Entities Table"
+                content="Table that has entities information which are involve in the prediction process"
+              />
+            }
+            error={errors.entities_table}
+            isInvalid={!!errors.entities_table}
+            display="columnCompressed"
+          >
+            <EuiFieldText
+              value={!!predictionLogger ? predictionLogger.entities_table : ""}
+              onChange={(e) => onChange("entities_table")(e.target.value)}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </Panel>
   );
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
Redeploying an existing UPI model causes the UI to crash due to the value of `predictionLogger` passed to `PredictionLoggerPanel` being `null`. `predictionLogger` is a new field introduced in https://github.com/caraml-dev/merlin/pull/361 and existing deployed model doesn't have the property. 
This PR adds guard to check whether the value is null before accessing its internal properties . 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

**Checklist**

- [X] Tested locally
