### PR TITLE
Use pytest_configure to set mock responses as global variable

### DIFF
--- a/python/sdk/test/client_test.py
+++ b/python/sdk/test/client_test.py
@@ -18,7 +18,6 @@ from sys import version_info
 from unittest import mock
 
 import pytest
-from urllib3_mock import Responses
 
 import client as cl
 from client import ApiClient, Configuration
@@ -28,7 +27,8 @@ from merlin.model import Model, ModelType, Project
 from merlin.util import guess_mlp_ui_url
 from merlin.version import VERSION
 
-responses = Responses("requests.packages.urllib3")
+# get global mock responses that configured in conftest
+responses = pytest.responses
 
 
 @pytest.fixture

--- a/python/sdk/test/merlin_test.py
+++ b/python/sdk/test/merlin_test.py
@@ -14,15 +14,15 @@
 
 import json
 
+import mlflow
 import pytest
-from urllib3_mock import Responses
 
 import client as cl
 import merlin
-import mlflow
 from merlin.model import ModelVersion
 
-responses = Responses("requests.packages.urllib3")
+# get global mock responses that configured in conftest
+responses = pytest.responses
 
 default_resource_request = cl.ResourceRequest(1, 1, "100m", "128Mi")
 env_1 = cl.Environment(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

In #404, we merge mock_oauth in client_test.py and merlin_test.py to one pytest fixture in conftest.py. However, there's an issue where the mock responses in conftest is not used by client_test or merlin_test because it was using different instance of Reponses object.

This PR introduce [pytest_configure()](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_configure) function where it sets mock responses as global variable that can be called by other files.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Updated unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
