### PR TITLE
Update inference-logger kafka message delivery implementation

### DIFF
--- a/api/pkg/inference-logger/logger/handler_test.go
+++ b/api/pkg/inference-logger/logger/handler_test.go
@@ -187,6 +187,7 @@ func Test(t *testing.T) {
 					zapLogger := l.Sugar()
 
 					mockKafkaProducer := &mocks.KafkaProducer{}
+					mockKafkaProducer.On("Events", mock.Anything, mock.Anything).Return(nil)
 					mockKafkaProducer.On("Produce", mock.Anything, mock.Anything).Return(nil)
 					workerConfig := &WorkerConfig{
 						MinBatchSize: 1,

--- a/api/pkg/inference-logger/mocks/KafkaProducer.go
+++ b/api/pkg/inference-logger/mocks/KafkaProducer.go
@@ -39,6 +39,22 @@ func (_m *KafkaProducer) GetMetadata(_a0 *string, _a1 bool, _a2 int) (*kafka.Met
 	return r0, r1
 }
 
+// Events provides a mock function with given fields:
+func (_m *KafkaProducer) Events() chan kafka.Event {
+	ret := _m.Called()
+
+	var r0 chan kafka.Event
+	if rf, ok := ret.Get(0).(func() chan kafka.Event); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan kafka.Event)
+		}
+	}
+
+	return r0
+}
+
 // Produce provides a mock function with given fields: _a0, _a1
 func (_m *KafkaProducer) Produce(_a0 *kafka.Message, _a1 chan kafka.Event) error {
 	ret := _m.Called(_a0, _a1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Introduction of inference-logger previously - https://github.com/caraml-dev/merlin/pull/373, saw merlin models using kafka logger to be crashing with panics that are related to closed channels.

In the current logic, there is a sleep duration which closes the delivery channel, resulting in future go-routines to panic when working on a closed channel. This PR simplifies the logic for error handling and uses the producer's `Events()` for message delivery. This is also more aligned with Merlin's existing `pkg/kafka` (https://github.com/caraml-dev/merlin/blob/main/api/pkg/kafka/kafka.go#L97) implementation for ease of convergence in the future.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

`NONE`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
