### PR TITLE
Fix displaying model and transformer logs

### DIFF
--- a/api/models/service.go
+++ b/api/models/service.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	revisionPrefix = "r"
+	RevisionPrefix = "r"
 )
 
 type Service struct {
@@ -113,7 +113,7 @@ func CreateInferenceServiceName(modelName, versionID, revisionID string) string 
 		// This is for backward compatibility, when the endpoint / isvc name didn't include the revision number
 		return fmt.Sprintf("%s-%s", modelName, versionID)
 	}
-	return fmt.Sprintf("%s-%s-%s%s", modelName, versionID, revisionPrefix, revisionID)
+	return fmt.Sprintf("%s-%s-%s%s", modelName, versionID, RevisionPrefix, revisionID)
 }
 
 func GetInferenceURL(url *apis.URL, inferenceServiceName string, protocolValue protocol.Protocol) string {

--- a/api/service/utils_test.go
+++ b/api/service/utils_test.go
@@ -15,7 +15,7 @@ var (
 		Cluster:   "cluster1",
 		IsDefault: &isDefault,
 	}
-	labels = mlp.Labels{
+	mlpLabels = mlp.Labels{
 		{
 			Key:   "sample",
 			Value: "true",
@@ -29,7 +29,7 @@ var (
 			Name:   "project-1",
 			Team:   "dsp",
 			Stream: "dsp",
-			Labels: labels,
+			Labels: mlpLabels,
 		},
 		ExperimentID: 1,
 
@@ -100,7 +100,7 @@ var (
 			Name:   "project-1",
 			Team:   "dsp",
 			Stream: "dsp",
-			Labels: labels,
+			Labels: mlpLabels,
 		},
 		ExperimentID: 1,
 

--- a/ui/src/components/logs/ContainerLogsView.js
+++ b/ui/src/components/logs/ContainerLogsView.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useContext, useEffect, useState } from "react";
+import { AuthContext } from "@caraml-dev/ui-lib";
 import {
   EuiEmptyPrompt,
   EuiFlexGroup,
@@ -7,31 +7,32 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiTextColor,
-  EuiTitle
+  EuiTitle,
 } from "@elastic/eui";
+import React, { Fragment, useContext, useEffect, useState } from "react";
 import { LazyLog, ScrollFollow } from "react-lazylog";
-import { AuthContext } from "@caraml-dev/ui-lib";
 import config from "../../config";
-import mocks from "../../mocks";
-import { LogsSearchBar } from "./LogsSearchBar";
 import { useMerlinApi } from "../../hooks/useMerlinApi";
-import StackdriverLink from "./StackdriverLink";
+import mocks from "../../mocks";
 import { createStackdriverUrl } from "../../utils/createStackdriverUrl";
+import { LogsSearchBar } from "./LogsSearchBar";
+import StackdriverLink from "./StackdriverLink";
 
 const componentOrder = [
   "image_builder",
   "model",
   "transformer",
   "batch_job_driver",
-  "batch_job_executor"
+  "batch_job_executor",
 ];
 
 export const ContainerLogsView = ({
   projectId,
   model,
   versionId,
+  revisionId,
   jobId,
-  fetchContainerURL
+  fetchContainerURL,
 }) => {
   const [{ data: project, isLoaded: projectLoaded }] = useMerlinApi(
     `/projects/${projectId}`,
@@ -41,20 +42,13 @@ export const ContainerLogsView = ({
 
   const [params, setParams] = useState({
     component_type: "",
-    tail_lines: "1000"
+    tail_lines: "1000",
   });
 
   const [containerHaveBeenLoaded, setContainerHaveBeenLoaded] = useState(false);
 
-  const [
-    { data: containers, isLoaded: containersLoaded },
-    getContainers
-  ] = useMerlinApi(
-    fetchContainerURL,
-    { mock: mocks.containerOptions },
-    [],
-    true
-  );
+  const [{ data: containers, isLoaded: containersLoaded }, getContainers] =
+    useMerlinApi(fetchContainerURL, { mock: mocks.containerOptions }, [], true);
 
   useEffect(() => {
     var handle = setInterval(getContainers, 5000);
@@ -71,25 +65,25 @@ export const ContainerLogsView = ({
       if (containersLoaded && params.component_type === "") {
         if (
           containers.find(
-            container => container.component_type === "image_builder"
+            (container) => container.component_type === "image_builder"
           )
         ) {
           setParams({ ...params, component_type: "image_builder" });
         }
         if (
-          containers.find(container => container.component_type === "model")
+          containers.find((container) => container.component_type === "model")
         ) {
           setParams({ ...params, component_type: "model" });
         } else if (
           containers.find(
-            container => container.component_type === "transformer"
+            (container) => container.component_type === "transformer"
           )
         ) {
           setParams({ ...params, component_type: "transformer" });
         }
         if (
           containers.find(
-            container => container.component_type === "batch_job_driver"
+            (container) => container.component_type === "batch_job_driver"
           )
         ) {
           setParams({ ...params, component_type: "batch_job_driver" });
@@ -109,7 +103,7 @@ export const ContainerLogsView = ({
             componentOrder.indexOf(a.component_type) -
             componentOrder.indexOf(b.component_type)
         )
-        .map(container => container.component_type);
+        .map((container) => container.component_type);
       if (
         JSON.stringify(newComponentTypes) !== JSON.stringify(componentTypes)
       ) {
@@ -121,8 +115,8 @@ export const ContainerLogsView = ({
   const authCtx = useContext(AuthContext);
   const fetchOptions = {
     headers: {
-      Authorization: `Bearer ${authCtx.state.jwt}`
-    }
+      Authorization: `Bearer ${authCtx.state.jwt}`,
+    },
   };
 
   const [logUrl, setLogUrl] = useState("");
@@ -132,7 +126,7 @@ export const ContainerLogsView = ({
     () => {
       if (params.component_type !== "" && projectLoaded) {
         const activeContainers = containers.filter(
-          container => container.component_type === params.component_type
+          (container) => container.component_type === params.component_type
         );
 
         if (activeContainers && activeContainers.length > 0) {
@@ -145,7 +139,8 @@ export const ContainerLogsView = ({
             model_id: model.id,
             model_name: model.name,
             version_id: versionId,
-            prediction_job_id: jobId ? jobId : ""
+            revision_id: revisionId,
+            prediction_job_id: jobId ? jobId : "",
           };
           const logParams = new URLSearchParams(containerQuery).toString();
           const newLogUrl = config.MERLIN_API + "/logs?" + logParams;
@@ -155,14 +150,14 @@ export const ContainerLogsView = ({
 
           const pods = [
             ...new Set(
-              activeContainers.map(container => `"${container.pod_name}"`)
-            )
+              activeContainers.map((container) => `"${container.pod_name}"`)
+            ),
           ];
           let stackdriverQuery = {
             gcp_project: activeContainers[0].gcp_project,
             cluster: activeContainers[0].cluster,
             namespace: activeContainers[0].namespace,
-            pod_name: pods.join(" OR ")
+            pod_name: pods.join(" OR "),
           };
           setStackdriverUrl(createStackdriverUrl(stackdriverQuery));
         }

--- a/ui/src/pages/version/VersionDetails.js
+++ b/ui/src/pages/version/VersionDetails.js
@@ -234,6 +234,7 @@ const VersionDetails = () => {
                       projectId={projectId}
                       model={model}
                       versionId={versionId}
+                      revisionId={endpoint.revision_id}
                       fetchContainerURL={`/models/${modelId}/versions/${versionId}/endpoint/${endpointId}/containers`}
                     />
                   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

After the introduction of model version revision, the name of pods and their labels are updated as well which leads to the failure of getting the pod logs to be streamed. Currently, the label selector for getting the selected pod to be streamed depends on the model name + model version without revision. This PR updates the label selector to also include the revision on it.

Previous label selector:

`serving.kserve.io/inferenceservice=test-model-1`

After:

`serving.kserve.io/inferenceservice in (test-model-1,test-model-1-r1,test-model-1-r2)`

The label selection is using [set-based requirement](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) and include the previous pod name for backward compatibility and previous revisions to make sure we displayed the logs from previous pod revision after the redeployment.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes displaying logs for model and transformer

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
