### PR TITLE
fix: fail redeployment delete existing resource

### DIFF
--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -241,11 +241,6 @@ func (c *controller) Deploy(ctx context.Context, modelService *models.Service) (
 
 	s, err = c.waitInferenceServiceReady(s)
 	if err != nil {
-		// remove created inferenceservice when got error
-		if err := c.deleteInferenceService(isvcName, modelService.Namespace); err != nil {
-			log.Warnf("unable to delete inference service %s with error %v", isvcName, err)
-		}
-
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

When updating the inference service, Merlin should not delete the existing resource.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes fail redeployment delete existing resource

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [X] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
