### PR TITLE
feat: Model deletion feature toggle

### DIFF
--- a/api/api/models_api.go
+++ b/api/api/models_api.go
@@ -130,7 +130,7 @@ func (c *ModelsController) DeleteModel(r *http.Request, vars map[string]string, 
 	}
 
 	// get all model version for this model
-	versions, _, err := c.VersionsService.ListVersions(ctx, modelID, c.MonitoringConfig, service.VersionQuery{})
+	versions, _, err := c.VersionsService.ListVersions(ctx, modelID, c.FeatureToggleConfig.MonitoringConfig, service.VersionQuery{})
 	if err != nil {
 		return InternalServerError(fmt.Sprintf("Error getting list of versions: %v", err.Error()))
 	}

--- a/api/api/models_api_test.go
+++ b/api/api/models_api_test.go
@@ -1289,30 +1289,38 @@ func TestDeleteModel(t *testing.T) {
 
 			ctl := &ModelsController{
 				AppContext: &AppContext{
-					VersionsService: versionSvc(),
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
-					},
-					AlertEnabled:          true,
+					VersionsService:       versionSvc(),
 					ModelsService:         modelsSvc(),
 					MlflowDeleteService:   mlflowDeleteSvc(),
 					PredictionJobService:  predictionJobSvc(),
 					EndpointsService:      endpointSvc(),
 					ProjectsService:       projectSvc(),
 					ModelEndpointsService: modelEndpointSvc(),
-				},
-				VersionsController: &VersionsController{
-					AppContext: &AppContext{
-						VersionsService: versionSvc(),
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
 						MonitoringConfig: config.MonitoringConfig{
 							MonitoringEnabled: true,
 							MonitoringBaseURL: "http://grafana",
 						},
-						AlertEnabled:         true,
+					},
+				},
+				VersionsController: &VersionsController{
+					AppContext: &AppContext{
+						VersionsService:      versionSvc(),
 						MlflowDeleteService:  mlflowDeleteSvc(),
 						PredictionJobService: predictionJobSvc(),
 						EndpointsService:     endpointSvc(),
+						FeatureToggleConfig: config.FeatureToggleConfig{
+							AlertConfig: config.AlertConfig{
+								AlertEnabled: true,
+							},
+							MonitoringConfig: config.MonitoringConfig{
+								MonitoringEnabled: true,
+								MonitoringBaseURL: "http://grafana",
+							},
+						},
 					},
 				},
 			}
@@ -1320,5 +1328,4 @@ func TestDeleteModel(t *testing.T) {
 			assertEqualResponses(t, tC.expected, resp)
 		})
 	}
-
 }

--- a/api/api/prediction_job_api_test.go
+++ b/api/api/prediction_job_api_test.go
@@ -196,11 +196,15 @@ func TestList(t *testing.T) {
 					ModelsService:        modelSvc,
 					VersionsService:      versionSvc,
 					PredictionJobService: predictionJobSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.List(&http.Request{}, tC.vars, nil)
@@ -451,11 +455,15 @@ func TestGet(t *testing.T) {
 					VersionsService:      versionSvc,
 					PredictionJobService: predictionJobSvc,
 					EnvironmentService:   envSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.Get(&http.Request{}, tC.vars, nil)
@@ -698,11 +706,15 @@ func TestStop(t *testing.T) {
 					VersionsService:      versionSvc,
 					PredictionJobService: predictionJobSvc,
 					EnvironmentService:   envSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.Stop(&http.Request{}, tC.vars, nil)
@@ -1036,11 +1048,15 @@ func TestListContainers_PredictionJob(t *testing.T) {
 					VersionsService:      versionSvc,
 					PredictionJobService: predictionJobSvc,
 					EnvironmentService:   envSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.ListContainers(&http.Request{}, tC.vars, nil)
@@ -1366,11 +1382,15 @@ func TestCreate(t *testing.T) {
 					VersionsService:      versionSvc,
 					PredictionJobService: predictionJobSvc,
 					EnvironmentService:   envSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.Create(&http.Request{}, tC.vars, tC.requestBody)
@@ -1501,11 +1521,15 @@ func TestListAllInProject(t *testing.T) {
 				AppContext: &AppContext{
 					ProjectsService:      projectSvc,
 					PredictionJobService: predictionJobSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.ListAllInProject(tC.request, tC.vars, nil)

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -68,6 +68,7 @@ type AppContext struct {
 
 	AuthorizationEnabled bool
 	AlertEnabled         bool
+	FeatureToggleConfig  config.FeatureToggleConfig
 	MonitoringConfig     config.MonitoringConfig
 
 	StandardTransformerConfig config.StandardTransformerConfig
@@ -186,7 +187,6 @@ func NewRouter(appCtx AppContext) (*mux.Router, error) {
 		{http.MethodGet, "/projects/{project_id:[0-9]+}/models/{model_id:[0-9]+}", nil, modelsController.GetModel, "GetModel"},
 		{http.MethodGet, "/projects/{project_id:[0-9]+}/models", nil, modelsController.ListModels, "ListModels"},
 		{http.MethodPost, "/projects/{project_id:[0-9]+}/models", models.Model{}, modelsController.CreateModel, "CreateModel"},
-		{http.MethodDelete, "/projects/{project_id:[0-9]+}/models/{model_id:[0-9]+}", nil, modelsController.DeleteModel, "DeleteModel"},
 
 		// Model Endpoints API
 		{http.MethodGet, "/projects/{project_id:[0-9]+}/model_endpoints", nil, modelEndpointsController.ListModelEndpointInProject, "ListModelEndpointInProject"},
@@ -224,6 +224,11 @@ func NewRouter(appCtx AppContext) (*mux.Router, error) {
 
 		// Standard Transformer Simulation API
 		{http.MethodPost, "/standard_transformer/simulate", models.TransformerSimulation{}, transformerController.SimulateTransformer, "SimulateTransformer"},
+	}
+
+	if appCtx.FeatureToggleConfig.ModelDeletionConfig.Enabled {
+		// Model deletion API
+		routes = append(routes, Route{http.MethodDelete, "/projects/{project_id:[0-9]+}/models/{model_id:[0-9]+}", nil, modelsController.DeleteModel, "DeleteModel"})
 	}
 
 	if appCtx.AlertEnabled {

--- a/api/api/router.go
+++ b/api/api/router.go
@@ -66,11 +66,8 @@ type AppContext struct {
 	TransformerService        service.TransformerService
 	MlflowDeleteService       mlflowDelete.Service
 
-	AuthorizationEnabled bool
-	AlertEnabled         bool
-	FeatureToggleConfig  config.FeatureToggleConfig
-	MonitoringConfig     config.MonitoringConfig
-
+	AuthorizationEnabled      bool
+	FeatureToggleConfig       config.FeatureToggleConfig
 	StandardTransformerConfig config.StandardTransformerConfig
 
 	FeastCoreClient core.CoreServiceClient
@@ -231,7 +228,7 @@ func NewRouter(appCtx AppContext) (*mux.Router, error) {
 		routes = append(routes, Route{http.MethodDelete, "/projects/{project_id:[0-9]+}/models/{model_id:[0-9]+}", nil, modelsController.DeleteModel, "DeleteModel"})
 	}
 
-	if appCtx.AlertEnabled {
+	if appCtx.FeatureToggleConfig.AlertConfig.AlertEnabled {
 		routes = append(routes, []Route{
 			// Model Endpoint Alerts API
 			{http.MethodGet, "/alerts/teams", nil, alertsController.ListTeams, "ListTeams"},

--- a/api/api/router_test.go
+++ b/api/api/router_test.go
@@ -366,11 +366,15 @@ func TestRejectAuthorization(t *testing.T) {
 				Enforcer:              mockEnforcer,
 				DB:                    nil,
 				AuthorizationEnabled:  true,
-				MonitoringConfig: config.MonitoringConfig{
-					MonitoringEnabled: true,
-					MonitoringBaseURL: "http://grafana",
+				FeatureToggleConfig: config.FeatureToggleConfig{
+					AlertConfig: config.AlertConfig{
+						AlertEnabled: true,
+					},
+					MonitoringConfig: config.MonitoringConfig{
+						MonitoringEnabled: true,
+						MonitoringBaseURL: "http://grafana",
+					},
 				},
-				AlertEnabled: true,
 			})
 			assert.NoError(t, err)
 			if tt.model != nil {

--- a/api/api/transformer_api_test.go
+++ b/api/api/transformer_api_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/caraml-dev/merlin/config"
 	"github.com/caraml-dev/merlin/models"
 	"github.com/caraml-dev/merlin/pkg/protocol"
 	"github.com/caraml-dev/merlin/pkg/transformer/spec"
@@ -312,11 +311,6 @@ func TestTransformerController_SimulateTransformer(t *testing.T) {
 			ctl := &TransformerController{
 				AppContext: &AppContext{
 					TransformerService: tt.transformerService(payload),
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
-					},
-					AlertEnabled: true,
 				},
 			}
 			got := ctl.SimulateTransformer(&http.Request{}, tt.vars, tt.requestBody)

--- a/api/api/utils.go
+++ b/api/api/utils.go
@@ -32,7 +32,7 @@ func (c *AppContext) getModelAndVersion(ctx context.Context, modelID models.ID, 
 		return nil, nil, fmt.Errorf("error retrieving model with id: %d", modelID)
 	}
 
-	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
 			return nil, nil, fmt.Errorf("model version with given id: %d not found", versionID)

--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -50,7 +50,7 @@ func (c *EndpointsController) ListEndpoint(r *http.Request, vars map[string]stri
 		return NotFound(fmt.Sprintf("Model with given `model_id: %d` not found", modelID))
 	}
 
-	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		return NotFound(fmt.Sprintf("Version with given `version_id: %d` not found: %v", versionID, err))
 	}
@@ -60,9 +60,9 @@ func (c *EndpointsController) ListEndpoint(r *http.Request, vars map[string]stri
 		return InternalServerError(err.Error())
 	}
 
-	if c.MonitoringConfig.MonitoringEnabled {
+	if c.FeatureToggleConfig.MonitoringConfig.MonitoringEnabled {
 		for k := range endpoints {
-			endpoints[k].UpdateMonitoringURL(c.MonitoringConfig.MonitoringBaseURL, models.EndpointMonitoringURLParams{
+			endpoints[k].UpdateMonitoringURL(c.FeatureToggleConfig.MonitoringConfig.MonitoringBaseURL, models.EndpointMonitoringURLParams{
 				Cluster:      endpoints[k].Environment.Cluster,
 				Project:      model.Project.Name,
 				Model:        model.Name,
@@ -86,7 +86,7 @@ func (c *EndpointsController) GetEndpoint(r *http.Request, vars map[string]strin
 		return NotFound(fmt.Sprintf("Model not found: %v", err))
 	}
 
-	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		return NotFound(fmt.Sprintf("Version not found: %v", err))
 	}
@@ -99,8 +99,8 @@ func (c *EndpointsController) GetEndpoint(r *http.Request, vars map[string]strin
 		return InternalServerError(fmt.Sprintf("Error getting version endpoint: %v", err))
 	}
 
-	if c.MonitoringConfig.MonitoringEnabled {
-		endpoint.UpdateMonitoringURL(c.MonitoringConfig.MonitoringBaseURL, models.EndpointMonitoringURLParams{
+	if c.FeatureToggleConfig.MonitoringConfig.MonitoringEnabled {
+		endpoint.UpdateMonitoringURL(c.FeatureToggleConfig.MonitoringConfig.MonitoringBaseURL, models.EndpointMonitoringURLParams{
 			Cluster:      endpoint.Environment.Cluster,
 			Project:      model.Project.Name,
 			Model:        model.Name,
@@ -206,12 +206,10 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 	return Created(endpoint)
 }
 
-var (
-	supportedUPIModelTypes = map[string]bool{
-		models.ModelTypePyFunc: true,
-		models.ModelTypeCustom: true,
-	}
-)
+var supportedUPIModelTypes = map[string]bool{
+	models.ModelTypePyFunc: true,
+	models.ModelTypeCustom: true,
+}
 
 func isModelSupportUPI(model *models.Model) bool {
 	_, isSupported := supportedUPIModelTypes[model.Type]
@@ -377,7 +375,7 @@ func (c *EndpointsController) ListContainers(r *http.Request, vars map[string]st
 	if err != nil {
 		return NotFound(fmt.Sprintf("Model not found: %v", err))
 	}
-	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	version, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		return NotFound(fmt.Sprintf("Version not found: %v", err))
 	}

--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -227,11 +227,15 @@ func TestListEndpoint(t *testing.T) {
 					ModelsService:    modelSvc,
 					VersionsService:  versionSvc,
 					EndpointsService: endpointSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.ListEndpoint(&http.Request{}, tC.vars, nil)
@@ -471,11 +475,15 @@ func TestGetEndpoint(t *testing.T) {
 					ModelsService:    modelSvc,
 					VersionsService:  versionSvc,
 					EndpointsService: endpointSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.GetEndpoint(&http.Request{}, tC.vars, nil)
@@ -668,11 +676,15 @@ func TestListContainers(t *testing.T) {
 					ModelsService:    modelSvc,
 					VersionsService:  versionSvc,
 					EndpointsService: endpointSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.ListContainers(&http.Request{}, tC.vars, nil)
@@ -3268,12 +3280,16 @@ func TestCreateEndpoint(t *testing.T) {
 
 			ctl := &EndpointsController{
 				AppContext: &AppContext{
-					ModelsService:             modelSvc,
-					VersionsService:           versionSvc,
-					EnvironmentService:        envSvc,
-					EndpointsService:          endpointSvc,
-					MonitoringConfig:          tC.monitoringConfig,
-					AlertEnabled:              true,
+					ModelsService:      modelSvc,
+					VersionsService:    versionSvc,
+					EnvironmentService: envSvc,
+					EndpointsService:   endpointSvc,
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: tC.monitoringConfig,
+					},
 					StandardTransformerConfig: tC.standardTransformerConfig,
 					FeastCoreClient:           feastCoreMock,
 				},
@@ -4928,11 +4944,15 @@ func TestUpdateEndpoint(t *testing.T) {
 					VersionsService:    versionSvc,
 					EnvironmentService: envSvc,
 					EndpointsService:   endpointSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.UpdateEndpoint(&http.Request{}, tC.vars, tC.requestBody)
@@ -5560,11 +5580,15 @@ func TestDeleteEndpoint(t *testing.T) {
 					VersionsService:    versionSvc,
 					EnvironmentService: envSvc,
 					EndpointsService:   endpointSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.DeleteEndpoint(&http.Request{}, tC.vars, nil)

--- a/api/api/versions_api.go
+++ b/api/api/versions_api.go
@@ -38,7 +38,7 @@ func (c *VersionsController) GetVersion(r *http.Request, vars map[string]string,
 	modelID, _ := models.ParseID(vars["model_id"])
 	versionID, _ := models.ParseID(vars["version_id"])
 
-	v, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	v, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
 			return NotFound(fmt.Sprintf("Model version not found: %v", err))
@@ -55,7 +55,7 @@ func (c *VersionsController) PatchVersion(r *http.Request, vars map[string]strin
 	modelID, _ := models.ParseID(vars["model_id"])
 	versionID, _ := models.ParseID(vars["version_id"])
 
-	v, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.MonitoringConfig)
+	v, err := c.VersionsService.FindByID(ctx, modelID, versionID, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
 			return NotFound(fmt.Sprintf("Model version not found: %v", err))
@@ -72,7 +72,7 @@ func (c *VersionsController) PatchVersion(r *http.Request, vars map[string]strin
 		return BadRequest(fmt.Sprintf("Error validating version: %v", err))
 	}
 
-	patchedVersion, err := c.VersionsService.Save(ctx, v, c.MonitoringConfig)
+	patchedVersion, err := c.VersionsService.Save(ctx, v, c.FeatureToggleConfig.MonitoringConfig)
 	if err != nil {
 		return InternalServerError(fmt.Sprintf("Error patching model version: %v", err))
 	}
@@ -89,7 +89,7 @@ func (c *VersionsController) ListVersions(r *http.Request, vars map[string]strin
 	}
 
 	modelID, _ := models.ParseID(vars["model_id"])
-	versions, nextCursor, err := c.VersionsService.ListVersions(ctx, modelID, c.MonitoringConfig, query)
+	versions, nextCursor, err := c.VersionsService.ListVersions(ctx, modelID, c.FeatureToggleConfig.MonitoringConfig, query)
 	if err != nil {
 		return InternalServerError(fmt.Sprintf("Error listing versions for model: %v", err))
 	}
@@ -138,7 +138,7 @@ func (c *VersionsController) CreateVersion(r *http.Request, vars map[string]stri
 		PythonVersion: versionPost.PythonVersion,
 	}
 
-	version, _ = c.VersionsService.Save(ctx, version, c.MonitoringConfig)
+	version, _ = c.VersionsService.Save(ctx, version, c.FeatureToggleConfig.MonitoringConfig)
 	return Created(version)
 }
 
@@ -226,7 +226,6 @@ func (c *VersionsController) getInactivePredictionJobsForDeletion(ctx context.Co
 }
 
 func (c *VersionsController) getInactiveEndpointsForDeletion(ctx context.Context, model *models.Model, version *models.Version) ([]*models.VersionEndpoint, *Response) {
-
 	endpoints, err := c.EndpointsService.ListEndpoints(ctx, model, version)
 	if err != nil {
 		return nil, InternalServerError("Failed listing model version endpoint")

--- a/api/api/versions_api_test.go
+++ b/api/api/versions_api_test.go
@@ -124,11 +124,15 @@ func TestGetVersion(t *testing.T) {
 			ctl := &VersionsController{
 				AppContext: &AppContext{
 					VersionsService: versionSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.GetVersion(&http.Request{}, tC.vars, nil)
@@ -263,11 +267,15 @@ func TestListVersion(t *testing.T) {
 			ctl := &VersionsController{
 				AppContext: &AppContext{
 					VersionsService: versionSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.ListVersions(&http.Request{URL: &url.URL{RawQuery: tC.queryParameter}}, tC.vars, nil)
@@ -708,11 +716,15 @@ func TestPatchVersion(t *testing.T) {
 			ctl := &VersionsController{
 				AppContext: &AppContext{
 					VersionsService: versionSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled: true,
 				},
 			}
 			resp := ctl.PatchVersion(&http.Request{}, tC.vars, tC.requestBody)
@@ -1153,11 +1165,15 @@ func TestCreateVersion(t *testing.T) {
 			ctl := &VersionsController{
 				AppContext: &AppContext{
 					VersionsService: versionSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled:  true,
 					MlflowClient:  mlflowClient,
 					ModelsService: modelsSvc,
 				},
@@ -1747,11 +1763,15 @@ func TestDeleteVersion(t *testing.T) {
 			ctl := &VersionsController{
 				AppContext: &AppContext{
 					VersionsService: versionSvc,
-					MonitoringConfig: config.MonitoringConfig{
-						MonitoringEnabled: true,
-						MonitoringBaseURL: "http://grafana",
+					FeatureToggleConfig: config.FeatureToggleConfig{
+						AlertConfig: config.AlertConfig{
+							AlertEnabled: true,
+						},
+						MonitoringConfig: config.MonitoringConfig{
+							MonitoringEnabled: true,
+							MonitoringBaseURL: "http://grafana",
+						},
 					},
-					AlertEnabled:         true,
 					ModelsService:        modelsSvc,
 					MlflowDeleteService:  mlflowDeleteSvc(),
 					PredictionJobService: predictionJobSvc(),

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -159,6 +159,8 @@ func main() {
 
 		MonitoringEnabled:              cfg.FeatureToggleConfig.MonitoringConfig.MonitoringEnabled,
 		MonitoringPredictionJobBaseURL: cfg.FeatureToggleConfig.MonitoringConfig.MonitoringJobBaseURL,
+
+		ModelDeletionEnabled: cfg.FeatureToggleConfig.ModelDeletionConfig.Enabled,
 	}
 
 	uiHomePage := fmt.Sprintf("/%s", strings.TrimPrefix(cfg.ReactAppConfig.HomePage, "/"))
@@ -328,6 +330,7 @@ func buildDependencies(ctx context.Context, cfg *config.Config, db *gorm.DB, dis
 
 		AuthorizationEnabled: cfg.AuthorizationConfig.AuthorizationEnabled,
 		AlertEnabled:         cfg.FeatureToggleConfig.AlertConfig.AlertEnabled,
+		FeatureToggleConfig:  cfg.FeatureToggleConfig,
 		MonitoringConfig:     cfg.FeatureToggleConfig.MonitoringConfig,
 
 		StandardTransformerConfig: cfg.StandardTransformerConfig,

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -328,11 +328,8 @@ func buildDependencies(ctx context.Context, cfg *config.Config, db *gorm.DB, dis
 		TransformerService:        transformerService,
 		MlflowDeleteService:       mlflowDeleteService,
 
-		AuthorizationEnabled: cfg.AuthorizationConfig.AuthorizationEnabled,
-		AlertEnabled:         cfg.FeatureToggleConfig.AlertConfig.AlertEnabled,
-		FeatureToggleConfig:  cfg.FeatureToggleConfig,
-		MonitoringConfig:     cfg.FeatureToggleConfig.MonitoringConfig,
-
+		AuthorizationEnabled:      cfg.AuthorizationConfig.AuthorizationEnabled,
+		FeatureToggleConfig:       cfg.FeatureToggleConfig,
 		StandardTransformerConfig: cfg.StandardTransformerConfig,
 
 		FeastCoreClient: coreClient,

--- a/api/cmd/api/ui_handler.go
+++ b/api/cmd/api/ui_handler.go
@@ -20,6 +20,8 @@ type uiEnvHandler struct {
 	MonitoringPredictionJobBaseURL string `json:"REACT_APP_MONITORING_DASHBOARD_JOB_BASE_URL"`
 
 	AlertEnabled bool `json:"REACT_APP_ALERT_ENABLED"`
+
+	ModelDeletionEnabled bool `json:"REACT_APP_MODEL_DELETION_ENABLED"`
 }
 
 func (h uiEnvHandler) handler(w http.ResponseWriter, r *http.Request) {

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -247,8 +247,9 @@ type InMemoryCacheConfig struct {
 }
 
 type FeatureToggleConfig struct {
-	MonitoringConfig MonitoringConfig
-	AlertConfig      AlertConfig
+	MonitoringConfig    MonitoringConfig
+	AlertConfig         AlertConfig
+	ModelDeletionConfig ModelDeletionConfig
 }
 
 type MonitoringConfig struct {
@@ -261,6 +262,10 @@ type AlertConfig struct {
 	AlertEnabled bool `default:"false"`
 	GitlabConfig GitlabConfig
 	WardenConfig WardenConfig
+}
+
+type ModelDeletionConfig struct {
+	Enabled bool `default:"false"`
 }
 
 type GitlabConfig struct {

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
 import objectAssignDeep from "object-assign-deep";
+import React from "react";
 
 const getEnv = (env) => {
   return window.env && env in window.env ? window.env[env] : process.env[env];
@@ -76,6 +76,12 @@ export const featureToggleConfig = {
   monitoringDashboardJobBaseURL: getEnv(
     "REACT_APP_MONITORING_DASHBOARD_JOB_BASE_URL"
   ),
+  modelDeletionEnabled: getEnv("REACT_APP_MODEL_DELETION_ENABLED")
+    ? !(
+        getEnv("REACT_APP_MODEL_DELETION_ENABLED").toString().toLowerCase() ===
+        "false"
+      )
+    : false,
 };
 
 export const costEstimationConfig = {

--- a/ui/src/model/ModelListTable.js
+++ b/ui/src/model/ModelListTable.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
+import { DateFromNow, useToggle } from "@caraml-dev/ui-lib";
 import {
   EuiBadge,
   EuiButtonEmpty,
@@ -30,16 +29,20 @@ import {
   EuiLink,
   EuiLoadingChart,
   EuiProgress,
+  EuiSearchBar,
   EuiText,
   EuiTextAlign,
   EuiToolTip,
-  EuiSearchBar,
 } from "@elastic/eui";
-import { DateFromNow, useToggle } from "@caraml-dev/ui-lib";
-import ModelEndpointActions from "./ModelEndpointActions";
 import PropTypes from "prop-types";
-import { DeleteModelModal, DeleteModelPyFuncV2Modal } from "../components/modals";
-
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  DeleteModelModal,
+  DeleteModelPyFuncV2Modal,
+} from "../components/modals";
+import { featureToggleConfig } from "../config";
+import ModelEndpointActions from "./ModelEndpointActions";
 
 const moment = require("moment");
 
@@ -56,10 +59,10 @@ const ModelListTable = ({ items, isLoaded, error, fetchModels }) => {
     modelTypes: [],
     itemsToList: [],
   });
-  const [ isDeleteModelPyFuncV2ModalVisible, toggleDeleteModelPyFuncV2Modal ] = useToggle()
-  const [ isDeleteModelModalVisible, toggleDeleteModelModal ] = useToggle()
-  const [ modelForModal, setModelForModal ] = useState({});
-
+  const [isDeleteModelPyFuncV2ModalVisible, toggleDeleteModelPyFuncV2Modal] =
+    useToggle();
+  const [isDeleteModelModalVisible, toggleDeleteModelModal] = useToggle();
+  const [modelForModal, setModelForModal] = useState({});
 
   const isTerminatedEndpoint = (endpoint) => {
     return endpoint.status === "terminated";
@@ -244,13 +247,13 @@ const ModelListTable = ({ items, isLoaded, error, fetchModels }) => {
   };
 
   const handleDeleteModel = (model) => {
-    setModelForModal(model)
-    if (model.type === "pyfunc_v2"){
-      toggleDeleteModelPyFuncV2Modal()
+    setModelForModal(model);
+    if (model.type === "pyfunc_v2") {
+      toggleDeleteModelPyFuncV2Modal();
     } else {
-      toggleDeleteModelModal()
+      toggleDeleteModelModal();
     }
-  }
+  };
 
   const columns = [
     {
@@ -382,8 +385,8 @@ const ModelListTable = ({ items, isLoaded, error, fetchModels }) => {
         header: true,
         fullWidth: false,
       },
-      render: (_, model) =>
-        <EuiFlexGroup alignItems="flexEnd" direction="column" gutterSize="s"> 
+      render: (_, model) => (
+        <EuiFlexGroup alignItems="flexEnd" direction="column" gutterSize="s">
           {model.type === "pyfunc_v2" && (
             <EuiFlexItem grow={false}>
               <EuiToolTip position="top" content={<p>Batch Prediction Job</p>}>
@@ -398,12 +401,20 @@ const ModelListTable = ({ items, isLoaded, error, fetchModels }) => {
               </EuiToolTip>
             </EuiFlexItem>
           )}
-          <EuiFlexItem grow={false}>
-            <EuiButtonEmpty color={"danger"} iconType="trash" size="xs" onClick={() => handleDeleteModel(model)}>
-              <EuiText size="xs">Delete</EuiText>
-            </EuiButtonEmpty>
-          </EuiFlexItem>
+          {featureToggleConfig.modelDeletionEnabled && (
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color={"danger"}
+                iconType="trash"
+                size="xs"
+                onClick={() => handleDeleteModel(model)}
+              >
+                <EuiText size="xs">Delete</EuiText>
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
+      ),
     },
     {
       align: "right",
@@ -501,20 +512,20 @@ const ModelListTable = ({ items, isLoaded, error, fetchModels }) => {
     </EuiCallOut>
   ) : (
     <div>
-       {isDeleteModelPyFuncV2ModalVisible && (
-          <DeleteModelPyFuncV2Modal 
-            closeModal={() => toggleDeleteModelPyFuncV2Modal()}
-            model={modelForModal}
-            callback={fetchModels}
-          /> 
-       )}
-       {isDeleteModelModalVisible && (
+      {isDeleteModelPyFuncV2ModalVisible && (
+        <DeleteModelPyFuncV2Modal
+          closeModal={() => toggleDeleteModelPyFuncV2Modal()}
+          model={modelForModal}
+          callback={fetchModels}
+        />
+      )}
+      {isDeleteModelModalVisible && (
         <DeleteModelModal
           closeModal={() => toggleDeleteModelModal()}
           model={modelForModal}
           callback={fetchModels}
-         />
-       )}
+        />
+      )}
       <EuiInMemoryTable
         items={items}
         columns={columns}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

This PR adds feature toggle to enabling or disabling model deletion feature. Model deletion includes the deletion of its descendant resources such as model versions and batch prediction jobs. For model with many descendants (e.g., more than 500 versions), the deletion can take a long time to finish because the deletion is happening in synchronous.

This PR introduces ModelDeletionConfig in FeatureToggleConfig. This configuration used to enable/disable ModelDeletionAPI and also to show/hide Delete button on Model List page.

This PR also refactors AppContext to just use FeatureToggleConfig that has Alert, Monitoring, and Model Deletion configs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Updated unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
