### PR TITLE
Pin caraml-upi-protos>=0.3.4

### DIFF
--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -6,7 +6,7 @@ prometheus_client==0.14.1
 uvloop>=0.15.2,<0.18.0
 orjson>=2.6.8
 tornado
-caraml-upi-protos
+caraml-upi-protos>=0.3.4
 grpcio-reflection
 grpcio-health-checking
 confluent-kafka==2.3.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

pyfunc-server's converter needs 'prediction_log_pb2' from 'caraml.upi.v1' which only available in >=0.3.4

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes error: ImportError: cannot import name 'prediction_log_pb2' from 'caraml.upi.v1' if user use old version of caraml-upi-protos

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
