### PR TITLE
Fix: image build process on pyfunc v3 model

### DIFF
--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -184,7 +184,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 func (depl *ModelServiceDeployment) generateModelOptions(ctx context.Context, model *models.Model, version *models.Version, endpoint *models.VersionEndpoint) (*models.ModelOption, error) {
 	modelOpt := &models.ModelOption{}
 	switch model.Type {
-	case models.ModelTypePyFunc:
+	case models.ModelTypePyFunc, models.ModelTypePyFuncV3:
 		imageRef, err := depl.ImageBuilder.BuildImage(ctx, model.Project, model, version, endpoint.ImageBuilderResourceRequest)
 		if err != nil {
 			return modelOpt, err

--- a/api/queue/work/model_service_deployment_test.go
+++ b/api/queue/work/model_service_deployment_test.go
@@ -250,7 +250,7 @@ func TestExecuteDeployment(t *testing.T) {
 			},
 			imageBuilder: func() *imageBuilderMock.ImageBuilder {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
-				mockImgBuilder.On("BuildImage", context.Background(), project, mock.Anything, mock.Anything).
+				mockImgBuilder.On("BuildImage", context.Background(), project, mock.Anything, mock.Anything, mock.Anything).
 					Return("gojek/mymodel-1:latest", nil)
 				return mockImgBuilder
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->
In v0.37.0 the image building is triggered when deploying pyfunc_v3, but in the recent release the image building process is skip for pyfunc_v3 hence the deployment will fail

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Trigger image building process for pyfunc_v3 deployment

Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
