### PR TITLE
Remove pinning of grpcio dependencies

### DIFF
--- a/examples/custom-model/upi_v1/requirements.txt
+++ b/examples/custom-model/upi_v1/requirements.txt
@@ -1,3 +1,3 @@
 merlin-sdk
-caraml-upi-protos>=0.3.7
+caraml-upi-protos>=0.3.1
 pandas

--- a/examples/custom-model/upi_v1/requirements.txt
+++ b/examples/custom-model/upi_v1/requirements.txt
@@ -1,4 +1,3 @@
 merlin-sdk
-grpcio>=1.31.0,<1.49.0
-caraml-upi-protos>=0.3.1
+caraml-upi-protos>=0.3.7
 pandas

--- a/examples/transformer/upi/requirements.txt
+++ b/examples/transformer/upi/requirements.txt
@@ -1,4 +1,3 @@
 pandas
 cloudpickle==2.0.0
 merlin-sdk
-grpcio==1.22.0

--- a/python/batch-predictor/main.py
+++ b/python/batch-predictor/main.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
             .builder \
             .appName(args.job_name) \
             .getOrCreate()
-        spark.conf.set("spark.sql.execution.arrow.enabled", "true")
+        spark.conf.set("spark.sql.execution.arrow.pyspark.enabled", "true")
 
     print(f"Spark Conf: {spark.sparkContext.getConf().getAll()}")
     if args.dry_run_path is not None:

--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -3,5 +3,4 @@ pyspark==3.0.1
 mlflow>=1.26.1,<2.0.0
 cloudpickle==2.0.0
 pyarrow>=0.14.1,<=9.0.0
-protobuf>=3.0,<5.0.0
 file:${SDK_PATH}#egg=merlin-sdk

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -6,10 +6,5 @@ prometheus_client==0.14.1
 uvloop>=0.15.2,<0.18.0
 orjson>=2.6.8
 tornado
-caraml-upi-protos
-# Starting 1.49.0, grpc uses protobuf 4.X which are incompatible with most of our dependencies
-grpcio<1.49.0
-grpcio-reflection<1.49.0
-grpcio-tools<1.49.0
-grpcio-health-checking<1.49.0
+caraml-upi-protos>=0.3.7
 file:${SDK_PATH}#egg=merlin-sdk

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -6,5 +6,5 @@ prometheus_client==0.14.1
 uvloop>=0.15.2,<0.18.0
 orjson>=2.6.8
 tornado
-caraml-upi-protos>=0.3.7
+caraml-upi-protos
 file:${SDK_PATH}#egg=merlin-sdk

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -23,7 +23,7 @@ version = imp.load_source(
 
 REQUIRES = [
     "boto3>=1.9.84",
-    "caraml-upi-protos>=0.3.7",
+    "caraml-upi-protos>=0.3.1",
     "certifi>=2017.4.17",
     "Click>=7.0,<8.1.4",
     "cloudpickle==2.0.0",  # used by mlflow

--- a/python/sdk/setup.py
+++ b/python/sdk/setup.py
@@ -23,7 +23,7 @@ version = imp.load_source(
 
 REQUIRES = [
     "boto3>=1.9.84",
-    "caraml-upi-protos>=0.3.1",
+    "caraml-upi-protos>=0.3.7",
     "certifi>=2017.4.17",
     "Click>=7.0,<8.1.4",
     "cloudpickle==2.0.0",  # used by mlflow
@@ -44,7 +44,6 @@ REQUIRES = [
 TEST_REQUIRES = [
     "google-cloud-bigquery-storage>=0.7.0",
     "google-cloud-bigquery>=1.18.0",
-    "grpcio>=1.31.0,<1.49.0",
     "joblib>=0.13.0,<1.2.0",  # >=1.2.0 upon upgrade of kserve's version
     "mypy>=0.812",
     "pytest-cov",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

With https://github.com/caraml-dev/merlin/pull/465, we no longer need to pin the `grpcio` related libraries, which will in turn constrain the `protobuf` dependencies.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove pinning of grpcio dependencies
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
