### PR TITLE
Set feast grpc connection count for simulator

### DIFF
--- a/api/pkg/transformer/executor/transformer.go
+++ b/api/pkg/transformer/executor/transformer.go
@@ -45,7 +45,9 @@ func NewStandardTransformerWithConfig(ctx context.Context, transformerConfig *sp
 	executorConfig := &transformerExecutorConfig{
 		transformerConfig: transformerConfig,
 		modelPredictor:    defaultModelPredictor,
-		feastOpts:         feast.Options{},
+		feastOpts: feast.Options{
+			FeastGRPCConnCount: 1,
+		},
 	}
 	for _, opt := range opts {
 		opt(executorConfig)

--- a/api/service/transformer_simulation_service.go
+++ b/api/service/transformer_simulation_service.go
@@ -72,6 +72,7 @@ func (ts *transformerService) createTransformerExecutor(ctx context.Context, sim
 			StorageConfigs:     ts.cfg.ToFeastStorageConfigsForSimulation(),
 			DefaultFeastSource: ts.cfg.DefaultFeastSource,
 			BatchSize:          defaultFeastBatchSize,
+			FeastGRPCConnCount: ts.cfg.FeastGPRCConnCount,
 		}),
 		executor.WithProtocol(simulationPayload.Protocol),
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
In the latest RC we introduce connection pool for feast serving gRPC, but it introduce bug for simulator since the number of connection pool is not set when initialize simulator executor hence use 0 connection. This PR fix that issue by setting the number of connection pool

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
