### PR TITLE
Add FeastClientMaxConcurrentRequests to Transformer Simulator

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -323,6 +323,8 @@ type StandardTransformerConfig struct {
 	Jaeger             JaegerConfig          `validate:"required"`
 	SimulationFeast    SimulationFeastConfig `validate:"required"`
 	Kafka              KafkaConfig           `validate:"required"`
+	// Simulator configs
+	SimulatorFeastClientMaxConcurrentRequests int `validate:"required" default:"100"`
 }
 
 // KafkaConfig configuration for publishing prediction log

--- a/api/service/transformer_simulation_service.go
+++ b/api/service/transformer_simulation_service.go
@@ -69,10 +69,11 @@ func (ts *transformerService) createTransformerExecutor(ctx context.Context, sim
 		executor.WithTraceEnabled(true),
 		executor.WithModelPredictor(executor.NewMockModelPredictor(mockModelResponseBody, mockModelRequestHeaders, simulationPayload.Protocol)),
 		executor.WithFeastOptions(feast.Options{
-			StorageConfigs:     ts.cfg.ToFeastStorageConfigsForSimulation(),
-			DefaultFeastSource: ts.cfg.DefaultFeastSource,
-			BatchSize:          defaultFeastBatchSize,
-			FeastGRPCConnCount: ts.cfg.FeastGPRCConnCount,
+			StorageConfigs:                   ts.cfg.ToFeastStorageConfigsForSimulation(),
+			DefaultFeastSource:               ts.cfg.DefaultFeastSource,
+			BatchSize:                        defaultFeastBatchSize,
+			FeastGRPCConnCount:               ts.cfg.FeastGPRCConnCount,
+			FeastClientMaxConcurrentRequests: ts.cfg.SimulatorFeastClientMaxConcurrentRequests,
 		}),
 		executor.WithProtocol(simulationPayload.Protocol),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new field in the Merlin API server's config, `SimulatorFeastClientMaxConcurrentRequests`, which will be used to initialise a standard transformer executor whenever the transformer simulator is used. Previously, this value is not passed as options to the Feast transformer, causing the Hystrix max concurrent request value to default as `10`, which is much lower than the [default](https://github.com/caraml-dev/merlin/blob/main/api/pkg/transformer/feast/feature_retriever.go#L106) value which a regular standard transformer is initialised with, `100`.

By introducing this new field, all simulate requests will have the same max concurrent request limit set as 100 by default (unless specified otherwise by the Merlin API server's operator). 

**Which issue(s) this PR fixes**:
A bug whereby a user might not experience the same behaviour from a regular standard transformer and from the simulator, if the number of concurrent requests to Feast is different.

Fixes #

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
