### PR TITLE
Fix deleting transformer's pdb

### DIFF
--- a/api/cluster/controller_test.go
+++ b/api/cluster/controller_test.go
@@ -855,3 +855,193 @@ func Test_controller_ListPods(t *testing.T) {
 	assert.Equal(t, "test-model-1-predictor-default-a", podList.Items[0].ObjectMeta.Name)
 	assert.Equal(t, "test-model-1-predictor-default-b", podList.Items[1].ObjectMeta.Name)
 }
+
+func TestController_Delete(t *testing.T) {
+	isvcName := models.CreateInferenceServiceName("my-model", "1")
+	projectName := "my-project"
+	pdb := &policyv1.PodDisruptionBudget{}
+
+	tests := []struct {
+		name         string
+		modelService *models.Service
+		getResult    *inferenceServiceReactor
+		deleteResult *inferenceServiceReactor
+		deployConfig config.DeploymentConfig
+		wantError    bool
+	}{
+		{
+			name: "success: delete predictor",
+			modelService: &models.Service{
+				Name:      isvcName,
+				Namespace: projectName,
+			},
+			getResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deleteResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deployConfig: config.DeploymentConfig{},
+			wantError:    false,
+		},
+		{
+			name: "success: delete predictor and transformer",
+			modelService: &models.Service{
+				Name:      isvcName,
+				Namespace: projectName,
+				Transformer: &models.Transformer{
+					Enabled: true,
+				},
+			},
+			getResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deleteResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deployConfig: config.DeploymentConfig{},
+			wantError:    false,
+		},
+		{
+			name: "success: delete predictor and its pdb",
+			modelService: &models.Service{
+				Name:      isvcName,
+				Namespace: projectName,
+			},
+			getResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deleteResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deployConfig: config.DeploymentConfig{
+				PodDisruptionBudget: config.PodDisruptionBudgetConfig{
+					Enabled: true,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "success: delete predictor, transformer, and their pdb",
+			modelService: &models.Service{
+				Name:      isvcName,
+				Namespace: projectName,
+				Transformer: &models.Transformer{
+					Enabled: true,
+				},
+			},
+			getResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deleteResult: &inferenceServiceReactor{
+				&kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      isvcName,
+						Namespace: projectName,
+					},
+				},
+				nil,
+			},
+			deployConfig: config.DeploymentConfig{
+				PodDisruptionBudget: config.PodDisruptionBudgetConfig{
+					Enabled: true,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "skip: predictor not found",
+			modelService: &models.Service{
+				Name:      isvcName,
+				Namespace: projectName,
+			},
+			getResult: &inferenceServiceReactor{
+				nil,
+				kerrors.NewNotFound(schema.GroupResource{Group: kfservingGroup, Resource: inferenceServiceResource}, isvcName),
+			},
+			deleteResult: &inferenceServiceReactor{
+				nil,
+				nil,
+			},
+			deployConfig: config.DeploymentConfig{},
+			wantError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kfClient := fakekserve.NewSimpleClientset().ServingV1beta1().(*fakekservev1beta1.FakeServingV1beta1)
+			kfClient.PrependReactor(getMethod, inferenceServiceResource, func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tt.getResult.isvc, tt.getResult.err
+			})
+			kfClient.PrependReactor(deleteMethod, inferenceServiceResource, func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tt.deleteResult.isvc, tt.deleteResult.err
+			})
+
+			v1Client := fake.NewSimpleClientset().CoreV1()
+
+			policyV1Client := fake.NewSimpleClientset().PolicyV1().(*fakepolicyv1.FakePolicyV1)
+			policyV1Client.Fake.PrependReactor(deleteMethod, pdbResource, func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, pdb, nil
+			})
+
+			containerFetcher := NewContainerFetcher(v1Client, clusterMetadata)
+
+			templater := clusterresource.NewInferenceServiceTemplater(config.StandardTransformerConfig{})
+
+			ctl, _ := newController(kfClient, v1Client, nil, policyV1Client, tt.deployConfig, containerFetcher, templater)
+			mSvc, err := ctl.Delete(context.Background(), tt.modelService)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Nil(t, mSvc)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, mSvc)
+		})
+	}
+}

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -249,8 +249,9 @@ func (k *endpointService) UndeployEndpoint(ctx context.Context, environment *mod
 	}
 
 	modelService := &models.Service{
-		Name:      models.CreateInferenceServiceName(model.Name, version.ID.String()),
-		Namespace: model.Project.Name,
+		Name:        models.CreateInferenceServiceName(model.Name, version.ID.String()),
+		Namespace:   model.Project.Name,
+		Transformer: endpoint.Transformer,
 	}
 
 	_, err := ctl.Delete(ctx, modelService)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

controller.Delete uses models.Service to get inference service data to be deleted. However, for deleting transformer's pdb resource, we need models.Service.Transformer value which is missing.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes deleting transformer's pdb

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
