### PR TITLE
Sanitize revision_id query param on Logs API

### DIFF
--- a/ui/src/components/logs/ContainerLogsView.js
+++ b/ui/src/components/logs/ContainerLogsView.js
@@ -139,7 +139,7 @@ export const ContainerLogsView = ({
             model_id: model.id,
             model_name: model.name,
             version_id: versionId,
-            revision_id: revisionId,
+            revision_id: revisionId ? revisionId : "",
             prediction_job_id: jobId ? jobId : "",
           };
           const logParams = new URLSearchParams(containerQuery).toString();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

Fix error on getting batch job logs due to revision_id=undefined in query param:

```
{
    "error": "Error while parsing query string: schema: error converting value for \"revision_id\""
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes getting batch job logs

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
