### PR TITLE
Replace manually set GHCR_TOKEN with autogenerated GITHUB_TOKEN

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -14,7 +14,7 @@ jobs:
         uses: docker/build-push-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
           repository: caraml-dev/mlflow
           path: mlflow

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish-mlflow-docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v2
       - name: Build and push MLflow Docker image

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -9,7 +9,6 @@ jobs:
   publish-mlflow-docker:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -518,4 +518,4 @@ jobs:
     secrets:
       pypi_username: ${{ secrets.PYPI_USERNAME }}
       pypi_password: ${{ secrets.PYPI_PASSWORD }}
-      ghcr_token: ${{ secrets.GHCR_TOKEN }}
+      ghcr_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
   publish-api:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Download API Docker Artifact
@@ -62,7 +61,6 @@ jobs:
   publish-transformer:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Download API Docker Artifact
@@ -132,7 +130,6 @@ jobs:
   publish-inference-logger:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Download API Docker Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
 
   publish-api:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download API Docker Artifact
         uses: actions/download-artifact@v2
@@ -58,6 +61,9 @@ jobs:
 
   publish-transformer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download API Docker Artifact
         uses: actions/download-artifact@v2
@@ -125,6 +131,9 @@ jobs:
 
   publish-inference-logger:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Download API Docker Artifact
         uses: actions/download-artifact@v2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the GitHub actions files to remove the use of the `GHCR_TOKEN` that's manually set up in the repository to validate all container pushes to the GitHub registry, and instead replace it with the autogenerated `GITHUB_TOKEN` [secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret).

Unfortunately, even after giving all the relevant permissions to the Merlin repo (to publish to the `caraml-dev` packages) as well as giving the `GITHUB_TOKEN` the necessary [rights](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-default-github_token-permissions) to have write permissions to the `packages` scope, we are still unable to publish all the existing images to their respective locations just by changing the `GHCR_TOKEN` to the `GITHUB_TOKEN`.

In particular, for images that are pushed to a path that doesn't have `merlin/` as a subpath like:
- `ghcr.io/caraml-dev/merlin`
- `ghcr.io/caraml-dev/merlin-transformer`
- `ghcr.io/caraml-dev/merlin-logger` 
- `ghcr.io/caraml-dev/mlflow`

we'll need to explicitly [specify](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#publishing-a-package-using-an-action) the write permissions in the GitHub action where we're pushing the Docker image to the GitHub registry:

```yaml
  publish-inference-logger:
    ...
    permissions:
      packages: write
    steps:
      ...
      - name: Retag and Push Docker Image
        run: |
          ...
          docker push ${IMAGE_TAG}
```

For some reason GitHub doesn't recognise packages with those paths as belonging to the Merlin repository when they do not have a `merlin/` subpath and thus do not automatically give the GitHub token rights to push there; pushes to `ghcr.io/caraml-dev/merlin/merlin-pyfunc-base-*` and `ghcr.io/caraml-dev/merlin/merlin-pyspark-base-*` for example do not require these additional permissions.

**Which issue(s) this PR fixes**:
None

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes

cc: @zenovore 