### PR TITLE
fix(sdk): Fix SDK model redeployment

### DIFF
--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -231,13 +231,10 @@ func (k *endpointService) override(left *models.VersionEndpoint, right *models.V
 		left.EnvVars = models.MergeEnvVars(left.EnvVars, right.EnvVars)
 	}
 
-	// default to HttpJson if not provided
-	if right.Protocol == "" {
-		right.Protocol = protocol.HttpJson
-	}
-
 	// override protocol
-	left.Protocol = right.Protocol
+	if right.Protocol != "" {
+		left.Protocol = right.Protocol
+	}
 
 	return nil
 }

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -236,6 +236,11 @@ func (k *endpointService) override(left *models.VersionEndpoint, right *models.V
 		left.Protocol = right.Protocol
 	}
 
+	// set default protocol if it is not specified explicitly
+	if left.Protocol == "" {
+		left.Protocol = protocol.HttpJson
+	}
+
 	return nil
 }
 

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -702,6 +702,7 @@ func TestDeployEndpoint(t *testing.T) {
 							EnvironmentName:      env.Name,
 							Namespace:            project.Name,
 							InferenceServiceName: iSvcName,
+							Protocol:             protocol.HttpJson,
 						},
 					},
 				},

--- a/python/sdk/merlin/client.py
+++ b/python/sdk/merlin/client.py
@@ -256,9 +256,9 @@ class MerlinClient:
         env_vars: Dict[str, str] = None,
         transformer: Transformer = None,
         logger: Logger = None,
-        deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
+        deployment_mode: DeploymentMode = None,
         autoscaling_policy: AutoscalingPolicy = None,
-        protocol: Protocol = Protocol.HTTP_JSON,
+        protocol: Protocol = None,
     ) -> VersionEndpoint:
         return model_version.deploy(
             environment_name,

--- a/python/sdk/merlin/fluent.py
+++ b/python/sdk/merlin/fluent.py
@@ -353,9 +353,9 @@ def deploy(
     env_vars: Dict[str, str] = None,
     transformer: Transformer = None,
     logger: Logger = None,
-    deployment_mode: DeploymentMode = DeploymentMode.SERVERLESS,
+    deployment_mode: DeploymentMode = None,
     autoscaling_policy: AutoscalingPolicy = None,
-    protocol: Protocol = Protocol.HTTP_JSON,
+    protocol: Protocol = None,
 ) -> VersionEndpoint:
     """
     Deploy a model version.

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1095,16 +1095,16 @@ class ModelVersion:
         target_deployment_mode = None
         if deployment_mode is None:
             if current_endpoint is None:
-                target_deployment_mode = DeploymentMode.SERVERLESS
+                target_deployment_mode = DeploymentMode.SERVERLESS.value
         else:
-            target_deployment_mode = deployment_mode
+            target_deployment_mode = deployment_mode.value
 
         target_protocol = None
         if protocol is None:
             if current_endpoint is None:
-                target_protocol = Protocol.HTTP_JSON
+                target_protocol = Protocol.HTTP_JSON.value
         else:
-            target_protocol = protocol
+            target_protocol = protocol.value
 
         target_env_name = environment_name
         if target_env_name is None:

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1224,7 +1224,6 @@ class ModelVersion:
             autoscaling_policy=target_autoscaling_policy,
             protocol=target_protocol,
         )
-        current_endpoint = self.endpoint
         if current_endpoint is not None:
             # This allows a serving deployment to be update while it is serving
             if current_endpoint.status == Status.SERVING:

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1085,9 +1085,9 @@ class ModelVersion:
         :param env_vars: List of environment variables to be passed to the model container.
         :param transformer: The service to be deployed alongside the model for pre/post-processing steps.
         :param logger: Response/Request logging configuration for model or transformer.
-        :param deployment_mode: mode of deployment for the endpoint (default: DeploymentMode.SERVERLESS)
+        :param deployment_mode: mode of deployment for the endpoint (default: None)
         :param autoscaling_policy: autoscaling policy to be used for the deployment (default: None)
-        :param protocol: protocol to be used for deploying the model (default: HTTP_JSON)
+        :param protocol: protocol to be used for deploying the model (default: None)
         :return: VersionEndpoint object
         """
         current_endpoint = self.endpoint
@@ -1607,8 +1607,7 @@ class ModelVersion:
 
     @staticmethod
     def _get_default_autoscaling_policy(deployment_mode: str) -> client.AutoscalingPolicy:
-        # If a previous model version does not exist, we set up a default autoscaling_policy
-        if deployment_mode == DeploymentMode.RAW_DEPLOYMENT:
+        if deployment_mode == DeploymentMode.RAW_DEPLOYMENT.value:
             autoscaling_policy = RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY
         else:
             autoscaling_policy = SERVERLESS_DEFAULT_AUTOSCALING_POLICY

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1565,7 +1565,7 @@ class ModelVersion:
     def _get_env_list(self) -> List[client.models.Environment]:
         return EnvironmentApi(self._api_client).environments_get()
 
-    def _get_endpoint_in_environment(self, environment_name: str) -> Optional[VersionEndpoint]:
+    def _get_endpoint_in_environment(self, environment_name: Optional[str]) -> Optional[VersionEndpoint]:
         """
         Return the FIRST endpoint of this model version that is deployed in the environment specified
 

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1086,7 +1086,7 @@ class ModelVersion:
         env_list = self._get_env_list()
         target_env_name = _get_default_target_env_name(env_list) if environment_name is None else environment_name
 
-        current_endpoint = self._get_endpoint_in_environment(environment_name)
+        current_endpoint = self._get_endpoint_in_environment(target_env_name)
 
         target_deployment_mode = None
         target_protocol = None

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1093,9 +1093,11 @@ class ModelVersion:
         current_endpoint = self.endpoint
         env_list = self._get_env_list()
 
+        # target_env_name can never be set as null
+        target_env_name = environment_name if environment_name is not None else ModelVersion._get_default_target_env_name(env_list)
+
         target_deployment_mode = None
         target_protocol = None
-        target_env_name = ModelVersion._get_default_target_env_name(env_list)
         target_resource_request = None
         target_autoscaling_policy = None
         target_env_vars: List[client.models.Environment] = []
@@ -1117,9 +1119,6 @@ class ModelVersion:
 
         if protocol is not None:
             target_protocol = protocol.value
-
-        if environment_name is not None:
-            target_env_name = environment_name
 
         if resource_request is not None:
             resource_request.validate()

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1093,9 +1093,6 @@ class ModelVersion:
         current_endpoint = self.endpoint
         env_list = self._get_env_list()
 
-        # target_env_name can never be set as null
-        target_env_name = environment_name if environment_name is not None else ModelVersion._get_default_target_env_name(env_list)
-
         target_deployment_mode = None
         target_protocol = None
         target_resource_request = None
@@ -1107,12 +1104,20 @@ class ModelVersion:
         # Get the currently deployed endpoint and if there's no deployed endpoint yet, use the default values for
         # non-nullable fields
         if current_endpoint is None:
+            target_env_name = ModelVersion._get_default_target_env_name(env_list)
             target_deployment_mode = DeploymentMode.SERVERLESS.value
             target_protocol = Protocol.HTTP_JSON.value
             target_resource_request = ModelVersion._get_default_resource_request(target_env_name, env_list)
             target_autoscaling_policy = ModelVersion._get_default_autoscaling_policy(
                 deployment_mode.value if deployment_mode is not None else target_deployment_mode
             )
+
+        if environment_name is not None:
+            target_env_name = environment_name
+        elif current_endpoint is not None:
+            # when we are updating a deployment but environment_name is not specified, we reuse the existing endpoint's
+            # environment name
+            target_env_name = current_endpoint.environment_name
 
         if deployment_mode is not None:
             target_deployment_mode = deployment_mode.value

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -36,7 +36,7 @@ REQUIRES = [
     "python_dateutil>=2.5.3",
     "PyYAML>=5.4",
     "six>=1.10",
-    "urllib3>=1.23",
+    "urllib3>=1.26",
     "numpy<=1.23.5", # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
     "caraml-auth-google==0.0.0.post7",
 ]

--- a/python/sdk/test/conftest.py
+++ b/python/sdk/test/conftest.py
@@ -136,7 +136,7 @@ def requests():
     retry_strategy = Retry(
         total=5,
         status_forcelist=[429, 500, 502, 503, 504, 404],
-        method_whitelist=["POST"],
+        allowed_methods=["POST"],
         backoff_factor=0.5,
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -630,6 +630,14 @@ class TestModelVersion:
             status=200,
             content_type="application/json",
         )
+        # This is the additional check which deploy makes to determine if there are any existing endpoints associated
+        responses.add(
+            "GET",
+            "/v1/models/1/versions/1/endpoint",
+            body=json.dumps([]),
+            status=200,
+            content_type="application/json",
+        )
         responses.add(
             "POST",
             "/v1/models/1/versions/1/endpoint",

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -516,6 +516,14 @@ class TestModelVersion:
 
     @responses.activate
     def test_deploy_default_env(self, version):
+        # This is the additional check which deploy makes to determine if there are any existing endpoints associated
+        responses.add(
+            "GET",
+            "/v1/models/1/versions/1/endpoint",
+            body=json.dumps([]),
+            status=200,
+            content_type="application/json",
+        )
         # no default environment
         responses.add(
             "GET",
@@ -688,6 +696,14 @@ class TestModelVersion:
 
     @responses.activate
     def test_undeploy_default_env(self, version):
+        # This is the additional check which deploy makes to determine if there are any existing endpoints associated
+        responses.add(
+            "GET",
+            "/v1/models/1/versions/1/endpoint",
+            body=json.dumps([]),
+            status=200,
+            content_type="application/json",
+        )
         # no default environment
         responses.add(
             "GET",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a fix to PR #455, which itself introduced a new feature to allow the redeployment of existing Merlin model versions using the `deploy` method. 

While this new feature assumes that a user would be able to only **_specify fields he/she intends to update_** in the model version configuration when calling the `deploy` method, the existing implementation however unexpectedly overwrites some of the existing configuration with certain default configuration values if they are not explicitly specified. These configuration values include:
- protocol
- deployment mode
- resources
- autoscaling policy

This happens because the 'deploy' method indirectly sets default values for the aforementioned configuration if they aren't specified (this was primarily intended to make the **initial** deployment process simpler so users wouldn't have to specify too many config values), and does not distinguish between a user calling `deploy` on an existing model version or on a new model version.

This PR thus makes changes to the SDK to set these defaults selectively. 

A separate change is made to the `override` method used in the Merlin API server update model version endpoint to override the existing model protocol ONLY when the new model version explicitly specifies a protocol. This change is a **_partial reversion_** of PR #300 (change 2) which means that from now on users need to explicitly specify the HTTP protocol (as opposed to leaving it as `null`) when updating a UPI model to use HTTP instead. It's ultimately a minor change since the main fix that had been introduced in that PR involves change 3 (in that PR).

**Which issue(s) this PR fixes**:
Fixes #455

**Does this PR introduce a user-facing change?**:
```release-note
Users need to explicitly specify the HTTP protocol (as opposed to leaving it as `null`) when updating a UPI model to use HTTP instead
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
