### PR TITLE
fix: move git initialization to function body

### DIFF
--- a/python/sdk/merlin/pyfunc.py
+++ b/python/sdk/merlin/pyfunc.py
@@ -10,7 +10,6 @@ import numpy
 import pandas
 from caraml.upi.v1 import upi_pb2
 from docker import APIClient
-from git import Repo
 from merlin.docker.docker import copy_pyfunc_dockerfile, wait_build_complete
 from merlin.protocol import Protocol
 from merlin.version import VERSION
@@ -516,6 +515,10 @@ def run_pyfunc_local_server(
 
 
 def _clone_merlin_repo(context_path: str):
+    # Can't be imported at module level because the initialization will fail when the git executable
+    # does not exists.
+    from git import Repo
+
     repo_url = "https://github.com/caraml-dev/merlin.git"
     repo_path = f"{context_path}/merlin"
     if not os.path.isdir(repo_path):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Import git module will fail when the execution environment does not contain git executable. As Merlin SDK does not strictly rely on git, we should move the import to the function body where it is needed instead.

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in which pyfunc related functions will fail when the execution environment does not have git executable.
```
