### PR TITLE
fix: order the output rows based on the order of the input entities

### DIFF
--- a/api/pkg/transformer/feast/call_test.go
+++ b/api/pkg/transformer/feast/call_test.go
@@ -223,6 +223,7 @@ func TestCall_do(t *testing.T) {
 						types.ValueType_INT64,
 						types.ValueType_INT64,
 					},
+					indexRows: []int{0, 1},
 					valueRows: transTypes.ValueRows{
 						transTypes.ValueRow{
 							"1001", "1002", int64(1111), int64(2222), int64(3333), int64(4444),
@@ -354,6 +355,7 @@ func TestCall_do(t *testing.T) {
 						types.ValueType_INT64,
 						types.ValueType_INT64,
 					},
+					indexRows: []int{0, 1},
 					valueRows: transTypes.ValueRows{
 						transTypes.ValueRow{
 							"1001", "1002", nil, nil, nil, nil,
@@ -485,6 +487,7 @@ func TestCall_do(t *testing.T) {
 						types.ValueType_INT64,
 						types.ValueType_INT64,
 					},
+					indexRows: []int{0, 1},
 					valueRows: transTypes.ValueRows{
 						transTypes.ValueRow{
 							"1001", "1002", int64(1), int64(2), int64(3), int64(4),
@@ -517,7 +520,11 @@ func TestCall_do(t *testing.T) {
 					return req.Project == tt.mockFeastCall.request.Project
 				})).Return(tt.mockFeastCall.response, nil)
 
-			got := fc.do(tt.args.ctx, tt.args.entityList, tt.args.features)
+			orderedEntityList := make([]orderedFeastRow, len(tt.args.entityList))
+			for i, entity := range tt.args.entityList {
+				orderedEntityList[i] = orderedFeastRow{Index: i, Row: entity}
+			}
+			got := fc.do(tt.args.ctx, orderedEntityList, tt.args.features)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/api/pkg/transformer/feast/feature_cache_test.go
+++ b/api/pkg/transformer/feast/feature_cache_test.go
@@ -27,7 +27,7 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 		args           args
 		valueInCache   *internalFeatureTable
 		want           *internalFeatureTable
-		missedEntities []feast.Row
+		missedEntities []orderedFeastRow
 	}{
 		{
 			name: "single entity, no value in cache",
@@ -51,9 +51,10 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_INVALID, feastTypes.ValueType_INVALID},
 				valueRows:   nil,
 			},
-			missedEntities: []feast.Row{
+			missedEntities: []orderedFeastRow{
 				{
-					"driver_id": feast.StrVal("1001"),
+					Index: 0,
+					Row:   feast.Row{"driver_id": feast.StrVal("1001")},
 				},
 			},
 		},
@@ -82,12 +83,14 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_INVALID, feastTypes.ValueType_INVALID},
 				valueRows:   nil,
 			},
-			missedEntities: []feast.Row{
+			missedEntities: []orderedFeastRow{
 				{
-					"driver_id": feast.StrVal("1001"),
+					Index: 0,
+					Row:   feast.Row{"driver_id": feast.StrVal("1001")},
 				},
 				{
-					"driver_id": feast.StrVal("1002"),
+					Index: 1,
+					Row:   feast.Row{"driver_id": feast.StrVal("1002")},
 				},
 			},
 		},
@@ -117,6 +120,7 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				},
 				columnNames: []string{"feature1", "feature2"},
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_STRING},
+				indexRows:   []int{0},
 				valueRows: types.ValueRows{
 					types.ValueRow{
 						"val1",
@@ -132,6 +136,7 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				},
 				columnNames: []string{"feature1", "feature2"},
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_STRING},
+				indexRows:   []int{0},
 				valueRows: types.ValueRows{
 					types.ValueRow{
 						"val1",
@@ -139,9 +144,10 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 					},
 				},
 			},
-			missedEntities: []feast.Row{
+			missedEntities: []orderedFeastRow{
 				{
-					"driver_id": feast.StrVal("1002"),
+					Index: 1,
+					Row:   feast.Row{"driver_id": feast.StrVal("1002")},
 				},
 			},
 		},
@@ -196,6 +202,7 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				},
 				columnNames: []string{"feature1", "feature2"},
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_STRING},
+				indexRows:   []int{0, 1},
 				valueRows: types.ValueRows{
 					types.ValueRow{
 						"val11",
@@ -249,9 +256,10 @@ func TestFeatureCache_FetchFeatureTable(t *testing.T) {
 				columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_INVALID, feastTypes.ValueType_INVALID},
 				valueRows:   nil,
 			},
-			missedEntities: []feast.Row{
+			missedEntities: []orderedFeastRow{
 				{
-					"driver_id": feast.StrVal("1001"),
+					Index: 0,
+					Row:   feast.Row{"driver_id": feast.StrVal("1001")},
 				},
 			},
 		},
@@ -304,6 +312,7 @@ func TestFeatureCache_InsertFeatureTable(t *testing.T) {
 					},
 					columnNames: []string{"feature3", "feature4"},
 					columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_STRING},
+					indexRows:   []int{0},
 					valueRows: types.ValueRows{
 						types.ValueRow{
 							"val11",

--- a/api/pkg/transformer/feast/feature_retriever.go
+++ b/api/pkg/transformer/feast/feature_retriever.go
@@ -243,9 +243,15 @@ func (fr *FeastRetriever) getFeatureTable(ctx context.Context, entities []feast.
 	entitySet := getEntitySet(columns, featureTableSpec.Entities)
 
 	var featureTable *internalFeatureTable
-	entityNotInCache := entities
+	var entityNotInCache []orderedFeastRow
 	if fr.options.CacheEnabled {
 		featureTable, entityNotInCache = fr.featureCache.fetchFeatureTable(entities, columns, featureTableSpec.Project)
+	} else {
+		entityNotInCache = make([]orderedFeastRow, len(entities))
+		for i, entity := range entities {
+			entityNotInCache[i] = orderedFeastRow{Index: i, Row: entity}
+		}
+
 	}
 
 	numOfBatchBeforeCeil := float64(len(entityNotInCache)) / float64(fr.options.BatchSize)

--- a/api/pkg/transformer/feast/feature_retriever_test.go
+++ b/api/pkg/transformer/feast/feature_retriever_test.go
@@ -148,6 +148,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 						},
@@ -238,6 +239,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_INT32, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{int32(1001), 1.1},
 						},
@@ -343,6 +345,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0, 1},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 							transTypes.ValueRow{"2002", 2.2},
@@ -446,6 +449,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0, 1},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 							transTypes.ValueRow{"2002", nil},
@@ -551,6 +555,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0, 1},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 							transTypes.ValueRow{"2002", 0.5},
@@ -699,6 +704,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 						},
@@ -714,6 +720,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"customer_id", "customer_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"2002", 2.2},
 						},
@@ -877,6 +884,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"jsonextract", "geohash_statistics:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"9001", 3.2},
 						},
@@ -967,6 +975,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"s2id", "geohash_statistics:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1154732743855177728", 3.2},
 						},
@@ -1058,6 +1067,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"s2id", "geohash_statistics:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1154732743855177728", 3.2},
 						},
@@ -1163,6 +1173,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "driver_trips:average_daily_rides"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE},
+						indexRows:   []int{0, 1},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", 1.1},
 							transTypes.ValueRow{"2002", 2.2},
@@ -1260,6 +1271,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "double_list_feature"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE_LIST},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", []float64{111.1111, 222.2222}},
 						},
@@ -1409,6 +1421,7 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest(t *testing.T) {
 						},
 						columnNames: []string{"driver_id", "double_list_feature"},
 						columnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_DOUBLE_LIST},
+						indexRows:   []int{0},
 						valueRows: transTypes.ValueRows{
 							transTypes.ValueRow{"1001", []float64{111.1111, 222.2222}},
 						},
@@ -1852,6 +1865,158 @@ func TestFeatureRetriever_RetrieveFeatureOfEntityInRequest_Batching(t *testing.T
 		}
 		mockFeastClient.AssertExpectations(t)
 	}
+}
+
+func TestFeatureRetriever_RetrieveFeatureOfEntityFromCache(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	mockFeastClient := &mocks.Client{}
+	feastClients := Clients{
+		spec.ServingSource_REDIS: mockFeastClient,
+	}
+	featureTableSpecs := []*spec.FeatureTable{
+		{
+			TableName: "my-table",
+			Project:   "default",
+			Source:    spec.ServingSource_REDIS,
+			Entities: []*spec.Entity{
+				{
+					Name:      "merchant_id",
+					ValueType: "STRING",
+					Extractor: &spec.Entity_JsonPath{
+						JsonPath: "$.merchants[*]",
+					},
+				},
+			},
+			Features: []*spec.Feature{
+				{
+					Name:         "restaurant_features:sales_volume",
+					DefaultValue: "1",
+					ValueType:    "INT32",
+				},
+			},
+		},
+	}
+	compiledJSONPaths, err := CompileJSONPaths(featureTableSpecs, jsonpath.Map)
+	if err != nil {
+		panic(err)
+	}
+
+	compiledExpressions, err := CompileExpressions(featureTableSpecs, symbol.NewRegistry())
+	if err != nil {
+		panic(err)
+	}
+
+	jsonPathStorage := jsonpath.NewStorage()
+	jsonPathStorage.AddAll(compiledJSONPaths)
+	expressionStorage := expression.NewStorage()
+	expressionStorage.AddAll(compiledExpressions)
+	entityExtractor := NewEntityExtractor(jsonPathStorage, expressionStorage)
+	options := &Options{
+		FeastClientHystrixCommandName: "TestFeatureRetriever_RetrieveFeatureOfEntityFromCache",
+		FeastTimeout:                  1 * time.Second,
+		BatchSize:                     100,
+		CacheEnabled:                  true,
+		CacheSizeInMB:                 100,
+		CacheTTL:                      10 * time.Minute,
+	}
+	fr := NewFeastRetriever(feastClients, entityExtractor, featureTableSpecs, options, logger)
+	mockFeastClient.On("GetOnlineFeatures", mock.Anything, mock.MatchedBy(func(req *feast.OnlineFeaturesRequest) bool {
+		if len(req.Entities) != 2 {
+			return false
+		}
+		for i, merchantId := range []string{"0", "3"} {
+			if req.Entities[i]["merchant_id"].GetStringVal() != merchantId {
+				return false
+			}
+		}
+		return true
+	})).Return(&feast.OnlineFeaturesResponse{
+		RawResponse: &serving.GetOnlineFeaturesResponseV2{
+			Metadata: &serving.GetOnlineFeaturesResponseMetadata{
+				FieldNames: &serving.FieldList{Val: []string{"merchant_id", "restaurant_features:sales_volume"}},
+			},
+			Results: []*serving.GetOnlineFeaturesResponseV2_FieldVector{
+				{
+					Values: []*feastTypes.Value{
+						feast.StrVal("0"),
+						feast.Int32Val(100),
+					},
+					Statuses: []serving.FieldStatus{
+						serving.FieldStatus_PRESENT,
+						serving.FieldStatus_PRESENT,
+					},
+				},
+				{
+					Values: []*feastTypes.Value{
+						feast.StrVal("3"),
+						feast.Int32Val(200),
+					},
+					Statuses: []serving.FieldStatus{
+						serving.FieldStatus_PRESENT,
+						serving.FieldStatus_PRESENT,
+					},
+				},
+			},
+		},
+	}, nil)
+	mockFeastClient.On("GetOnlineFeatures", mock.Anything, mock.MatchedBy(func(req *feast.OnlineFeaturesRequest) bool {
+		if len(req.Entities) != 2 {
+			return false
+		}
+		for i, merchantId := range []string{"1", "2"} {
+			if req.Entities[i]["merchant_id"].GetStringVal() != merchantId {
+				return false
+			}
+		}
+		return true
+	})).Return(&feast.OnlineFeaturesResponse{
+		RawResponse: &serving.GetOnlineFeaturesResponseV2{
+			Metadata: &serving.GetOnlineFeaturesResponseMetadata{
+				FieldNames: &serving.FieldList{Val: []string{"merchant_id", "restaurant_features:sales_volume"}},
+			},
+			Results: []*serving.GetOnlineFeaturesResponseV2_FieldVector{
+				{
+					Values: []*feastTypes.Value{
+						feast.StrVal("1"),
+						feast.Int32Val(200),
+					},
+					Statuses: []serving.FieldStatus{
+						serving.FieldStatus_PRESENT,
+						serving.FieldStatus_PRESENT,
+					},
+				},
+				{
+					Values: []*feastTypes.Value{
+						feast.StrVal("2"),
+						feast.Int32Val(300),
+					},
+					Statuses: []serving.FieldStatus{
+						serving.FieldStatus_PRESENT,
+						serving.FieldStatus_PRESENT,
+					},
+				},
+			},
+		},
+	}, nil)
+
+	var requestJsonUncached transTypes.JSONObject
+	requestUncached := []byte(`{"merchants": ["0", "3"]}`)
+	_ = json.Unmarshal(requestUncached, &requestJsonUncached)
+	_, err = fr.RetrieveFeatureOfEntityInRequest(context.Background(), requestJsonUncached)
+	assert.NoError(t, err)
+	var requestJsonPartialCached transTypes.JSONObject
+	requestPartialCached := []byte(`{"merchants": ["0", "1", "2", "3"]}`)
+	_ = json.Unmarshal(requestPartialCached, &requestJsonPartialCached)
+	tablePartialCache, err := fr.RetrieveFeatureOfEntityInRequest(context.Background(), requestJsonPartialCached)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(tablePartialCache))
+	expectedFeatureTable := transTypes.FeatureTable{
+		Name:        "my-table",
+		Columns:     []string{"merchant_id", "restaurant_features:sales_volume"},
+		ColumnTypes: []feastTypes.ValueType_Enum{feastTypes.ValueType_STRING, feastTypes.ValueType_INT32},
+		Data:        []transTypes.ValueRow{{"0", int32(100)}, {"1", int32(200)}, {"2", int32(300)}, {"3", int32(200)}},
+	}
+	assert.Equal(t, expectedFeatureTable, *tablePartialCache[0])
 }
 
 func TestFeatureRetriever_buildEntitiesRows(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the rows for the Feast Table are not guaranteed to be ordered based on the original order of the entities, which is a counter intuitive behaviour, consider that the official feast serving client returns the result based on the original entities order. It also affect usability as users need to perform extra work to reorder the table based on the original entity rows.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
```release-note
Feast Table output rows are now guaranteed to follow the order of entity rows.
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [x] Updated documentation
- [x] Update Swagger spec if the PR introduce API changes
- [x] Regenerated Golang and Python client if the PR introduce API changes
