### PR TITLE
Fix getting model and model endpoint id for rendering model alert page

### DIFF
--- a/ui/src/model/ModelDetails.js
+++ b/ui/src/model/ModelDetails.js
@@ -44,7 +44,7 @@ export const ModelDetails = () => {
     },
     {
       text: model.name,
-      href: `/merlin/projects/${projectId}/models/${model.id}`,
+      href: `/merlin/projects/${projectId}/models/${modelId}`,
     },
   ];
 

--- a/ui/src/model/ModelDetails.js
+++ b/ui/src/model/ModelDetails.js
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from "react";
-import { Route, Routes, useLocation, useParams } from "react-router-dom";
-import {
-  EuiLoadingContent,
-  EuiPageTemplate,
-  EuiSpacer
-} from "@elastic/eui";
-import { get } from "@caraml-dev/ui-lib";
-import { useMerlinApi } from "../hooks/useMerlinApi";
-import { ModelAlert } from "./alert/ModelAlert";
+import { EuiLoadingContent, EuiPageTemplate, EuiSpacer } from "@elastic/eui";
+import React from "react";
+import { Route, Routes, useParams } from "react-router-dom";
 import { featureToggleConfig } from "../config";
+import { useMerlinApi } from "../hooks/useMerlinApi";
+import mocks from "../mocks";
+import { ModelAlert } from "./alert/ModelAlert";
 
 const LoadingContent = () => (
   <EuiPageTemplate.Section>
@@ -34,34 +30,23 @@ const LoadingContent = () => (
 
 export const ModelDetails = () => {
   const { projectId, modelId } = useParams();
-  const location = useLocation();
-  const [model, setModel] = useState(get(location.state, "model"));
-  const [breadcrumbs, setBreadcrumbs] = useState([]);
 
-  const [{ data: models, isLoaded: modelsLoaded }] = useMerlinApi(
-    `/projects/${projectId}/models`,
-    {},
-    [],
-    !model
+  const [{ data: model, isLoaded: modelLoaded }] = useMerlinApi(
+    `/projects/${projectId}/models/${modelId}`,
+    { mock: mocks.model },
+    []
   );
 
-  useEffect(() => {
-    modelsLoaded && setModel(models.find(m => m.id.toString() === modelId));
-  }, [models, modelsLoaded, modelId, setModel]);
-
-  useEffect(() => {
-    model &&
-      setBreadcrumbs([
-        {
-          text: "Models",
-          href: `/merlin/projects/${projectId}/models`
-        },
-        {
-          text: model.name,
-          href: `/merlin/projects/${projectId}/models/${model.id}`
-        }
-      ]);
-  }, [projectId, model]);
+  const breadcrumbs = [
+    {
+      text: "Models",
+      href: `/merlin/projects/${projectId}/models`,
+    },
+    {
+      text: model.name,
+      href: `/merlin/projects/${projectId}/models/${model.id}`,
+    },
+  ];
 
   return (
     <EuiPageTemplate restrictWidth="90%" paddingSize="none">
@@ -71,20 +56,26 @@ export const ModelDetails = () => {
         iconType={"machineLearningApp"}
         pageTitle={model.name}
       />
-      
+
       <EuiSpacer size="l" />
       <EuiPageTemplate.Section color={"transparent"}>
         {featureToggleConfig.alertEnabled && (
           <Routes>
             <Route index element={<LoadingContent default />} />
-            {model && (<Route path="endpoints/:endpointId/alert" element={<ModelAlert
+            {modelLoaded && model && (
+              <Route
                 path="endpoints/:endpointId/alert"
-                breadcrumbs={breadcrumbs}
-                model={model}
-              />} />)}
+                element={
+                  <ModelAlert
+                    path="endpoints/:endpointId/alert"
+                    breadcrumbs={breadcrumbs}
+                    model={model}
+                  />
+                }
+              />
+            )}
           </Routes>
         )}
-       
       </EuiPageTemplate.Section>
       <EuiSpacer size="l" />
     </EuiPageTemplate>

--- a/ui/src/model/alert/ModelAlert.js
+++ b/ui/src/model/alert/ModelAlert.js
@@ -14,23 +14,25 @@
  * limitations under the License.
  */
 
-import React, { Fragment, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { replaceBreadcrumbs } from "@caraml-dev/ui-lib";
 import {
   EuiButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiTitle
+  EuiTitle,
 } from "@elastic/eui";
-import { replaceBreadcrumbs } from "@caraml-dev/ui-lib";
+import PropTypes from "prop-types";
+import React, { Fragment, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { useMerlinApi } from "../../hooks/useMerlinApi";
 import mocks from "../../mocks";
 import { ModelAlertForm } from "./components/ModelAlertForm";
-import PropTypes from "prop-types";
 
-export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
+export const ModelAlert = ({ breadcrumbs, model }) => {
+  const { endpointId } = useParams();
+
   const navigate = useNavigate();
   const redirectUrl = `/merlin/projects/${model.project_id}`;
 
@@ -40,7 +42,7 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
 
   const [request, setRequest] = useState({
     model_id: model.id,
-    alert_conditions: []
+    alert_conditions: [],
   });
 
   const [endpoint, setEndpoint] = useState();
@@ -48,14 +50,14 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
   useEffect(() => {
     if (model && endpointId) {
       const endpoint = model.endpoints.find(
-        e => e.id.toString() === endpointId
+        (e) => e.id.toString() === endpointId
       );
       setEndpoint(endpoint);
 
-      setRequest(r => ({
+      setRequest((r) => ({
         ...r,
         model_endpoint_id: parseInt(endpointId),
-        environment_name: endpoint.environment_name
+        environment_name: endpoint.environment_name,
       }));
     }
   }, [model, endpointId, setEndpoint, setRequest]);
@@ -66,7 +68,7 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
     `/models/${model.id}/endpoints/${endpointId}/alert`,
     {
       mock: mocks.modelEndpointAlert,
-      muteError: true
+      muteError: true,
     }
   );
 
@@ -134,7 +136,8 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
                   <EuiFlexItem grow={false}>
                     <EuiButtonEmpty
                       size="s"
-                      onClick={() => navigate(redirectUrl)}>
+                      onClick={() => navigate(redirectUrl)}
+                    >
                       Cancel
                     </EuiButtonEmpty>
                   </EuiFlexItem>
@@ -145,7 +148,8 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
                       color="primary"
                       fill
                       disabled={request.alert_conditions.length === 0}
-                      onClick={saveAlert}>
+                      onClick={saveAlert}
+                    >
                       Save
                     </EuiButton>
                   </EuiFlexItem>
@@ -162,5 +166,5 @@ export const ModelAlert = ({ breadcrumbs, model, endpointId }) => {
 ModelAlert.propTypes = {
   breadcrumbs: PropTypes.array,
   model: PropTypes.object,
-  endpointId: PropTypes.string
+  endpointId: PropTypes.string,
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

There's a bug on Model Endpoint Alert page where users 1) Cannot open alert page if they write the endpoint on the browser address bar and 2) Cannot create alert.

The first issue is due to the page cannot get the model data from location state, hence I updated it to fetch the model data from the API.

And the second issue is due to endpointId is undefined because endpointId is not passed correctly as well. I updated it to get the value via `useParams` hook instead of via component props.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes Model Alert UI

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
