### PR TITLE
Add missing flags for logger

### DIFF
--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -38,6 +38,11 @@ var (
 	logMode          = flag.String("log-mode", string(merlinlogger.LogModeAll), "Whether to log 'request', 'response' or 'all'")
 	inferenceService = flag.String("inference-service", "my-model-1", "The InferenceService name to add as header to log events")
 	namespace        = flag.String("namespace", "my-project", "The namespace to add as header to log events")
+
+	// These flags are not needed by our logger but provided by Kserve, hence we need to parse it to avoid error.
+	sourceUri = flag.String("source-uri", "", "The source URI to use when publishing cloudevents")
+	endpoint  = flag.String("endpoint", "", "The endpoint name to add as header to log events")
+	component = flag.String("component", "", "The component name (predictor, explainer, transformer) to add as header to log events")
 )
 
 const (

--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -76,6 +76,11 @@ type config struct {
 func main() {
 	flag.Parse()
 
+	// Avoid unused variable linting error
+	_ = *sourceUri
+	_ = *endpoint
+	_ = *component
+
 	l, _ := zap.NewProduction()
 	log := l.Sugar()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

When enabling logger, Kserve adds some flags to the logger container. But these flags are not registered by logger app, hence raising error.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
