### PR TITLE
fix: Add precautionary logic for PDB

### DIFF
--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -232,7 +232,7 @@ func (c *controller) Deploy(ctx context.Context, modelService *models.Service) (
 	}
 
 	if c.deploymentConfig.PodDisruptionBudget.Enabled {
-		pdbs := c.createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
+		pdbs := createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
 		if err := c.deployPodDisruptionBudgets(ctx, pdbs); err != nil {
 			log.Errorf("unable to create pdb %v", err)
 			return nil, ErrUnableToCreatePDB
@@ -273,7 +273,7 @@ func (c *controller) Delete(ctx context.Context, modelService *models.Service) (
 	}
 
 	if c.deploymentConfig.PodDisruptionBudget.Enabled {
-		pdbs := c.createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
+		pdbs := createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
 		if err := c.deletePodDisruptionBudgets(ctx, pdbs); err != nil {
 			log.Errorf("unable to delete pdb %v", err)
 			return nil, ErrUnableToDeletePDB


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

PDB support was introduced in https://github.com/caraml-dev/merlin/pull/420. In some scenarios, the PDB can create problems. As an example, if PDB is configured to have a minimum of 20% replicas available and there is only one replica in the deployment, it's not possible to drain that node. To prevent such issues, this PR introduces some precautionary checks, - ensuring that at least 1 replica of the deployment can be removed:

```
Let
===
# replicas: r
minAvailablePercent / 100: p

We want
=======
r - ceil(r * p) >= 1 // ceil because k8s rounds up to the nearest int
=> ceil(r * p) + 1 <= r
=> ceil(r * p) < r // We can say this because all terms in the above inequality are int
```

It's enough to check `ceil(r * p) < r` where r is the minReplicas because:

```
r - ceil(r * p) >= 1
=> r * (1 - ceil(p)) >= 1

We can see that, as r increases, LHS will increase. So, it's enough to ensure this inequality holds for the smallest possible value of r, which is the minReplicas configured for the deployment.
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Disable PDB when the min replicas is very low, so that it doesn't block node drain.
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
