### PR TITLE
Bugfix: Fix error when adding transformers to existing deployments

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -187,12 +187,20 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 	orig.Spec.Transformer = nil
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
 		orig.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer)
-		orig.Spec.Transformer.TopologySpreadConstraints, err = updateExistingInferenceServiceTopologySpreadConstraints(
-			orig,
-			modelService,
-			config,
-			kservev1beta1.TransformerComponent,
-		)
+		if orig.Status.Components[kservev1beta1.TransformerComponent].LatestCreatedRevision == "" {
+			orig.Spec.Transformer.TopologySpreadConstraints, err = createNewInferenceServiceTopologySpreadConstraints(
+				modelService,
+				config,
+				kservev1beta1.TransformerComponent,
+			)
+		} else {
+			orig.Spec.Transformer.TopologySpreadConstraints, err = updateExistingInferenceServiceTopologySpreadConstraints(
+				orig,
+				modelService,
+				config,
+				kservev1beta1.TransformerComponent,
+			)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("unable to create transformer topology spread constraints: %w", err)
 		}

--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -187,7 +187,8 @@ func (t *InferenceServiceTemplater) PatchInferenceServiceSpec(orig *kservev1beta
 	orig.Spec.Transformer = nil
 	if modelService.Transformer != nil && modelService.Transformer.Enabled {
 		orig.Spec.Transformer = t.createTransformerSpec(modelService, modelService.Transformer)
-		if orig.Status.Components[kservev1beta1.TransformerComponent].LatestCreatedRevision == "" {
+		if _, ok := orig.Status.Components[kservev1beta1.TransformerComponent]; !ok ||
+			orig.Status.Components[kservev1beta1.TransformerComponent].LatestCreatedRevision == "" {
 			orig.Spec.Transformer.TopologySpreadConstraints, err = createNewInferenceServiceTopologySpreadConstraints(
 				modelService,
 				config,

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -4912,9 +4912,6 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 						kservev1beta1.PredictorComponent: {
 							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
-						kservev1beta1.TransformerComponent: {
-							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
-						},
 					},
 				},
 			},
@@ -5032,7 +5029,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00001",
 										},
 									},
 								},
@@ -5042,7 +5039,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5060,7 +5057,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-transformer-default-00002",
+											"app":       "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5083,9 +5080,6 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
 							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
-						},
-						kservev1beta1.TransformerComponent: {
-							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},
@@ -5150,9 +5144,6 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 						kservev1beta1.PredictorComponent: {
 							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
 						},
-						kservev1beta1.TransformerComponent: {
-							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
-						},
 					},
 				},
 			},
@@ -5270,7 +5261,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.ScheduleAnyway,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00001",
 										},
 									},
 								},
@@ -5280,7 +5271,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									WhenUnsatisfiable: corev1.DoNotSchedule,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
-											"app": "model-1-transformer-default-00002",
+											"app": "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5298,7 +5289,7 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: map[string]string{
 											"app-label": "spread",
-											"app":       "model-1-transformer-default-00002",
+											"app":       "model-1-transformer-default-00001",
 										},
 										MatchExpressions: []metav1.LabelSelectorRequirement{
 											{
@@ -5321,9 +5312,6 @@ func TestPatchInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 					Components: map[kservev1beta1.ComponentType]kservev1beta1.ComponentStatusSpec{
 						kservev1beta1.PredictorComponent: {
 							LatestCreatedRevision: fmt.Sprintf("%s-predictor-default-00001", modelSvc.Name),
-						},
-						kservev1beta1.TransformerComponent: {
-							LatestCreatedRevision: fmt.Sprintf("%s-transformer-default-00001", modelSvc.Name),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a fix to a bug created in the feature added in #382, whereby updating an existing Merlin model deployment without a transformer throws an error if the update features a new transformer (that did not exist before). This bug occurs because of the way topology spread constraints are generated for serverless deployments using the `LastCreatedRevision` value of a prior revision, which would not exist for a model deployment that did not originally have a transformer specified its configs.

This PR thus adds an additional if-else check to check for the existence of such a value (which is safer than just checking for the existence of a transformer specified in the model configuration), before determining whether to create a new transformer revision name or to update an existing one.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
