### PR TITLE
fix: PDB not deleted and multiple PDBs targeting single deployment

### DIFF
--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -25,7 +25,7 @@ type PodDisruptionBudget struct {
 
 func NewPodDisruptionBudget(modelService *models.Service, componentType string, pdbConfig config.PodDisruptionBudgetConfig) *PodDisruptionBudget {
 	return &PodDisruptionBudget{
-		Name:                     fmt.Sprintf("%s-%s-%s", modelService.Name, componentType, models.PDBComponentType),
+		Name:                     fmt.Sprintf("%s-%s-%s", modelService.ModelName, componentType, models.PDBComponentType),
 		Namespace:                modelService.Namespace,
 		Labels:                   modelService.Metadata.ToLabel(),
 		MaxUnavailablePercentage: pdbConfig.MaxUnavailablePercentage,

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -24,10 +24,14 @@ type PodDisruptionBudget struct {
 }
 
 func NewPodDisruptionBudget(modelService *models.Service, componentType string, pdbConfig config.PodDisruptionBudgetConfig) *PodDisruptionBudget {
+	labels := modelService.Metadata.ToLabel()
+	labels["component"] = componentType
+	labels["serving.kserve.io/inferenceservice"] = modelService.Name
+
 	return &PodDisruptionBudget{
-		Name:                     fmt.Sprintf("%s-%s-%s", modelService.ModelName, componentType, models.PDBComponentType),
+		Name:                     fmt.Sprintf("%s-%s-%s", modelService.Name, componentType, models.PDBComponentType),
 		Namespace:                modelService.Namespace,
-		Labels:                   modelService.Metadata.ToLabel(),
+		Labels:                   labels,
 		MaxUnavailablePercentage: pdbConfig.MaxUnavailablePercentage,
 		MinAvailablePercentage:   pdbConfig.MinAvailablePercentage,
 	}
@@ -78,7 +82,7 @@ func createPodDisruptionBudgets(modelService *models.Service, pdbConfig config.P
 	if modelService.ResourceRequest != nil &&
 		math.Ceil(float64(modelService.ResourceRequest.MinReplica)*
 			minAvailablePercent) < float64(modelService.ResourceRequest.MinReplica) {
-		predictorPdb := NewPodDisruptionBudget(modelService, models.ModelComponentType, pdbConfig)
+		predictorPdb := NewPodDisruptionBudget(modelService, models.PredictorComponentType, pdbConfig)
 		pdbs = append(pdbs, predictorPdb)
 	}
 

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -107,7 +107,6 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 	models.InitKubernetesLabeller("gojek.com/", "dev")
 
 	twenty, eighty := 20, 80
-	_ = eighty
 
 	defaultMetadata := models.Metadata{
 		App:       "mymodel",

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -104,7 +104,8 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 }
 
 func TestCreatePodDisruptionBudgets(t *testing.T) {
-	models.InitKubernetesLabeller("gojek.com/", "dev")
+	err := models.InitKubernetesLabeller("gojek.com/", "dev")
+	assert.Nil(t, err)
 
 	twenty, eighty := 20, 80
 

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -104,14 +104,16 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 }
 
 func TestCreatePodDisruptionBudgets(t *testing.T) {
+	models.InitKubernetesLabeller("gojek.com/", "dev")
+
 	twenty, eighty := 20, 80
-	defaultLabels := map[string]string{
-		"app":          "",
-		"component":    "",
-		"environment":  "",
-		"orchestrator": "merlin",
-		"stream":       "",
-		"team":         "",
+	_ = eighty
+
+	defaultMetadata := models.Metadata{
+		App:       "mymodel",
+		Component: models.ComponentModelVersion,
+		Stream:    "mystream",
+		Team:      "myteam",
 	}
 
 	tests := map[string]struct {
@@ -132,10 +134,10 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 		},
 		"model min replica low | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:         "test-1",
-				ModelName:    "test",
+				Name:         "mymodel-1",
+				ModelName:    "mymodel",
 				ModelVersion: "1",
-				Namespace:    "test-ns",
+				Namespace:    "mynamespace",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 1,
 				},
@@ -145,6 +147,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						MinReplica: 3,
 					},
 				},
+				Metadata: defaultMetadata,
 			},
 			pdbConfig: config.PodDisruptionBudgetConfig{
 				Enabled:                true,
@@ -152,19 +155,28 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 			},
 			expected: []*PodDisruptionBudget{
 				{
-					Name:                   "test-transformer-pdb",
-					Namespace:              "test-ns",
-					Labels:                 defaultLabels,
+					Name:      "mymodel-1-transformer-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "transformer",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MinAvailablePercentage: &twenty,
 				},
 			},
 		},
 		"transformer min replica low | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:         "test-1",
-				ModelName:    "test",
+				Name:         "mymodel-1",
+				ModelName:    "mymodel",
 				ModelVersion: "1",
-				Namespace:    "test-ns",
+				Namespace:    "mynamespace",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 3,
 				},
@@ -174,6 +186,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						MinReplica: 1,
 					},
 				},
+				Metadata: defaultMetadata,
 			},
 			pdbConfig: config.PodDisruptionBudgetConfig{
 				Enabled:                true,
@@ -181,19 +194,28 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 			},
 			expected: []*PodDisruptionBudget{
 				{
-					Name:                   "test-model-pdb",
-					Namespace:              "test-ns",
-					Labels:                 defaultLabels,
+					Name:      "mymodel-1-predictor-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "predictor",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MinAvailablePercentage: &twenty,
 				},
 			},
 		},
 		"all pdbs | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:         "test-1",
-				ModelName:    "test",
+				Name:         "mymodel-1",
+				ModelName:    "mymodel",
 				ModelVersion: "1",
-				Namespace:    "test-ns",
+				Namespace:    "mynamespace",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 5,
 				},
@@ -203,6 +225,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						MinReplica: 3,
 					},
 				},
+				Metadata: defaultMetadata,
 			},
 			pdbConfig: config.PodDisruptionBudgetConfig{
 				Enabled:                true,
@@ -210,25 +233,43 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 			},
 			expected: []*PodDisruptionBudget{
 				{
-					Name:                   "test-model-pdb",
-					Namespace:              "test-ns",
-					Labels:                 defaultLabels,
+					Name:      "mymodel-1-predictor-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "predictor",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MinAvailablePercentage: &twenty,
 				},
 				{
-					Name:                   "test-transformer-pdb",
-					Namespace:              "test-ns",
-					Labels:                 defaultLabels,
+					Name:      "mymodel-1-transformer-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "transformer",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MinAvailablePercentage: &twenty,
 				},
 			},
 		},
 		"all pdbs | maxUnavailablePercentage": {
 			modelService: &models.Service{
-				Name:         "test-1",
-				ModelName:    "test",
+				Name:         "mymodel-1",
+				ModelName:    "mymodel",
 				ModelVersion: "1",
-				Namespace:    "test-ns",
+				Namespace:    "mynamespace",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 5,
 				},
@@ -238,6 +279,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 						MinReplica: 3,
 					},
 				},
+				Metadata: defaultMetadata,
 			},
 			pdbConfig: config.PodDisruptionBudgetConfig{
 				Enabled:                  true,
@@ -245,15 +287,33 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 			},
 			expected: []*PodDisruptionBudget{
 				{
-					Name:                     "test-model-pdb",
-					Namespace:                "test-ns",
-					Labels:                   defaultLabels,
+					Name:      "mymodel-1-predictor-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "predictor",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MaxUnavailablePercentage: &eighty,
 				},
 				{
-					Name:                     "test-transformer-pdb",
-					Namespace:                "test-ns",
-					Labels:                   defaultLabels,
+					Name:      "mymodel-1-transformer-pdb",
+					Namespace: "mynamespace",
+					Labels: map[string]string{
+						"gojek.com/app":                      "mymodel",
+						"gojek.com/component":                "model-version",
+						"gojek.com/environment":              "dev",
+						"gojek.com/orchestrator":             "merlin",
+						"gojek.com/stream":                   "mystream",
+						"gojek.com/team":                     "myteam",
+						"component":                          "transformer",
+						"serving.kserve.io/inferenceservice": "mymodel-1",
+					},
 					MaxUnavailablePercentage: &eighty,
 				},
 			},

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -132,8 +132,10 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 		},
 		"model min replica low | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:      "test",
-				Namespace: "test-ns",
+				Name:         "test-1",
+				ModelName:    "test",
+				ModelVersion: "1",
+				Namespace:    "test-ns",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 1,
 				},
@@ -159,8 +161,10 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 		},
 		"transformer min replica low | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:      "test",
-				Namespace: "test-ns",
+				Name:         "test-1",
+				ModelName:    "test",
+				ModelVersion: "1",
+				Namespace:    "test-ns",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 3,
 				},
@@ -186,8 +190,10 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 		},
 		"all pdbs | minAvailablePercentage": {
 			modelService: &models.Service{
-				Name:      "test",
-				Namespace: "test-ns",
+				Name:         "test-1",
+				ModelName:    "test",
+				ModelVersion: "1",
+				Namespace:    "test-ns",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 5,
 				},
@@ -219,8 +225,10 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 		},
 		"all pdbs | maxUnavailablePercentage": {
 			modelService: &models.Service{
-				Name:      "test",
-				Namespace: "test-ns",
+				Name:         "test-1",
+				ModelName:    "test",
+				ModelVersion: "1",
+				Namespace:    "test-ns",
 				ResourceRequest: &models.ResourceRequest{
 					MinReplica: 5,
 				},

--- a/api/models/container.go
+++ b/api/models/container.go
@@ -27,6 +27,7 @@ const (
 
 	ImageBuilderComponentType     = "image_builder"
 	ModelComponentType            = "model"
+	PredictorComponentType        = "predictor"
 	TransformerComponentType      = "transformer"
 	PDBComponentType              = "pdb" // Pod disruption budget
 	BatchJobDriverComponentType   = "batch_job_driver"

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -249,9 +249,10 @@ func (k *endpointService) UndeployEndpoint(ctx context.Context, environment *mod
 	}
 
 	modelService := &models.Service{
-		Name:        models.CreateInferenceServiceName(model.Name, version.ID.String()),
-		Namespace:   model.Project.Name,
-		Transformer: endpoint.Transformer,
+		Name:            models.CreateInferenceServiceName(model.Name, version.ID.String()),
+		Namespace:       model.Project.Name,
+		ResourceRequest: endpoint.ResourceRequest,
+		Transformer:     endpoint.Transformer,
 	}
 
 	_, err := ctl.Delete(ctx, modelService)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

This PR fixes two issues:

1. Fail to delete predictor PDB because the resource request is not passed to createPodDisruptionBudgets() function hence, the pdb for the predictor is not appended to pdbs to be deleted because it's not meet this [condition](https://github.com/caraml-dev/merlin/blob/main/api/cluster/pdb.go#L78):
```
if modelService.ResourceRequest != nil &&
```

2. Because the PDB is not deleted, there would be multiple PDBs in the cluster and all of them would be targeting the same active deployments because of incorrect Selector spec.

For example, we have deployed sklearn-sample-r version 54 and 55. Then we undeploy version 54. The remaining pods are only for version 55:

```
$ kubectl get po
NAME                                                              READY   STATUS    RESTARTS   AGE
sklearn-sample-r-55-predictor-default-779754655d-cgvqj            1/1     Running   0          42m
sklearn-sample-r-55-predictor-default-779754655d-dw6hc            1/1     Running   0          42m
```

 However, the PDB for version 54 still exists:

```
$ kubectl get pdb
NAME                             MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
sklearn-sample-r-54-model-pdb    20%             N/A               2                     44m
sklearn-sample-r-55-model-pdb    20%             N/A               3                     44m
```

And both of them have the same selector:

```
  spec:
    minAvailable: 20%
    selector:
      matchLabels:
        gojek.com/app: sklearn-sample-s
        gojek.com/component: model-version
        gojek.com/environment: staging
        gojek.com/orchestrator: merlin
        gojek.com/stream: dsp
        gojek.com/team: dsp
```

This PR adds more labels for the selector.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes fail to delete predictor PDB
Fixes multiple PDBs targeting single deployment

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
