### PR TITLE
Fix current deployment history status

### DIFF
--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -2,7 +2,8 @@ argparse>=1.4.0
 numpy >= 1.8.2
 cloudpickle==2.0.0
 prometheus_client==0.14.1
-uvloop>=0.15.2
+#TODO: Remove uvloop pinning once we drop Python 3.7 support
+uvloop>=0.15.2,<0.19.0
 orjson>=2.6.8
 tornado
 caraml-upi-protos

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -3,7 +3,7 @@ numpy >= 1.8.2
 cloudpickle==2.0.0
 prometheus_client==0.14.1
 #TODO: Remove uvloop pinning once we drop Python 3.7 support
-uvloop>=0.15.2,<0.19.0
+uvloop>=0.15.2,<0.18.0
 orjson>=2.6.8
 tornado
 caraml-upi-protos

--- a/ui/src/pages/version/HistoryDetails.js
+++ b/ui/src/pages/version/HistoryDetails.js
@@ -29,7 +29,9 @@ const DeploymentStatus = ({
   if (status === "running" || status === "serving") {
     if (
       deployment.id === deployedRevision.id &&
-      (endpointStatus === "running" || endpointStatus === "serving")
+      (endpointStatus === "pending" ||
+        endpointStatus === "running" ||
+        endpointStatus === "serving")
     ) {
       return <EuiHealth color="success">Deployed</EuiHealth>;
     }
@@ -92,7 +94,6 @@ const RevisionPanel = ({ deployments, deploymentsLoaded, endpoint }) => {
           {deployment.id === deployedRevision.id && (
             <EuiBadge color="default">Current</EuiBadge>
           )}
-          {/* {JSON.stringify(deployment.id)} */}
         </>
       ),
     },

--- a/ui/src/pages/version/HistoryDetails.js
+++ b/ui/src/pages/version/HistoryDetails.js
@@ -46,7 +46,8 @@ const RevisionPanel = ({ deployments, deploymentsLoaded, endpoint }) => {
 
   const deployedRevision = orderedDeployments.find(
     (deployment) =>
-      deployment.status === "running" || deployment.status === "serving"
+      (deployment.status === "running" || deployment.status === "serving") &&
+      deployment.error === ""
   ) || { id: null };
 
   const canBeExpanded = (deployment) => {


### PR DESCRIPTION
…, the current deployment history shall be in Deployed status

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

During the redeployment, the current revision deployment status should keep in Deployed status instead of Not Deployed.

### During redeployment

<img width="500" alt="Screen Shot 2023-10-20 at 14 37 34" src="https://github.com/caraml-dev/merlin/assets/8122852/e20e15f0-d5c1-4c7e-a814-e83b22791801">

### After redeployment completed 

<img width="500" alt="Screen Shot 2023-10-20 at 14 38 46" src="https://github.com/caraml-dev/merlin/assets/8122852/ac3e53ac-d8ee-4dba-93aa-d2f6a8602337">

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
