### PR TITLE
Update caraml-auth-google version

### DIFF
--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -38,7 +38,7 @@ REQUIRES = [
     "six>=1.10",
     "urllib3>=1.23",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
-    "caraml-auth-google==0.0.0.post4",
+    "caraml-auth-google==0.0.0.post6",
 ]
 
 TEST_REQUIRES = [


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR pins the version of the `caraml-auth-google` package in the SDK to `0.0.0post6`, which fixes any potential dependency conflicts between `urllib3>=2.0` and `google-auth`. See https://github.com/caraml-dev/caraml-sdk/pull/5 for more details.

**Which issue(s) this PR fixes**:
- errors using functions/objects defined in the `google.auth` package when `urllib3>=2.0` is installed

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
