### PR TITLE
Add image builder's prometheus metrics: attempts, results, and duration

### DIFF
--- a/api/pkg/imagebuilder/config.go
+++ b/api/pkg/imagebuilder/config.go
@@ -17,9 +17,9 @@ package imagebuilder
 import (
 	"time"
 
-	cfg "github.com/caraml-dev/merlin/config"
-
 	v1 "k8s.io/api/core/v1"
+
+	cfg "github.com/caraml-dev/merlin/config"
 )
 
 type Config struct {

--- a/api/pkg/imagebuilder/imagebuilder_test.go
+++ b/api/pkg/imagebuilder/imagebuilder_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	cfg "github.com/caraml-dev/merlin/config"
-
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -39,6 +37,7 @@ import (
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 	ktesting "k8s.io/client-go/testing"
 
+	cfg "github.com/caraml-dev/merlin/config"
 	"github.com/caraml-dev/merlin/mlp"
 	"github.com/caraml-dev/merlin/models"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

For better observability across the image builder process, I added 3 Prometheus metrics: attempts, results, and durations.

The results in `/metrics` endpoint would be something like this:

```
# HELP merlin_image_builder_attempts Total of image builder attempts
# TYPE merlin_image_builder_attempts counter
merlin_image_builder_attempts{model="pyfunc-sample",model_type="pyfunc",model_version="4",project="string-theory",python_version="3.8.*"} 1

# HELP merlin_image_builder_duration_seconds Duration of image builder in seconds
# TYPE merlin_image_builder_duration_seconds histogram
merlin_image_builder_duration_seconds_bucket{model="pyfunc-sample",model_type="pyfunc",model_version="4",project="string-theory",python_version="3.8.*",result="success",le="420"} 1
...
merlin_image_builder_duration_seconds_sum{model="pyfunc-sample",model_type="pyfunc",model_version="4",project="string-theory",python_version="3.8.*",result="success"} 385.718119541
merlin_image_builder_duration_seconds_count{model="pyfunc-sample",model_type="pyfunc",model_version="4",project="string-theory",python_version="3.8.*",result="success"} 1

# HELP merlin_image_builder_results Total of image builder results
# TYPE merlin_image_builder_results counter
merlin_image_builder_results{model="pyfunc-sample",model_type="pyfunc",model_version="4",project="string-theory",python_version="3.8.*",result="success"} 1
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
