### PR TITLE
Add PodDisruptionBudget to models and transformers

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -177,8 +177,6 @@ jobs:
         run: |
           make setup
           make init-dep-api
-      - name: Lint API files
-        run: make lint-api
       - name: Test API files
         env:
           POSTGRES_HOST: localhost

--- a/api/cluster/container_test.go
+++ b/api/cluster/container_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/caraml-dev/merlin/config"
 	kserveclifake "github.com/kserve/kserve/pkg/client/clientset/versioned/fake"
 	kservev1beta1fake "github.com/kserve/kserve/pkg/client/clientset/versioned/typed/serving/v1beta1/fake"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	ktesting "k8s.io/client-go/testing"
+
+	"github.com/caraml-dev/merlin/config"
 )
 
 func TestContainer_GetContainers(t *testing.T) {

--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -19,11 +19,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/caraml-dev/merlin/cluster/resource"
-	"github.com/caraml-dev/merlin/config"
-	"github.com/caraml-dev/merlin/log"
-	"github.com/caraml-dev/merlin/models"
-	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kservev1beta1client "github.com/kserve/kserve/pkg/client/clientset/versioned/typed/serving/v1beta1"
 	"github.com/pkg/errors"
@@ -36,6 +31,12 @@ import (
 	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/caraml-dev/merlin/cluster/resource"
+	"github.com/caraml-dev/merlin/config"
+	"github.com/caraml-dev/merlin/log"
+	"github.com/caraml-dev/merlin/models"
+	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 )
 
 type Controller interface {

--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -20,10 +20,12 @@ import (
 	"time"
 
 	"github.com/caraml-dev/merlin/cluster/resource"
+	"github.com/caraml-dev/merlin/config"
+	"github.com/caraml-dev/merlin/log"
+	"github.com/caraml-dev/merlin/models"
+	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kservev1beta1client "github.com/kserve/kserve/pkg/client/clientset/versioned/typed/serving/v1beta1"
-	"k8s.io/client-go/rest"
-
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,12 +33,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	policyv1client "k8s.io/client-go/kubernetes/typed/policy/v1"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/caraml-dev/merlin/config"
-	"github.com/caraml-dev/merlin/log"
-	"github.com/caraml-dev/merlin/models"
-	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 )
 
 type Controller interface {
@@ -75,6 +74,7 @@ type controller struct {
 	servingClient              kservev1beta1client.ServingV1beta1Interface
 	clusterClient              corev1client.CoreV1Interface
 	batchClient                batchv1client.BatchV1Interface
+	policyClient               policyv1client.PolicyV1Interface
 	namespaceCreator           NamespaceCreator
 	deploymentConfig           *config.DeploymentConfig
 	kfServingResourceTemplater *resource.InferenceServiceTemplater
@@ -107,18 +107,24 @@ func NewController(clusterConfig Config, deployConfig config.DeploymentConfig, s
 		return nil, err
 	}
 
+	policyV1Client, err := policyv1client.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	containerFetcher := NewContainerFetcher(coreV1Client, Metadata{
 		ClusterName: clusterConfig.ClusterName,
 		GcpProject:  clusterConfig.GcpProject,
 	})
 
 	kfServingResourceTemplater := resource.NewInferenceServiceTemplater(standardTransformerConfig)
-	return newController(servingClient, coreV1Client, batchV1Client, deployConfig, containerFetcher, kfServingResourceTemplater)
+	return newController(servingClient, coreV1Client, batchV1Client, policyV1Client, deployConfig, containerFetcher, kfServingResourceTemplater)
 }
 
 func newController(kfservingClient kservev1beta1client.ServingV1beta1Interface,
 	coreV1Client corev1client.CoreV1Interface,
 	batchV1Client batchv1client.BatchV1Interface,
+	policyV1Client policyv1client.PolicyV1Interface,
 	deploymentConfig config.DeploymentConfig,
 	containerFetcher ContainerFetcher,
 	templater *resource.InferenceServiceTemplater,
@@ -127,6 +133,7 @@ func newController(kfservingClient kservev1beta1client.ServingV1beta1Interface,
 		servingClient:              kfservingClient,
 		clusterClient:              coreV1Client,
 		batchClient:                batchV1Client,
+		policyClient:               policyV1Client,
 		namespaceCreator:           NewNamespaceCreator(coreV1Client, deploymentConfig.NamespaceTimeout),
 		deploymentConfig:           &deploymentConfig,
 		ContainerFetcher:           containerFetcher,
@@ -191,6 +198,14 @@ func (k *controller) Deploy(ctx context.Context, modelService *models.Service) (
 		}
 	}
 
+	if k.deploymentConfig.PodDisruptionBudget.Enabled {
+		pdbs := k.createPodDisruptionBudgets(modelService, k.deploymentConfig.PodDisruptionBudget)
+		if err := k.deployPodDisruptionBudgets(ctx, pdbs); err != nil {
+			log.Errorf("unable to create pdb %v", err)
+			return nil, ErrUnableToCreatePDB
+		}
+	}
+
 	s, err = k.waitInferenceServiceReady(s)
 	if err != nil {
 		// remove created inferenceservice when got error
@@ -219,9 +234,19 @@ func (k *controller) Delete(ctx context.Context, modelService *models.Service) (
 		}
 		return modelService, nil
 	}
+
 	if err := k.deleteInferenceService(modelService.Name, modelService.Namespace); err != nil {
 		return nil, err
 	}
+
+	if k.deploymentConfig.PodDisruptionBudget.Enabled {
+		pdbs := k.createPodDisruptionBudgets(modelService, k.deploymentConfig.PodDisruptionBudget)
+		if err := k.deletePodDisruptionBudgets(ctx, pdbs); err != nil {
+			log.Errorf("unable to delete pdb %v", err)
+			return nil, ErrUnableToCreatePDB
+		}
+	}
+
 	return modelService, nil
 }
 

--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -244,7 +244,7 @@ func (k *controller) Delete(ctx context.Context, modelService *models.Service) (
 		pdbs := k.createPodDisruptionBudgets(modelService, k.deploymentConfig.PodDisruptionBudget)
 		if err := k.deletePodDisruptionBudgets(ctx, pdbs); err != nil {
 			log.Errorf("unable to delete pdb %v", err)
-			return nil, ErrUnableToCreatePDB
+			return nil, ErrUnableToDeletePDB
 		}
 	}
 

--- a/api/cluster/controller_test.go
+++ b/api/cluster/controller_test.go
@@ -21,10 +21,6 @@ import (
 	"testing"
 	"time"
 
-	clusterresource "github.com/caraml-dev/merlin/cluster/resource"
-	"github.com/caraml-dev/merlin/config"
-	"github.com/caraml-dev/merlin/mlp"
-	"github.com/caraml-dev/merlin/models"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	fakekserve "github.com/kserve/kserve/pkg/client/clientset/versioned/fake"
 	fakekservev1beta1 "github.com/kserve/kserve/pkg/client/clientset/versioned/typed/serving/v1beta1/fake"
@@ -43,6 +39,11 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
+
+	clusterresource "github.com/caraml-dev/merlin/cluster/resource"
+	"github.com/caraml-dev/merlin/config"
+	"github.com/caraml-dev/merlin/mlp"
+	"github.com/caraml-dev/merlin/models"
 )
 
 const (

--- a/api/cluster/errors.go
+++ b/api/cluster/errors.go
@@ -27,5 +27,5 @@ var (
 	ErrUnableToUpdateInferenceService    = errors.New("error updating inference service")
 	ErrTimeoutCreateInferenceService     = errors.New("timeout creating inference service")
 	ErrUnableToCreatePDB                 = errors.New("error creating pod disruption budget")
-	ErrUnableToUpdatePDB                 = errors.New("error udpating pod disruption budget")
+	ErrUnableToDeletePDB                 = errors.New("error deleting pod disruption budget")
 )

--- a/api/cluster/errors.go
+++ b/api/cluster/errors.go
@@ -26,4 +26,6 @@ var (
 	ErrUnableToCreateInferenceService    = errors.New("error creating inference service")
 	ErrUnableToUpdateInferenceService    = errors.New("error updating inference service")
 	ErrTimeoutCreateInferenceService     = errors.New("timeout creating inference service")
+	ErrUnableToCreatePDB                 = errors.New("error creating pod disruption budget")
+	ErrUnableToUpdatePDB                 = errors.New("error udpating pod disruption budget")
 )

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/caraml-dev/merlin/config"
-	"github.com/caraml-dev/merlin/models"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	metav1cfg "k8s.io/client-go/applyconfigurations/meta/v1"
 	policyv1cfg "k8s.io/client-go/applyconfigurations/policy/v1"
+
+	"github.com/caraml-dev/merlin/config"
+	"github.com/caraml-dev/merlin/models"
 )
 
 type PodDisruptionBudget struct {

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -43,17 +43,14 @@ func (cfg PodDisruptionBudget) BuildPDBSpec() (*policyv1cfg.PodDisruptionBudgetS
 		},
 	}
 
-	if cfg.MaxUnavailablePercentage != nil {
-		maxUnavailable := intstr.FromInt(*cfg.MaxUnavailablePercentage)
-		pdbSpec.MaxUnavailable = &maxUnavailable
-	}
-
 	// Since we can specify only one of maxUnavailable and minAvailable, minAvailable takes precedence
 	// https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
 	if cfg.MinAvailablePercentage != nil {
 		minAvailable := intstr.FromInt(*cfg.MinAvailablePercentage)
 		pdbSpec.MinAvailable = &minAvailable
-		pdbSpec.MaxUnavailable = nil
+	} else if cfg.MaxUnavailablePercentage != nil {
+		maxUnavailable := intstr.FromInt(*cfg.MaxUnavailablePercentage)
+		pdbSpec.MaxUnavailable = &maxUnavailable
 	}
 
 	return pdbSpec, nil

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -1,0 +1,113 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/caraml-dev/merlin/config"
+	"github.com/caraml-dev/merlin/models"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	metav1cfg "k8s.io/client-go/applyconfigurations/meta/v1"
+	policyv1cfg "k8s.io/client-go/applyconfigurations/policy/v1"
+)
+
+type PodDisruptionBudget struct {
+	Name                     string
+	Namespace                string
+	Labels                   map[string]string
+	MaxUnavailablePercentage *int
+	MinAvailablePercentage   *int
+	Selector                 *metav1.LabelSelector
+}
+
+func NewPodDisruptionBudget(modelService *models.Service, componentType string, pdbConfig config.PodDisruptionBudgetConfig) *PodDisruptionBudget {
+	return &PodDisruptionBudget{
+		Name:                     fmt.Sprintf("%s-%s-%s", modelService.Name, componentType, models.PDBComponentType),
+		Namespace:                modelService.Namespace,
+		Labels:                   modelService.Metadata.ToLabel(),
+		MaxUnavailablePercentage: pdbConfig.MaxUnavailablePercentage,
+		MinAvailablePercentage:   pdbConfig.MinAvailablePercentage,
+	}
+}
+
+func (cfg PodDisruptionBudget) BuildPDBSpec() (*policyv1cfg.PodDisruptionBudgetSpecApplyConfiguration, error) {
+	if cfg.MaxUnavailablePercentage == nil && cfg.MinAvailablePercentage == nil {
+		return nil, fmt.Errorf("one of maxUnavailable and minAvailable must be specified")
+	}
+
+	pdbSpec := &policyv1cfg.PodDisruptionBudgetSpecApplyConfiguration{
+		Selector: &metav1cfg.LabelSelectorApplyConfiguration{
+			MatchLabels: cfg.Labels,
+		},
+	}
+
+	if cfg.MaxUnavailablePercentage != nil {
+		maxUnavailable := intstr.FromInt(*cfg.MaxUnavailablePercentage)
+		pdbSpec.MaxUnavailable = &maxUnavailable
+	}
+
+	// Since we can specify only one of maxUnavailable and minAvailable, minAvailable takes precedence
+	// https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+	if cfg.MinAvailablePercentage != nil {
+		minAvailable := intstr.FromInt(*cfg.MinAvailablePercentage)
+		pdbSpec.MinAvailable = &minAvailable
+		pdbSpec.MaxUnavailable = nil
+	}
+
+	return pdbSpec, nil
+}
+
+func (c *controller) createPodDisruptionBudgets(modelService *models.Service, pdbConfig config.PodDisruptionBudgetConfig) []*PodDisruptionBudget {
+	pdbs := []*PodDisruptionBudget{}
+
+	predictorPdb := NewPodDisruptionBudget(modelService, models.ModelComponentType, pdbConfig)
+	pdbs = append(pdbs, predictorPdb)
+
+	if modelService.Transformer != nil && modelService.Transformer.Enabled {
+		transformerPdb := NewPodDisruptionBudget(modelService, models.TransformerComponentType, pdbConfig)
+		pdbs = append(pdbs, transformerPdb)
+	}
+
+	return pdbs
+}
+
+func (c *controller) deployPodDisruptionBudgets(ctx context.Context, pdbs []*PodDisruptionBudget) error {
+	for _, pdb := range pdbs {
+		if err := c.deployPodDisruptionBudget(ctx, pdb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *controller) deployPodDisruptionBudget(ctx context.Context, pdb *PodDisruptionBudget) error {
+	pdbSpec, err := pdb.BuildPDBSpec()
+	if err != nil {
+		return err
+	}
+
+	pdbCfg := policyv1cfg.PodDisruptionBudget(pdb.Name, pdb.Namespace)
+	pdbCfg.WithLabels(pdb.Labels)
+	pdbCfg.WithSpec(pdbSpec)
+
+	_, err = c.policyClient.PodDisruptionBudgets(pdb.Namespace).Apply(ctx, pdbCfg, metav1.ApplyOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *controller) deletePodDisruptionBudgets(ctx context.Context, pdbs []*PodDisruptionBudget) error {
+	for _, pdb := range pdbs {
+		if err := c.deletePodDisruptionBudget(ctx, pdb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *controller) deletePodDisruptionBudget(ctx context.Context, pdb *PodDisruptionBudget) error {
+	return c.policyClient.PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{})
+}

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	metav1cfg "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -107,5 +108,9 @@ func (c *controller) deletePodDisruptionBudgets(ctx context.Context, pdbs []*Pod
 }
 
 func (c *controller) deletePodDisruptionBudget(ctx context.Context, pdb *PodDisruptionBudget) error {
-	return c.policyClient.PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{})
+	err := c.policyClient.PodDisruptionBudgets(pdb.Namespace).Delete(ctx, pdb.Name, metav1.DeleteOptions{})
+	if !kerrors.IsNotFound(err) {
+		return err
+	}
+	return nil
 }

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -86,7 +86,13 @@ func main() {
 		log.Panicf("Failed initializing config: %v", err)
 	}
 
-	cfg.ClusterConfig.EnvironmentConfigs = config.InitEnvironmentConfigs(cfg.ClusterConfig.EnvironmentConfigPath)
+	// cfg.ClusterConfig.EnvironmentConfigs = config.InitEnvironmentConfigs(cfg.ClusterConfig.EnvironmentConfigPath)
+	environmentConfigs, err := config.InitEnvironmentConfigs(cfg.ClusterConfig.EnvironmentConfigPath)
+	if err != nil {
+		log.Panicf("Failed initializing environment configs: %v", err)
+	}
+
+	cfg.ClusterConfig.EnvironmentConfigs = environmentConfigs
 	if cfg.ClusterConfig.InClusterConfig && len(cfg.ClusterConfig.EnvironmentConfigs) > 1 {
 		log.Panicf("There should only be one cluster if in cluster credentials are used")
 	}

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -424,11 +424,13 @@ func (cfg *Config) Validate() error {
 	if err != nil {
 		return err
 	}
+
 	// Validate pyfunc server keep alive config, it must be string in json format
 	var pyfuncGRPCOpts json.RawMessage
 	if err := json.Unmarshal([]byte(cfg.PyfuncGRPCOptions), &pyfuncGRPCOpts); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/api/config/deployment.go
+++ b/api/config/deployment.go
@@ -41,6 +41,8 @@ type DeploymentConfig struct {
 	QueueResourcePercentage string
 	// GRPC Options for Pyfunc server
 	PyfuncGRPCOptions string
+	// PDB config to be applied on models and transformers
+	PodDisruptionBudget PodDisruptionBudgetConfig
 }
 
 type ResourceRequests struct {
@@ -52,4 +54,13 @@ type ResourceRequests struct {
 	CPURequest resource.Quantity
 	// Memory request of inference service
 	MemoryRequest resource.Quantity
+}
+
+// PodDisruptionBudgetConfig are the configuration for PodDisruptionBudgetConfig for
+// Turing services.
+type PodDisruptionBudgetConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// Can specify only one of maxUnavailable and minAvailable
+	MaxUnavailablePercentage *int `yaml:"max_unavailable_percentage"`
+	MinAvailablePercentage   *int `yaml:"min_available_percentage"`
 }

--- a/api/config/environment.go
+++ b/api/config/environment.go
@@ -19,12 +19,13 @@ import (
 	"os"
 	"time"
 
-	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	sigyaml "sigs.k8s.io/yaml"
+
+	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 )
 
 type EnvironmentConfig struct {

--- a/api/config/environment.go
+++ b/api/config/environment.go
@@ -117,12 +117,12 @@ func InitEnvironmentConfigs(path string) ([]*EnvironmentConfig, error) {
 
 	var configs []*EnvironmentConfig
 	if err = yaml.Unmarshal(cfgFile, &configs); err != nil {
-		return nil, fmt.Errorf("unable to unmarshall deployment config file:\n %s,\nDue to: %v", cfgFile, err)
+		return nil, fmt.Errorf("unable to unmarshall deployment config file:\n %s,\ndue to: %w", cfgFile, err)
 	}
 
 	for _, env := range configs {
 		if err := env.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid environment config: %v", err)
+			return nil, fmt.Errorf("invalid environment config: %w", err)
 		}
 
 		if env.K8sConfig == nil {

--- a/api/config/environment.go
+++ b/api/config/environment.go
@@ -15,11 +15,12 @@
 package config
 
 import (
-	"log"
+	"fmt"
 	"os"
 	"time"
 
 	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
+	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -41,6 +42,7 @@ type EnvironmentConfig struct {
 	MaxCPU                    string                    `yaml:"max_cpu"`
 	MaxMemory                 string                    `yaml:"max_memory"`
 	TopologySpreadConstraints TopologySpreadConstraints `yaml:"topology_spread_constraints"`
+	PodDisruptionBudget       PodDisruptionBudgetConfig `yaml:"pod_disruption_budget"`
 
 	QueueResourcePercentage string `yaml:"queue_resource_percentage"`
 
@@ -48,6 +50,24 @@ type EnvironmentConfig struct {
 	DefaultDeploymentConfig    *ResourceRequestConfig              `yaml:"default_deployment_config"`
 	DefaultTransformerConfig   *ResourceRequestConfig              `yaml:"default_transformer_config"`
 	K8sConfig                  *mlpcluster.K8sConfig               `validate:"required" yaml:"k8s_config"`
+}
+
+func (e *EnvironmentConfig) Validate() error {
+	v := validator.New()
+
+	// Use struct level validation for PodDisruptionBudgetConfig
+	v.RegisterStructValidation(func(sl validator.StructLevel) {
+		field := sl.Current().Interface().(PodDisruptionBudgetConfig)
+		// If PDB is enabled, one of max unavailable or min available shall be set
+		if field.Enabled &&
+			(field.MaxUnavailablePercentage == nil && field.MinAvailablePercentage == nil) ||
+			(field.MaxUnavailablePercentage != nil && field.MinAvailablePercentage != nil) {
+			sl.ReportError(field.MaxUnavailablePercentage, "max_unavailable_percentage", "int", "choose_one[max_unavailable_percentage,min_available_percentage]", "")
+			sl.ReportError(field.MinAvailablePercentage, "min_available_percentage", "int", "choose_one[max_unavailable_percentage,min_available_percentage]", "")
+		}
+	}, PodDisruptionBudgetConfig{})
+
+	return v.Struct(e)
 }
 
 type TopologySpreadConstraints []corev1.TopologySpreadConstraint
@@ -89,21 +109,28 @@ type ResourceRequestConfig struct {
 	MemoryRequest string `yaml:"memory_request"`
 }
 
-func InitEnvironmentConfigs(path string) []*EnvironmentConfig {
+func InitEnvironmentConfigs(path string) ([]*EnvironmentConfig, error) {
 	cfgFile, err := os.ReadFile(path)
 	if err != nil {
-		log.Panicf("unable to read deployment config file: %s", path)
+		return nil, fmt.Errorf("unable to read deployment config file: %s", path)
 	}
+
 	var configs []*EnvironmentConfig
 	if err = yaml.Unmarshal(cfgFile, &configs); err != nil {
-		log.Panicf("unable to unmarshall deployment config file:\n %s,\nDue to: %v", cfgFile, err)
+		return nil, fmt.Errorf("unable to unmarshall deployment config file:\n %s,\nDue to: %v", cfgFile, err)
 	}
+
 	for _, env := range configs {
+		if err := env.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid environment config: %v", err)
+		}
+
 		if env.K8sConfig == nil {
-			log.Panicf("Error, k8sConfig for %s is nil", env.Name)
+			return nil, fmt.Errorf("k8sConfig for %s is nil", env.Name)
 		}
 	}
-	return configs
+
+	return configs, nil
 }
 
 func ParseDeploymentConfig(cfg *EnvironmentConfig, pyfuncGRPCOptions string) DeploymentConfig {
@@ -127,5 +154,6 @@ func ParseDeploymentConfig(cfg *EnvironmentConfig, pyfuncGRPCOptions string) Dep
 		TopologySpreadConstraints: cfg.TopologySpreadConstraints,
 		QueueResourcePercentage:   cfg.QueueResourcePercentage,
 		PyfuncGRPCOptions:         pyfuncGRPCOptions,
+		PodDisruptionBudget:       cfg.PodDisruptionBudget,
 	}
 }

--- a/api/config/environment_test.go
+++ b/api/config/environment_test.go
@@ -133,7 +133,7 @@ func TestPDBConfig(t *testing.T) {
 				assert.Nil(t, err)
 			} else {
 				assert.NotNil(t, err)
-				assert.Equal(t, tC.validateErr, err)
+				assert.Equal(t, tC.validateErr.Error(), err.Error())
 				return
 			}
 

--- a/api/config/testdata/invalid-pdb-environment-both-nil.yaml
+++ b/api/config/testdata/invalid-pdb-environment-both-nil.yaml
@@ -1,0 +1,44 @@
+- name: "id-dev"
+  is_default: true
+  is_prediction_job_enabled: true
+  is_default_prediction_job: true
+  cluster: "dev"
+  region: "id"
+  gcp_project: ""
+  deployment_timeout: "10m"
+  namespace_timeout: "2m"
+  max_cpu: "8"
+  max_memory: "8Gi"
+  pod_disruption_budget:
+    enabled: true
+    # This invalid as we must specify one of maxUnavailable and minAvailable
+    # max_unavailable_percentage: 20
+    # min_available_percentage: 80
+  queue_resource_percentage: "20"
+  default_prediction_job_config:
+    executor_replica: 3
+    driver_cpu_request: "2"
+    driver_memory_request: "2Gi"
+    executor_cpu_request: "2"
+    executor_memory_request: "2Gi"
+  default_deployment_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  default_transformer_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  k8s_config:
+    name: id-dev
+    cluster:
+      server: id-dev.k8s-cluster
+      insecure-skip-tls-verify: true
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: gke-gcloud-auth-plugin
+        interactiveMode: IfAvailable
+        provideClusterInfo: true

--- a/api/config/testdata/invalid-pdb-environment-both-set.yaml
+++ b/api/config/testdata/invalid-pdb-environment-both-set.yaml
@@ -1,0 +1,44 @@
+- name: "id-dev"
+  is_default: true
+  is_prediction_job_enabled: true
+  is_default_prediction_job: true
+  cluster: "dev"
+  region: "id"
+  gcp_project: ""
+  deployment_timeout: "10m"
+  namespace_timeout: "2m"
+  max_cpu: "8"
+  max_memory: "8Gi"
+  pod_disruption_budget:
+    enabled: true
+    # This invalid as we can specify only one of maxUnavailable and minAvailable
+    max_unavailable_percentage: 20
+    min_available_percentage: 80
+  queue_resource_percentage: "20"
+  default_prediction_job_config:
+    executor_replica: 3
+    driver_cpu_request: "2"
+    driver_memory_request: "2Gi"
+    executor_cpu_request: "2"
+    executor_memory_request: "2Gi"
+  default_deployment_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  default_transformer_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  k8s_config:
+    name: id-dev
+    cluster:
+      server: id-dev.k8s-cluster
+      insecure-skip-tls-verify: true
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: gke-gcloud-auth-plugin
+        interactiveMode: IfAvailable
+        provideClusterInfo: true

--- a/api/config/testdata/valid-environment-1.yaml
+++ b/api/config/testdata/valid-environment-1.yaml
@@ -1,0 +1,42 @@
+- name: "id-dev"
+  is_default: true
+  is_prediction_job_enabled: true
+  is_default_prediction_job: true
+  cluster: "dev"
+  region: "id"
+  gcp_project: ""
+  deployment_timeout: "10m"
+  namespace_timeout: "2m"
+  max_cpu: "8"
+  max_memory: "8Gi"
+  pod_disruption_budget:
+    enabled: true
+    max_unavailable_percentage: 20
+  queue_resource_percentage: "20"
+  default_prediction_job_config:
+    executor_replica: 3
+    driver_cpu_request: "2"
+    driver_memory_request: "2Gi"
+    executor_cpu_request: "2"
+    executor_memory_request: "2Gi"
+  default_deployment_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  default_transformer_config:
+    min_replica: 0
+    max_replica: 1
+    cpu_request: "500m"
+    memory_request: "500Mi"
+  k8s_config:
+    name: id-dev
+    cluster:
+      server: id-dev.k8s-cluster
+      insecure-skip-tls-verify: true
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: gke-gcloud-auth-plugin
+        interactiveMode: IfAvailable
+        provideClusterInfo: true

--- a/api/models/container.go
+++ b/api/models/container.go
@@ -28,6 +28,7 @@ const (
 	ImageBuilderComponentType     = "image_builder"
 	ModelComponentType            = "model"
 	TransformerComponentType      = "transformer"
+	PDBComponentType              = "pdb" // Pod disruption budget
 	BatchJobDriverComponentType   = "batch_job_driver"
 	BatchJobExecutorComponentType = "batch_job_executor"
 )
@@ -46,7 +47,8 @@ func NewContainer(name string,
 	podName string,
 	namespace string,
 	cluster string,
-	gcpProject string) *Container {
+	gcpProject string,
+) *Container {
 	return &Container{
 		Name:          name,
 		PodName:       podName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

This PR will add PodDisruptionBudget resources to Merlin components (model and transformer).

Modifications:

1. Add PodDisruptionBudget config
2. Add Deploy and Delete PodDisruptionBudget on Cluster Controller
3. Refactor test-api job to not run lint-api since it's already done in separate job

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
