### PR TITLE
fix: Use the correct endpoint for standard transformer simulator permission check

### DIFF
--- a/api/middleware/authorization.go
+++ b/api/middleware/authorization.go
@@ -51,7 +51,7 @@ type Operation struct {
 var publicOperations = []Operation{
 	{"/projects", []string{http.MethodGet}},
 	{"/environments", []string{http.MethodGet}},
-	{"/standard-transformer/simulate", []string{http.MethodPost}},
+	{"/standard_transformer/simulate", []string{http.MethodPost}},
 	{"/alerts/teams", []string{http.MethodGet}},
 }
 

--- a/api/middleware/authorization_test.go
+++ b/api/middleware/authorization_test.go
@@ -30,7 +30,7 @@ func TestAuthorizer_RequireAuthorization(t *testing.T) {
 	}{
 		{"All authenticated users can list projects", "/projects", "GET", false},
 		{"All authenticated users can list environments", "/environments", "GET", false},
-		{"All authenticated users can make changes to simulator", "/standard-transformer/simulate", "POST", false},
+		{"All authenticated users can make changes to simulator", "/standard_transformer/simulate", "POST", false},
 		{"Only authorized users can create model", "/models/100", "POST", true},
 		{"Options http request does not require authorization", "/projects", "OPTIONS", false},
 		{"Only authorized users can access project sub resources", "/projects/100/model_endpoints", "GET", true},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
The simulator endpoint is standard_transformer/simulate as oppose to standard-transformer/simulate.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
