### PR TITLE
docs: Reword certain parts of the model/model version deletion docs 

### DIFF
--- a/docs/user-guide/model_deletion.md
+++ b/docs/user-guide/model_deletion.md
@@ -1,12 +1,12 @@
 # Model Deletion
 
-A Merlin model can be deleted only if it is not serving any endpoints, does not have any deployed model versions, or, if the model has the `pyfunc_v2` type, the model version must not have any active prediction jobs. Deleting a model will result in purging all the model versions associated with it, as well as related entities such as endpoints or prediction jobs (applicable for models with the `pyfunc_v2` type) from the Merlin database. This action is **irreversible**.
+A Merlin model can be deleted only if it is not serving any endpoints and does not have any deployed model versions or, if the model is of the `pyfunc_v2` type, none of its model versions must not have any active prediction jobs. Deleting a model will result in the purging of all the model versions associated with it, as well as related entities such as endpoints or prediction jobs (applicable for models of the `pyfunc_v2` type) from the Merlin database. This action is **irreversible**.
 
-A model with associated model versions that have active prediction jobs or endpoints cannot be deleted.
+A model with model versions that have any active prediction jobs or endpoints cannot be deleted.
 
 
-## Model Deletion Via SDK
-To delete a Model, you can call `delete_model()` function from Merlin Python SDK.
+## Model Deletion Via the SDK
+To delete a Model, you can call the `delete_model()` function from the Merlin Python SDK.
 
 ```python
 merlin.set_project("test-project")
@@ -18,11 +18,11 @@ model = merlin.active_model()
 model.delete_model()
 ```
 
-## Model Deletion via UI
-To delete a model from the UI, you can access the delete button directly on the model list page. The dialog will provide information about how many entities that are blocking the deletion process.
+## Model Deletion via the UI
+To delete a model from the UI, you can access the delete button directly on the model list page. The dialog will provide information about any entities that are blocking the deletion process.
 
-If the model does not have any entities, it will show this dialog
+- If the model does not have any associated entities, a dialog like the one below will be displayed:
 ![Model Version Deletion Without Entity](../images/delete_model_no_entity.png)
 
-If the model does have active entities, it will show this dialog
+- If the model has any associated active entities, a dialog like the one below will be displayed:
 ![Model Version Deletion Without Entity](../images/delete_model_active_entity.png)

--- a/docs/user-guide/model_version_deletion.md
+++ b/docs/user-guide/model_version_deletion.md
@@ -1,11 +1,14 @@
 # Model Version Deletion
 
-A Merlin model version can be deleted only if it is not serving any endpoints, does not have any deployed endpoints, or if the model has the `pyfunc_v2` type, the model version must not have any active prediction jobs. Deleting a model version will result in purging the model version and its related entities, such as endpoints or prediction jobs, from the Merlin database. This action is **irreversible**.
+A Merlin model version can be deleted only if it is not serving any endpoints and does not have any deployed 
+endpoints or, if the base model is of the `pyfunc_v2` type, the model version must not have any active prediction jobs. 
+Deleting a model version will result in the purging of the model version and its related entities, such as endpoints or 
+prediction jobs, from the Merlin database. This action is **irreversible**.
 
-Model version with related active prediction jobs or endpoints can not be deleted.
+Model versions with related active prediction jobs or endpoints can not be deleted.
 
-## Model Version Deletion Via SDK
-To delete a Model Version, you can call `delete_model_version()` function from Merlin Python SDK.
+## Model Version Deletion Via the SDK
+To delete a Model Version, you can call the `delete_model_version()` function from Merlin Python SDK.
 
 ```python
 merlin.set_project("test-project")
@@ -18,14 +21,14 @@ version.delete_model_version()
 ```
 
 
-## Model Version Deletion via UI
+## Model Version Deletion via the UI
 To delete a model version from the UI, you can access the delete button directly on the model version list page. The dialog will provide information about entities that are blocking the deletion process or will be deleted along with the model version.
 
-If the model version does not have any entities, it will show this dialog 
+- If the model version does not have any associated entities, a dialog like the one below will be displayed:
 ![Model Version Deletion Without Entity](../images/delete_model_version_no_entity.png)
 
-If the model version does have active entities, it will show this dialog (showing which entities block the deletion process)
+- If the model version has any associated active entities, a dialog like the one below (showing the entities blocking the deletion process) will be displayed:
 ![Model Version Deletion Without Entity](../images/delete_model_version_active_entity.png)
 
-If the model version does have inactive entities, it will show this dialog (showing which entities will get deleted along with the deletion process)
+- If the model version has any associated inactive entities, a dialog like the one below (showing which entities will get deleted along with the deletion process) will be displayed:
 ![Model Version Deletion Without Entity](../images/delete_model_version_inactive_entity.png)


### PR DESCRIPTION
**What this PR does / why we need it**:
This tiny-PR rewords certain parts of the model/model version deletion docs that were added in #402 to make them more consistent.

**Which issue(s) this PR fixes**:
NONE
Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [x] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
