### PR TITLE
Uninstall merlin-sdk before installing pyfunc/batch dependencies

### DIFF
--- a/python/batch-predictor/docker/app.Dockerfile
+++ b/python/batch-predictor/docker/app.Dockerfile
@@ -31,7 +31,7 @@ COPY --chown=${UID}:${GID} batch-predictor ${HOME}/merlin-spark-app
 COPY --chown=${UID}:${GID} sdk ${HOME}/sdk
 ENV SDK_PATH=${HOME}/sdk
 
-RUN /bin/bash -c ". activate merlin-model && pip install -r ${HOME}/merlin-spark-app/requirements.txt"
+RUN /bin/bash -c ". activate merlin-model && pip uninstall -y merlin-sdk && pip install -r ${HOME}/merlin-spark-app/requirements.txt"
 
 # Download and dry-run user model artifacts and code
 ARG MODEL_ARTIFACTS_URL

--- a/python/pyfunc-server/docker/Dockerfile
+++ b/python/pyfunc-server/docker/Dockerfile
@@ -32,8 +32,7 @@ COPY sdk /sdk
 ENV SDK_PATH=/sdk
 
 WORKDIR /pyfunc-server
-RUN /bin/bash -c ". activate merlin-model && pip uninstall merlin-sdk || true"
-RUN /bin/bash -c ". activate merlin-model && pip install -r /pyfunc-server/requirements.txt"
+RUN /bin/bash -c ". activate merlin-model && pip uninstall -y merlin-sdk && pip install -r /pyfunc-server/requirements.txt"
 
 # Download and dry-run user model artifacts and code
 ARG MODEL_ARTIFACTS_URL

--- a/python/pyfunc-server/docker/Dockerfile
+++ b/python/pyfunc-server/docker/Dockerfile
@@ -32,6 +32,7 @@ COPY sdk /sdk
 ENV SDK_PATH=/sdk
 
 WORKDIR /pyfunc-server
+RUN /bin/bash -c ". activate merlin-model && pip uninstall merlin-sdk || true"
 RUN /bin/bash -c ". activate merlin-model && pip install -r /pyfunc-server/requirements.txt"
 
 # Download and dry-run user model artifacts and code


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
<!-- Explain here the context and why you're making the change. What is the problem you're trying to solve. --->

If user has a direct or indirect dependency on merlin-sdk on their pyfunc or batch job's conda.yaml, that merlin-sdk version is the one that will be used to run the pyfunc or batch job, ignoring the local merlin-sdk. By uninstalling it before installing the pyfunc or batch job dependencies, we make sure to always use the local merlin-sdk version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes pyfunc/batch job running old version of merlin

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

**Checklist**

- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduce API changes
