### PR TITLE
Fail fast if cannot initialize logSink

### DIFF
--- a/api/cmd/inference-logger/Makefile
+++ b/api/cmd/inference-logger/Makefile
@@ -1,0 +1,15 @@
+APP_NAME=inference-logger
+LOG_URL?=kafka:localhost:9092
+
+.PHONY: build
+build:
+	@go build -o bin/${APP_NAME} ./main.go
+
+.PHONY: run
+run:
+	@rm /tmp/agent.sock || true
+	@SERVING_READINESS_PROBE='{"tcpSocket":{"port":8080,"host":"127.0.0.1"},"successThreshold":1}' UNIX_SOCKET_PATH="/tmp/agent.sock" ./bin/${APP_NAME} -log-url="${LOG_URL}"
+
+.PHONY: run-mock
+run-mock:
+	@go run ../../pkg/inference-logger/mock-server/mock_server.go

--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -124,7 +124,12 @@ func main() {
 		MaxBatchSize: QueueMaxBatchSize,
 	}
 
-	logSink := getLogSink(*logUrl, log)
+	logSink, err := getLogSink(*logUrl, log)
+	if err != nil {
+		log.Infof("Failed initializing logSink for %s: %v", *logUrl, err)
+		os.Exit(1)
+	}
+
 	dispatcher := createLoggerDispatcher(workerConfig, logSink, log)
 	dispatcher.Start()
 
@@ -277,7 +282,7 @@ func getTopicName(serviceName string) string {
 func getLogSink(
 	logUrl string,
 	log *zap.SugaredLogger,
-) merlinlogger.LogSink {
+) (merlinlogger.LogSink, error) {
 	var sinkKind merlinlogger.LoggerSinkKind
 	host := logUrl
 	for _, loggerSinkKind := range merlinlogger.LoggerSinkKinds {
@@ -309,7 +314,7 @@ func getLogSink(
 		nrLogClient := nrlog.New(cfg)
 		logClient = &nrLogClient
 
-		return merlinlogger.NewNewRelicSink(log, logClient, serviceName, projectName, modelName, modelVersion)
+		return merlinlogger.NewNewRelicSink(log, logClient, serviceName, projectName, modelName, modelVersion), nil
 	case merlinlogger.Kafka:
 		// Initialize the producer
 		var kafkaProducer merlinlogger.KafkaProducer
@@ -323,18 +328,19 @@ func getLogSink(
 		)
 		if err != nil {
 			log.Info(err)
-			return nil
+			return nil, fmt.Errorf("failed to create new kafka producer: %s", err)
 		}
+
 		// Test that we are able to query the broker on the topic. If the topic
 		// does not already exist on the broker, this should create it.
 		_, err = kafkaProducer.GetMetadata(&topicName, false, merlinlogger.ConnectTimeoutMS)
 		if err != nil {
 			log.Info(err)
-			return nil
+			return nil, fmt.Errorf("failed to get kafka producer's metadata: %s", err)
 		}
 
-		return merlinlogger.NewKafkaSink(log, kafkaProducer, serviceName, projectName, modelName, modelVersion, topicName)
+		return merlinlogger.NewKafkaSink(log, kafkaProducer, serviceName, projectName, modelName, modelVersion, topicName), nil
 	default:
-		return merlinlogger.NewConsoleSink(log)
+		return merlinlogger.NewConsoleSink(log), nil
 	}
 }

--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -328,7 +328,7 @@ func getLogSink(
 		)
 		if err != nil {
 			log.Info(err)
-			return nil, fmt.Errorf("failed to create new kafka producer: %s", err)
+			return nil, fmt.Errorf("failed to create new kafka producer: %w", err)
 		}
 
 		// Test that we are able to query the broker on the topic. If the topic
@@ -336,7 +336,7 @@ func getLogSink(
 		_, err = kafkaProducer.GetMetadata(&topicName, false, merlinlogger.ConnectTimeoutMS)
 		if err != nil {
 			log.Info(err)
-			return nil, fmt.Errorf("failed to get kafka producer's metadata: %s", err)
+			return nil, fmt.Errorf("failed to get kafka producer's metadata: %w", err)
 		}
 
 		return merlinlogger.NewKafkaSink(log, kafkaProducer, serviceName, projectName, modelName, modelVersion, topicName), nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

When trying to use Kafka LogSink but failed to initialize NewKafkaSink, the getLogSink function returns nil and the program continue running. This can lead to panic because the program trying to use nil value when trying to Send the payload log:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xf2359d]

goroutine 31 [running]:
github.com/caraml-dev/merlin/pkg/inference-logger/logger.(*Worker).Send(...)
	/src/log-collector/pkg/inference-logger/logger/worker.go:106
github.com/caraml-dev/merlin/pkg/inference-logger/logger.(*Worker).Start.func1()
	/src/log-collector/pkg/inference-logger/logger/worker.go:79 +0x5dd
created by github.com/caraml-dev/merlin/pkg/inference-logger/logger.(*Worker).Start
	/src/log-collector/pkg/inference-logger/logger/worker.go:40 +0x56
```

This PR modifies getLogSink to also return error and fail faster if it failed to initialize KafkaSink.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes inference-logger raise panic.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
