### PR TITLE
fix: Updating association tables correctly

### DIFF
--- a/api/database/database.go
+++ b/api/database/database.go
@@ -22,7 +22,6 @@ import (
 	migrate "github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-
 	pg "gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -43,8 +42,7 @@ func InitDB(cfg *config.DatabaseConfig) (*gorm.DB, error) {
 	db, err := gorm.Open(
 		pg.Open(connectionString(cfg)),
 		&gorm.Config{
-			FullSaveAssociations: true,
-			Logger:               logger.Default.LogMode(logger.Silent),
+			Logger: logger.Default.LogMode(logger.Silent),
 		},
 	)
 	if err != nil {

--- a/api/database/database.go
+++ b/api/database/database.go
@@ -43,7 +43,8 @@ func InitDB(cfg *config.DatabaseConfig) (*gorm.DB, error) {
 	db, err := gorm.Open(
 		pg.Open(connectionString(cfg)),
 		&gorm.Config{
-			Logger: logger.Default.LogMode(logger.Silent),
+			FullSaveAssociations: true,
+			Logger:               logger.Default.LogMode(logger.Silent),
 		},
 	)
 	if err != nil {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -54,7 +54,12 @@ func (v *versionEndpointStorage) Get(uuid uuid.UUID) (*models.VersionEndpoint, e
 
 func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	sanitizeEndpoint(endpoint)
-	return v.db.Session(&gorm.Session{FullSaveAssociations: true}).Save(&endpoint).Error
+
+	if err := v.db.Save(&endpoint).Error; err != nil {
+		return err
+	}
+
+	return v.db.Save(endpoint.Transformer).Error
 }
 
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -59,7 +59,11 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 		return err
 	}
 
-	return v.db.Save(endpoint.Transformer).Error
+	if endpoint.Transformer != nil {
+		return v.db.Save(endpoint.Transformer).Error
+	}
+
+	return nil
 }
 
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -54,7 +54,7 @@ func (v *versionEndpointStorage) Get(uuid uuid.UUID) (*models.VersionEndpoint, e
 
 func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	sanitizeEndpoint(endpoint)
-	return v.db.Save(&endpoint).Error
+	return v.db.Session(&gorm.Session{FullSaveAssociations: true}).Save(&endpoint).Error
 }
 
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -33,4 +33,4 @@ kubectl create namespace ${E2E_PROJECT_NAME} --dry-run=client -o yaml | kubectl 
 cd ../../python/sdk
 pip install pipenv==2022.8.19
 pipenv install --dev --skip-lock --python ${PYTHON_VERSION}
-pipenv run pytest -n=6 -W=ignore --cov=merlin -m "not (feast or batch or pyfunc or local_server_test or cli or customtransformer)"
+pipenv run pytest -n=8 -W=ignore --cov=merlin -m "not (feast or batch or pyfunc or local_server_test or cli or customtransformer)"

--- a/scripts/e2e/values-e2e.yaml
+++ b/scripts/e2e/values-e2e.yaml
@@ -67,7 +67,7 @@ environmentConfigs:
     cluster: merlin-cluster
     region: id
     gcp_project: gcp-project
-    deployment_timeout: 10m
+    deployment_timeout: 15m
     namespace_timeout: 2m
     max_cpu: 250m
     max_memory: 256Mi
@@ -83,12 +83,12 @@ environmentConfigs:
     default_deployment_config:
       min_replica: 0
       max_replica: 1
-      cpu_request: "25m"
+      cpu_request: "32m"
       memory_request: "128Mi"
     default_transformer_config:
       min_replica: 0
       max_replica: 1
-      cpu_request: "25m"
+      cpu_request: "32m"
       memory_request: "64Mi"
 ingress:
   enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

GORM V2 switched to using upsert to save associations, so saving changed fields won't works in V2. (to avoid save uncompleted associations to protect your data) [[ref](https://github.com/go-gorm/gorm/issues/3487#issuecomment-694889052)].

However, this breaks Merlin's behavior.

For example, when redeploying a model version with a standard transformer, the redeployment will not update the transformer configuration. The resulting SQL is:

```
INSERT INTO "transformers" (...) VALUES (...)
ON CONFLICT ("id")
DO UPDATE SET 
  "version_endpoint_id"="excluded"."version_endpoint_id"
RETURNING "id"
```

The ON CONFLICT DO UPDATE SET clause is ignoring other transformer fields.

This PR adds gorm session with FullSaveAssociations: true to gorm query so we will have the same behavior as gorm.v1 when updating associations table. [[ref](https://github.com/go-gorm/gorm/issues/3487#issuecomment-698303344)]. The resulting SQL is now:

```
INSERT INTO "transformers" (...) VALUES (...)
ON CONFLICT ("id")
DO UPDATE SET
  "updated_at"='2023-08-04 18:35:10.261',
  "enabled"="excluded"."enabled",
  "version_endpoint_id"="excluded"."version_endpoint_id",
  "transformer_type"="excluded"."transformer_type",
  "image"="excluded"."image",
  "command"="excluded"."command",
  "args"="excluded"."args",
  "resource_request"="excluded"."resource_request",
  "env_vars"="excluded"."env_vars"
RETURNING "id"
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes updating association tables

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
