### PR TITLE
fix: Parsing NewRelic API Key

### DIFF
--- a/api/cmd/inference-logger/main_test.go
+++ b/api/cmd/inference-logger/main_test.go
@@ -16,3 +16,44 @@ func TestGetModelVersion(t *testing.T) {
 func TestGetTopicName(t *testing.T) {
 	assert.Equal(t, "merlin-my-project-my-model-inference-log", getTopicName(getServiceName("my-project", "my-model")))
 }
+
+func Test_getNewRelicAPIKey(t *testing.T) {
+	type args struct {
+		newRelicUrl string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				newRelicUrl: "https://log-api.newrelic.com/log/v1?Api-Key=LICENSEKEY",
+			},
+			want:    "LICENSEKEY",
+			wantErr: false,
+		},
+		{
+			name: "not found",
+			args: args{
+				newRelicUrl: "https://log-api.newrelic.com/log/v1?foo=bar",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNewRelicAPIKey(tt.args.newRelicUrl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getNewRelicAPIKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getNewRelicAPIKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/api/pkg/inference-logger/logger/types.go
+++ b/api/pkg/inference-logger/logger/types.go
@@ -43,7 +43,7 @@ const (
 var LoggerSinkKinds = []LoggerSinkKind{Kafka, NewRelic, Console}
 
 func ParseSinkKindAndUrl(logUrl string) (LoggerSinkKind, string) {
-	var sinkKind LoggerSinkKind
+	sinkKind := Console
 	url := logUrl
 
 	for _, loggerSinkKind := range LoggerSinkKinds {

--- a/api/pkg/inference-logger/logger/types.go
+++ b/api/pkg/inference-logger/logger/types.go
@@ -1,6 +1,10 @@
 package logger
 
-import "github.com/golang/protobuf/ptypes/timestamp"
+import (
+	"strings"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
 
 type LogEntry struct {
 	RequestId      string
@@ -37,3 +41,17 @@ const (
 )
 
 var LoggerSinkKinds = []LoggerSinkKind{Kafka, NewRelic, Console}
+
+func ParseSinkKindAndUrl(logUrl string) (LoggerSinkKind, string) {
+	var sinkKind LoggerSinkKind
+	url := logUrl
+
+	for _, loggerSinkKind := range LoggerSinkKinds {
+		if strings.HasPrefix(logUrl, loggerSinkKind) {
+			sinkKind = loggerSinkKind
+			url = strings.TrimPrefix(logUrl, loggerSinkKind+":")
+		}
+	}
+
+	return sinkKind, url
+}

--- a/api/pkg/inference-logger/logger/types_test.go
+++ b/api/pkg/inference-logger/logger/types_test.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSinkKindAndUrl(t *testing.T) {
+	type args struct {
+		logUrl string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  LoggerSinkKind
+		want1 string
+	}{
+		{
+			"kafka",
+			args{
+				logUrl: "kafka:localhost:9092",
+			},
+			Kafka,
+			"localhost:9092",
+		},
+		{
+			"newrelic",
+			args{
+				logUrl: "newrelic:https://log-api.newrelic.com/log/v1?Api-Key=LICENSEKEY",
+			},
+			NewRelic,
+			"https://log-api.newrelic.com/log/v1?Api-Key=LICENSEKEY",
+		},
+		{
+			"console",
+			args{
+				logUrl: "console:localhost:8080",
+			},
+			Console,
+			"localhost:8080",
+		},
+		{
+			"invalid, fallback to console",
+			args{
+				logUrl: "invalid:localhost:8080",
+			},
+			Console,
+			"invalid:localhost:8080",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := ParseSinkKindAndUrl(tt.args.logUrl)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseSinkKindAndUrl() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ParseSinkKindAndUrl() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Inference Logger failed to get the correct NewRelic API Key value. For example, if we have this url: `https://log-api.newrelic.com/log/v1?Api-Key=LICENSEKEY`, the API Key supplied when sinking the log is actually `Api-Key=LICENSEKEY`, instead of just `LICENSEKEY`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes getting NewRelic API Key from the logUrl.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
