### PR TITLE
Fix panic due to use incorrect value for error message

### DIFF
--- a/api/pkg/transformer/pipeline/table_transform_op.go
+++ b/api/pkg/transformer/pipeline/table_transform_op.go
@@ -229,7 +229,7 @@ func updateColumns(env *Environment, specs []*spec.UpdateColumn, resultTable *ta
 
 			columnValue, err := subsetSeriesFromExpression(env, condition.Expression, rowIndex)
 			if err != nil {
-				return nil, fmt.Errorf("error evaluation column rule value for column %s: %v. Err: Ts", columnName, condition.Default.Expression)
+				return nil, fmt.Errorf("error evaluation column rule value for column %s: %v. Err: %v", columnName, condition.Expression, err)
 			}
 
 			colRuleValue := table.RowValues{

--- a/api/pkg/transformer/pipeline/table_transform_op_test.go
+++ b/api/pkg/transformer/pipeline/table_transform_op_test.go
@@ -347,6 +347,35 @@ func TestTableTransformOp_Execute(t1 *testing.T) {
 			},
 		},
 		{
+			name: "failed: update columns; failed during expression eval",
+			tableTransformSpec: &spec.TableTransformation{
+				InputTable:  "existing_table",
+				OutputTable: "output_table",
+				Steps: []*spec.TransformationStep{
+					{
+						UpdateColumns: []*spec.UpdateColumn{
+							{
+								Column: "conditional_col",
+								Conditions: []*spec.ColumnCondition{
+									{
+										RowSelector: "existing_table.Col('int_col') % 2 == 0",
+										Expression:  "existing_table.Col('int_col')",
+									},
+									{
+										RowSelector: "existing_table.Col('int_col') % 2 == 1",
+										Expression:  "existing_table.Col('not_exist_col')",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			env:      env,
+			wantErr:  true,
+			expError: fmt.Errorf("error evaluation column rule value for column conditional_col: existing_table.Col('not_exist_col'). Err: compiled expression 'existing_table.Col('not_exist_col')' not found"),
+		},
+		{
 			name: "success: filter row",
 			tableTransformSpec: &spec.TableTransformation{
 				InputTable:  "existing_table",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
We faced panic issue when update column in ST that involve conditional , this is happened due to accessing nil pointer when construct error message. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
