### PR TITLE
fix: Add missing delete batch job button

### DIFF
--- a/ui/src/job/JobListTable.js
+++ b/ui/src/job/JobListTable.js
@@ -94,10 +94,6 @@ const JobListTable = ({ projectId, modelId, jobs, isLoaded, error, fetchJobs }) 
     return ["pending", "running"].includes(status)
   }
 
-  const isTerminatedJob = function(status){
-    return ["terminating", "terminated"].includes(status)
-  }
-
   const columns = [
     {
       field: "name",
@@ -214,7 +210,7 @@ const JobListTable = ({ projectId, modelId, jobs, isLoaded, error, fetchJobs }) 
               </EuiButtonEmpty>
             </Link>
           </EuiFlexItem>
-          {!isTerminatedJob(item.status) && (<EuiFlexItem grow={false} key={`stop-job-${item.id}`}>
+          <EuiFlexItem grow={false} key={`stop-job-${item.id}`}>
             <EuiButtonEmpty
               onClick={() => {
                 setCurrentJob(item);
@@ -222,11 +218,11 @@ const JobListTable = ({ projectId, modelId, jobs, isLoaded, error, fetchJobs }) 
               }}
               color="danger"
               iconType={isActiveJob(item.status) ? "minusInCircle" : "trash"}
-              size="xs">
-              <EuiText size="xs">{isActiveJob(item.status) ? "Stop Job" : "Terminate Job"}</EuiText>
-
+              size="xs"
+              isDisabled={item.status === "terminating"}>
+              <EuiText size="xs">{isActiveJob(item.status) ? "Terminate" : "Delete"}</EuiText>
             </EuiButtonEmpty>
-          </EuiFlexItem>)}
+          </EuiFlexItem>
         </EuiFlexGroup>
       )
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes a change to the UI where the 'Terminate Job' button is not shown if a batch job is in the `terminating` or `terminated` stage. 

![image](https://github.com/caraml-dev/merlin/assets/36802364/b3296bf1-6fd0-4eae-9739-165e39c56937)

Previously the intention behind the decision to hide the button might've been because it was assumed that a job would have already been deleted (or in the process of being deleted) and thus there was no need for the button to be shown. However that may not necessarily be true; a job that is `terminating` would truly be deleted (as of the changes from #389) though a job that's already saved as `terminated` in the DB would not (theoretically, from #389 onwards, there can theoretically be no more **new** jobs that can be in the `terminated` state since they would've already been deleted from the DB). Thus we still need to expose this button for jobs in these two states. 

Additionally, the `isDisabled` prop has been used to disable the button if the job is already in the `terminating` state (since there's no point clicking on the same button multiple times), though this does not actually show up in practice since the API server doesn't actually return that [state](https://github.com/caraml-dev/merlin/blob/main/api/models/prediction_job.go#L91) i.e. upon clicking on the 'Delete' or 'Terminate' button, the job gets deleted by the API server from the DB automatically.

Last but not least, some of the button names have been standardised with those found in Turing - 'Terminate' appears when a job is running but 'Delete' appears when the job is no longer running (i.e. it has already completed or failed).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
