### PR TITLE
fix: Check cached projects first when listProjects by a specific name

### DIFF
--- a/api/service/project_service.go
+++ b/api/service/project_service.go
@@ -53,7 +53,7 @@ func (ps projectsService) List(ctx context.Context, name string) (mlp.Projects, 
 	if name != "" {
 		// If looking for a specific project, try fetching the project from local cache first
 		projects, err := ps.listProjects(name)
-		if err != nil && len(projects) > 0 {
+		if err == nil && len(projects) > 0 {
 			return projects, nil
 		}
 	}

--- a/api/service/project_service.go
+++ b/api/service/project_service.go
@@ -50,6 +50,14 @@ func NewProjectsService(mlpAPIClient mlp.APIClient) (ProjectsService, error) {
 }
 
 func (ps projectsService) List(ctx context.Context, name string) (mlp.Projects, error) {
+	if name != "" {
+		// If looking for a specific project, try fetching the project from local cache first
+		projects, err := ps.listProjects(name)
+		if err != nil && len(projects) > 0 {
+			return projects, nil
+		}
+	}
+	// Refresh cache and try filtering
 	err := ps.refreshProjects(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Follow up from: https://github.com/caraml-dev/merlin/pull/405

With the project caching changes made earlier, the `ListProjects` API will end up refreshing all the projects in the cache every single time. This worsens the performance of `merlin.set_project(name)` SDK method, that relies on this function under the hood (especially when running multiple e2e test cases in parallel and there are hundreds on MLP projects). 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

To overcome this performance degradation, a slight modification is made to the implementation. We first search the cache for matching projects and if > 0 projects are found, they are returned, before attempting to refresh cache and try again.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
