### PR TITLE
Set DB logger level to silent

### DIFF
--- a/api/database/database.go
+++ b/api/database/database.go
@@ -43,7 +43,7 @@ func InitDB(cfg *config.DatabaseConfig) (*gorm.DB, error) {
 	db, err := gorm.Open(
 		pg.Open(connectionString(cfg)),
 		&gorm.Config{
-			Logger: logger.Default.LogMode(logger.Info),
+			Logger: logger.Default.LogMode(logger.Silent),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

In #413, when updating gorm version, the database's default logger level was set to info which made merlin log to be quite noisy. This PR set the logger level to silent.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
