### PR TITLE
Fix: Set version endpoint created and updated time on initialization

### DIFF
--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/caraml-dev/merlin/pkg/autoscaling"
 	"github.com/caraml-dev/merlin/pkg/deployment"
@@ -102,6 +103,9 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		AutoscalingPolicy: autoscalingPolicy,
 		EnvVars:           envVars,
 		Protocol:          protocol.HttpJson,
+		CreatedUpdated: CreatedUpdated{
+			CreatedAt: time.Now(),
+		},
 	}
 
 	if monitoringConfig.MonitoringEnabled {

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -16,7 +16,6 @@ package models
 
 import (
 	"net/url"
-	"time"
 
 	"github.com/caraml-dev/merlin/pkg/autoscaling"
 	"github.com/caraml-dev/merlin/pkg/deployment"
@@ -103,10 +102,6 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		AutoscalingPolicy: autoscalingPolicy,
 		EnvVars:           envVars,
 		Protocol:          protocol.HttpJson,
-		CreatedUpdated: CreatedUpdated{
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		},
 	}
 
 	if monitoringConfig.MonitoringEnabled {

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -105,6 +105,7 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		Protocol:          protocol.HttpJson,
 		CreatedUpdated: CreatedUpdated{
 			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
 		},
 	}
 

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -16,6 +16,7 @@ package models
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/caraml-dev/merlin/pkg/autoscaling"
 	"github.com/caraml-dev/merlin/pkg/deployment"
@@ -102,6 +103,10 @@ func NewVersionEndpoint(env *Environment, project mlp.Project, model *Model, ver
 		AutoscalingPolicy: autoscalingPolicy,
 		EnvVars:           envVars,
 		Protocol:          protocol.HttpJson,
+		CreatedUpdated: CreatedUpdated{
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
 	}
 
 	if monitoringConfig.MonitoringEnabled {

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -77,6 +77,10 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		return queue.RetryableError{Message: err.Error()}
 	}
 
+	// Use CreatedUpdated value from DB so that jobArgs.Endpoint's CreatedUpdated are not default value (0001-01-01 00:00:00 +0000 UTC)
+	endpoint.CreatedAt = prevEndpoint.CreatedAt
+	endpoint.UpdatedAt = prevEndpoint.UpdatedAt
+
 	isRedeployment := false
 
 	// Need to reassign destionationURL cause it is ignored when marshalled and unmarshalled
@@ -157,7 +161,6 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 	endpoint.URL = svc.URL
 	endpoint.ServiceName = svc.ServiceName
 	endpoint.InferenceServiceName = svc.CurrentIsvcName
-	endpoint.UpdatedAt = time.Now()
 	endpoint.Message = "" // reset message
 
 	if previousStatus == models.EndpointServing {

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -157,6 +157,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 	endpoint.URL = svc.URL
 	endpoint.ServiceName = svc.ServiceName
 	endpoint.InferenceServiceName = svc.CurrentIsvcName
+	endpoint.UpdatedAt = time.Now()
 	endpoint.Message = "" // reset message
 
 	if previousStatus == models.EndpointServing {

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -77,10 +77,6 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		return queue.RetryableError{Message: err.Error()}
 	}
 
-	// Use CreatedUpdated value from DB so that jobArgs.Endpoint's CreatedUpdated are not default value (0001-01-01 00:00:00 +0000 UTC)
-	endpoint.CreatedAt = prevEndpoint.CreatedAt
-	endpoint.UpdatedAt = prevEndpoint.UpdatedAt
-
 	isRedeployment := false
 
 	// Need to reassign destionationURL cause it is ignored when marshalled and unmarshalled

--- a/python/sdk/test/pyfunc/env.yaml
+++ b/python/sdk/test/pyfunc/env.yaml
@@ -2,7 +2,7 @@ dependencies:
   - python=3.10.*
   - pip:
     - joblib>=0.13.0,<1.2.0  # >=1.2.0 upon upgrade of kserve's version
-    - numpy
+    - numpy<=1.23.5  # Temporary pin numpy due to https://numpy.org/doc/stable/release/1.20.0-notes.html#numpy-1-20-0-release-notes
     - scikit-learn==1.0.2  #TODO: >=1.1.2 upon python 3.7 deprecation
     - xgboost==1.6.2
     - pytest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

After using jobArgs.Endpoint data as the [reference value](https://github.com/caraml-dev/merlin/blob/v0.34.0/api/queue/work/model_service_deployment.go#L61) for the deployment, the CreatedUpdated value is set to the time default value (`0001-01-01 00:00:00 +0000 UTC`) which could lead to DB update to use this value. This PR fixes it by getting the created_at and updated_at from version_endpoints DB so that it can be updated correctly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes wrong created_at value on version_endpoints

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
