### PR TITLE
Add viperKeyDelimiter; Add unit test for imagebuilder nodeselectors

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -37,6 +37,8 @@ import (
 )
 
 const (
+	viperKeyDelimiter = "::"
+
 	MaxDeployedVersion = 2
 )
 
@@ -451,7 +453,7 @@ func (cfg *Config) Validate() error {
 //
 // Refer to example.yaml for an example of config file.
 func Load(spec interface{}, filepaths ...string) (*Config, error) {
-	v := viper.New()
+	v := viper.NewWithOptions(viper.KeyDelimiter(viperKeyDelimiter))
 
 	err := reflectViperConfig("", spec, v)
 	if err != nil {
@@ -470,7 +472,7 @@ func Load(spec interface{}, filepaths ...string) (*Config, error) {
 	// Load config values from environment variables.
 	// Nested keys in the config is represented by variable name separated by '_'.
 	// For example, DbConfig.Host can be set from environment variable DBCONFIG_HOST.
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer(viperKeyDelimiter, "_"))
 	v.AutomaticEnv()
 
 	// Unmarshal config values into the config object.
@@ -513,7 +515,7 @@ func reflectViperConfig(prefix string, spec interface{}, v *viper.Viper) error {
 		viperKey := ftype.Name
 		// Nested struct tags
 		if prefix != "" {
-			viperKey = fmt.Sprintf("%s.%s", prefix, ftype.Name)
+			viperKey = fmt.Sprintf("%s%s%s", prefix, viperKeyDelimiter, ftype.Name)
 		}
 		value := ftype.Tag.Get("default")
 		if value == "-" {

--- a/api/config/environment_test.go
+++ b/api/config/environment_test.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -149,4 +151,25 @@ func TestPDBConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestImageBuilderConfig(t *testing.T) {
+	baseFilePath := "./testdata/config-1.yaml"
+	imageBuilderCfgFilePath := "./testdata/valid-imagebuilder-nodeselectors.yaml"
+
+	os.Clearenv()
+	setRequiredEnvironmentVariables()
+
+	filePaths := []string{baseFilePath}
+	filePaths = append(filePaths, imageBuilderCfgFilePath)
+
+	var emptyCfg Config
+	cfg, err := Load(&emptyCfg, filePaths...)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	expected := map[string]string{
+		"cloud.google.com/gke-nodepool": "image-build-job-node-pool",
+	}
+	assert.Equal(t, expected, cfg.ImageBuilderConfig.NodeSelectors)
 }

--- a/api/config/testdata/valid-imagebuilder-nodeselectors.yaml
+++ b/api/config/testdata/valid-imagebuilder-nodeselectors.yaml
@@ -1,3 +1,3 @@
 ImageBuilderConfig:
   NodeSelectors:
-    "cloud.google.com/gke-nodepool": image-build-job-node-pool
+    cloud.google.com/gke-nodepool: image-build-job-node-pool

--- a/api/config/testdata/valid-imagebuilder-nodeselectors.yaml
+++ b/api/config/testdata/valid-imagebuilder-nodeselectors.yaml
@@ -1,0 +1,3 @@
+ImageBuilderConfig:
+  NodeSelectors:
+    "cloud.google.com/gke-nodepool": image-build-job-node-pool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Previous implementation of Viper cannot load the YAML key that contains ".". For example, give this config file:

```
NodeSelectors:
    cloud.google.com/gke-nodepool: image-build-job-node-pool
```

config.Load will raise error:

```
Failed initializing config: failed to unmarshal config values: 1 error(s) decoding:

* 'ImageBuilderConfig.NodeSelectors[cloud]' expected type 'string', got unconvertible type 'map[string]interface {}', value: 'map[google:map[com/gke-nodepool:image-build-job-node-pool]]'
```

This PR fixes this issue by setting viper key delimiter to `::`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
