### PR TITLE
Bugfix: Remove DictEnv custom type

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -216,7 +216,7 @@ type ImageBuilderConfig struct {
 	// How long to keep the image building job resource in the Kubernetes cluster. Default: 2 days (48 hours).
 	Retention     time.Duration `validate:"required" default:"48h"`
 	Tolerations   Tolerations
-	NodeSelectors DictEnv
+	NodeSelectors map[string]string
 	MaximumRetry  int32                 `validate:"required" default:"3"`
 	K8sConfig     *mlpcluster.K8sConfig `validate:"required" default:"-"`
 	SafeToEvict   bool                  `default:"false"`
@@ -231,18 +231,6 @@ func (spec *Tolerations) Decode(value string) error {
 		return err
 	}
 	*spec = tolerations
-	return nil
-}
-
-type DictEnv map[string]string
-
-func (d *DictEnv) Decode(value string) error {
-	var dict DictEnv
-
-	if err := json.Unmarshal([]byte(value), &dict); err != nil {
-		return err
-	}
-	*d = dict
 	return nil
 }
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -301,15 +301,15 @@ type ModelClientKeepAliveConfig struct {
 type StandardTransformerConfig struct {
 	ImageName             string `validate:"required"`
 	FeastServingURLs      FeastServingURLs
-	FeastCoreURL          string                       `validate:"required"`
-	FeastCoreAuthAudience string                       `validate:"required"`
-	EnableAuth            bool                         `default:"false"`
-	FeastRedisConfig      *FeastRedisConfig            `default:"-"`
-	FeastBigtableConfig   *FeastBigtableConfig         `default:"-"`
-	FeastGPRCConnCount    int                          `validate:"required" default:"10"`
-	FeastServingKeepAlive *FeastServingKeepAliveConfig `default:"-"`
-	ModelClientKeepAlive  *ModelClientKeepAliveConfig  `default:"-"`
-	ModelServerConnCount  int                          `validate:"required" default:"10"`
+	FeastCoreURL          string               `validate:"required"`
+	FeastCoreAuthAudience string               `validate:"required"`
+	EnableAuth            bool                 `default:"false"`
+	FeastRedisConfig      *FeastRedisConfig    `default:"-"`
+	FeastBigtableConfig   *FeastBigtableConfig `default:"-"`
+	FeastGPRCConnCount    int                  `validate:"required" default:"10"`
+	FeastServingKeepAlive *FeastServingKeepAliveConfig
+	ModelClientKeepAlive  *ModelClientKeepAliveConfig
+	ModelServerConnCount  int `validate:"required" default:"10"`
 	// Base64 Service Account
 	BigtableCredential string
 	DefaultFeastSource spec.ServingSource    `validate:"required" default:"2"`

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -197,22 +197,21 @@ type ClusterConfig struct {
 }
 
 type ImageBuilderConfig struct {
-	ClusterName                  string `validate:"required"`
-	GcpProject                   string
-	BuildContextURI              string `validate:"required"`
-	ContextSubPath               string
-	DockerfilePath               string           `validate:"required" default:"./Dockerfile"`
-	BaseImages                   BaseImageConfigs `validate:"required"`
-	PredictionJobBuildContextURI string           `validate:"required"`
-	PredictionJobContextSubPath  string
-	PredictionJobDockerfilePath  string           `validate:"required" default:"./Dockerfile"`
-	PredictionJobBaseImages      BaseImageConfigs `validate:"required"`
-	BuildNamespace               string           `validate:"required" default:"mlp"`
-	DockerRegistry               string           `validate:"required"`
-	BuildTimeout                 string           `validate:"required" default:"10m"`
-	KanikoImage                  string           `validate:"required" default:"gcr.io/kaniko-project/executor:v1.6.0"`
-	KanikoServiceAccount         string
-	Resources                    ResourceRequestsLimits `validate:"required"`
+	ClusterName                 string `validate:"required"`
+	GcpProject                  string
+	BuildContextURI             string `validate:"required"`
+	ContextSubPath              string
+	DockerfilePath              string           `validate:"required" default:"./Dockerfile"`
+	BaseImages                  BaseImageConfigs `validate:"required"`
+	PredictionJobContextSubPath string
+	PredictionJobDockerfilePath string           `validate:"required" default:"./Dockerfile"`
+	PredictionJobBaseImages     BaseImageConfigs `validate:"required"`
+	BuildNamespace              string           `validate:"required" default:"mlp"`
+	DockerRegistry              string           `validate:"required"`
+	BuildTimeout                string           `validate:"required" default:"10m"`
+	KanikoImage                 string           `validate:"required" default:"gcr.io/kaniko-project/executor:v1.6.0"`
+	KanikoServiceAccount        string
+	Resources                   ResourceRequestsLimits `validate:"required"`
 	// How long to keep the image building job resource in the Kubernetes cluster. Default: 2 days (48 hours).
 	Retention     time.Duration `validate:"required" default:"48h"`
 	Tolerations   Tolerations

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -199,7 +199,6 @@ type ClusterConfig struct {
 type ImageBuilderConfig struct {
 	ClusterName                 string `validate:"required"`
 	GcpProject                  string
-	BuildContextURI             string `validate:"required"`
 	ContextSubPath              string
 	DockerfilePath              string           `validate:"required" default:"./Dockerfile"`
 	BaseImages                  BaseImageConfigs `validate:"required"`


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #397 refactored multiple config fields used in the Merlin API server though some of the fields refactored were not cleanly removed. The `NodeSelectors` field was using a custom `DictEnv` type that was created to help unmarshall a map object stored in a json string (that was passed to the API server via an environment variable); however, with the refactoring done in the said PR, there is now no need for that custom type to exist, since Viper (the package used to unmarshall yaml configs) is able to directly parse a yaml map.

This PR removes that custom type, as well as two other unused fields, `BuildContextURI` and `PredictionJobBuildContextURI` from the `ImageBuilderConfig` struct.

**Which issue(s) this PR fixes**:
NONE

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
