### PR TITLE
Bugfix: Add image building job deletion delay

### DIFF
--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -71,7 +71,7 @@ const (
 	// jobCompletionTickDurationSecond is the interval at which the API server checks if a job has completed
 	jobCompletionTickDurationSecond = 5
 	// jobDeletionTimeoutSeconds is the maximum time to wait for a job to be deleted from a cluster
-	jobDeletionTimeoutSeconds = 10
+	jobDeletionTimeoutSeconds = 30
 	// jobDeletionTickDurationMilliseconds is the interval at which the API server checks if a job has been deleted
 	jobDeletionTickDurationMilliseconds = 100
 

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -350,7 +350,7 @@ func (c *imageBuilder) waitJobDeleted(ctx context.Context, job *batchv1.Job) err
 		case <-ticker.C:
 			_, err := jobClient.Get(ctx, job.Name, metav1.GetOptions{})
 			if err != nil {
-				if !kerrors.IsNotFound(err) {
+				if kerrors.IsNotFound(err) {
 					return nil
 				}
 				log.Errorf("unable to get job status for job %s: %v", job.Name, err)

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -68,8 +68,8 @@ type imageBuilder struct {
 const (
 	containerName    = "pyfunc-image-builder"
 	kanikoSecretName = "kaniko-secret"
-	// jobDeletionTickDurationMilliseconds is the interval at which the API server checks if a job has completed
-	jobCompletedTickDurationSecond = 5
+	// jobCompletionTickDurationSecond is the interval at which the API server checks if a job has completed
+	jobCompletionTickDurationSecond = 5
 	// jobDeletionTimeoutSeconds is the maximum time to wait for a job to be deleted from a cluster
 	jobDeletionTimeoutSeconds = 10
 	// jobDeletionTickDurationMilliseconds is the interval at which the API server checks if a job has been deleted
@@ -296,7 +296,7 @@ func (c *imageBuilder) imageRefExists(imageName, imageTag string) (bool, error) 
 
 func (c *imageBuilder) waitJobCompleted(ctx context.Context, job *batchv1.Job) error {
 	timeout := time.After(c.config.BuildTimeoutDuration)
-	ticker := time.NewTicker(time.Second * jobCompletedTickDurationSecond)
+	ticker := time.NewTicker(time.Second * jobCompletionTickDurationSecond)
 	jobClient := c.kubeClient.BatchV1().Jobs(c.config.BuildNamespace)
 	podClient := c.kubeClient.CoreV1().Pods(c.config.BuildNamespace)
 

--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -66,9 +66,14 @@ type imageBuilder struct {
 }
 
 const (
-	containerName      = "pyfunc-image-builder"
-	kanikoSecretName   = "kaniko-secret"
-	tickDurationSecond = 5
+	containerName    = "pyfunc-image-builder"
+	kanikoSecretName = "kaniko-secret"
+	// jobDeletionTickDurationMilliseconds is the interval at which the API server checks if a job has completed
+	jobCompletedTickDurationSecond = 5
+	// jobDeletionTimeoutSeconds is the maximum time to wait for a job to be deleted from a cluster
+	jobDeletionTimeoutSeconds = 10
+	// jobDeletionTickDurationMilliseconds is the interval at which the API server checks if a job has been deleted
+	jobDeletionTickDurationMilliseconds = 100
 
 	gacEnvKey  = "GOOGLE_APPLICATION_CREDENTIALS"
 	saFilePath = "/secret/kaniko-secret.json"
@@ -142,6 +147,12 @@ func (c *imageBuilder) BuildImage(ctx context.Context, project mlp.Project, mode
 		if job.Status.Failed != 0 {
 			// job already created before so we have to delete it first if it failed
 			err = jobClient.Delete(ctx, job.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.Errorf("error deleting job: %v", err)
+				return "", ErrDeleteFailedJob
+			}
+
+			err = c.waitJobDeleted(ctx, job)
 			if err != nil {
 				log.Errorf("error deleting job: %v", err)
 				return "", ErrDeleteFailedJob
@@ -285,7 +296,7 @@ func (c *imageBuilder) imageRefExists(imageName, imageTag string) (bool, error) 
 
 func (c *imageBuilder) waitJobCompleted(ctx context.Context, job *batchv1.Job) error {
 	timeout := time.After(c.config.BuildTimeoutDuration)
-	ticker := time.NewTicker(time.Second * tickDurationSecond)
+	ticker := time.NewTicker(time.Second * jobCompletedTickDurationSecond)
 	jobClient := c.kubeClient.BatchV1().Jobs(c.config.BuildNamespace)
 	podClient := c.kubeClient.CoreV1().Pods(c.config.BuildNamespace)
 
@@ -322,6 +333,28 @@ func (c *imageBuilder) waitJobCompleted(ctx context.Context, job *batchv1.Job) e
 				return ErrUnableToBuildImage{
 					Message: errMessage,
 				}
+			}
+		}
+	}
+}
+
+func (c *imageBuilder) waitJobDeleted(ctx context.Context, job *batchv1.Job) error {
+	timeout := time.After(time.Second * jobDeletionTimeoutSeconds)
+	ticker := time.NewTicker(time.Millisecond * jobDeletionTickDurationMilliseconds)
+	jobClient := c.kubeClient.BatchV1().Jobs(c.config.BuildNamespace)
+
+	for {
+		select {
+		case <-timeout:
+			return ErrDeleteFailedJob
+		case <-ticker.C:
+			_, err := jobClient.Get(ctx, job.Name, metav1.GetOptions{})
+			if err != nil {
+				if !kerrors.IsNotFound(err) {
+					return nil
+				}
+				log.Errorf("unable to get job status for job %s: %v", job.Name, err)
+				return ErrDeleteFailedJob
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
As of present, when the Merlin API server triggers an image building job as part of launching a batch prediction job/service, it checks for the presence of an existing image building job in the cluster with the same name. The status of the image building job found (if it is found), corresponds to a variety of situations:
- Found; running -> an existing image building job is already taking place and still running -> wait for the job to complete
- Found; failed -> an existing image building job has failed -> delete the old job -> begin a new one
- Not found -> begin a new one

In particular, we're interested in the **_second_** scenario, where there a new job is triggered right after the deletion of the old (failed) run (see [this](https://github.com/caraml-dev/merlin/blob/9d2689df94ba0f622ce01bdb60ed27a9af37a603/api/pkg/imagebuilder/imagebuilder.go#L142) for more details): 

```go
err = jobClient.Delete(ctx, job.Name, metav1.DeleteOptions{})
if err != nil {
	log.Errorf("error deleting job: %v", err)
return "", ErrDeleteFailedJob
}

jobSpec, err := c.createKanikoJobSpec(project, model, version)
if err != nil {
	log.Errorf("unable to create job spec %s, error: %v", imageRef, err)
	return "", ErrUnableToCreateJobSpec{
		Message: err.Error(),
	}
}

job, err = jobClient.Create(ctx, jobSpec, metav1.CreateOptions{})
if err != nil {
	log.Errorf("unable to build image %s, error: %v", imageRef, err)
	return "", ErrUnableToBuildImage{
		Message: err.Error(),
	}
}
```

A potential problem can occur whereby the creation of the new job happens _too quickly_ after the deletion of the job, due to the k8s resources having insufficient time to be removed from the cluster (the kube API server would return an error saying that the creation of the new job has failed due to the existence of another job with the very same name). When this happens, the (new) image building job fails immediately.

This PR thus introduces a new method to wait for the deletion to be complete before proceeding with the creation of another image builder job.

#### Main Modifications
- `api/pkg/imagebuilder/imagebuilder.go` - Addition of an additional helper method to wait for image building jobs to be completely removed from the cluster

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
