### PR TITLE
fix: Incorrect request body for create and patch version

### DIFF
--- a/api/api/model_schema_api.go
+++ b/api/api/model_schema_api.go
@@ -49,6 +49,11 @@ func (m *ModelSchemaController) CreateOrUpdateSchema(r *http.Request, vars map[s
 	if !ok {
 		return BadRequest("Unable to parse request body")
 	}
+
+	if modelSchema.ModelID > 0 && modelSchema.ModelID != modelID {
+		return BadRequest("Mismatch model id between request path and body")
+	}
+
 	modelSchema.ModelID = modelID
 	schema, err := m.ModelSchemaService.Save(ctx, modelSchema)
 	if err != nil {

--- a/api/api/model_schema_api_test.go
+++ b/api/api/model_schema_api_test.go
@@ -371,6 +371,98 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 			},
 		},
 		{
+			desc: "success create ranking schema, with specifying model id",
+			vars: map[string]string{
+				"model_id": "1",
+			},
+			body: []byte(`{
+				"spec": {
+					"prediction_id_column":"prediction_id",
+					"tag_columns": ["tags"],
+					"feature_types": {
+						"featureA": "float64",
+						"featureB": "int64",
+						"featureC": "boolean"
+					},
+					"model_prediction_output": {
+						"prediction_group_id_column": "session_id",
+						"rank_score_column": "score",
+						"relevance_score": "relevance_score",
+						"output_class": "RankingOutput"
+					}
+				},
+				"model_id": 1
+			}`),
+			modelSchemaService: func() *mocks.ModelSchemaService {
+				mockSvc := &mocks.ModelSchemaService{}
+				mockSvc.On("Save", mock.Anything, &models.ModelSchema{
+					ModelID: models.ID(1),
+					Spec: &models.SchemaSpec{
+						PredictionIDColumn: "prediction_id",
+						TagColumns:         []string{"tags"},
+						FeatureTypes: map[string]models.ValueType{
+							"featureA": models.Float64,
+							"featureB": models.Int64,
+							"featureC": models.Boolean,
+						},
+						ModelPredictionOutput: &models.ModelPredictionOutput{
+							RankingOutput: &models.RankingOutput{
+								PredictionGroudIDColumn: "session_id",
+								RankScoreColumn:         "score",
+								RelevanceScoreColumn:    "relevance_score",
+								OutputClass:             models.Ranking,
+							},
+						},
+					},
+				}).Return(&models.ModelSchema{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Spec: &models.SchemaSpec{
+						PredictionIDColumn: "prediction_id",
+						TagColumns:         []string{"tags"},
+						FeatureTypes: map[string]models.ValueType{
+							"featureA": models.Float64,
+							"featureB": models.Int64,
+							"featureC": models.Boolean,
+						},
+						ModelPredictionOutput: &models.ModelPredictionOutput{
+							RankingOutput: &models.RankingOutput{
+								PredictionGroudIDColumn: "session_id",
+								RankScoreColumn:         "score",
+								RelevanceScoreColumn:    "relevance_score",
+								OutputClass:             models.Ranking,
+							},
+						},
+					},
+				}, nil)
+				return mockSvc
+			},
+			expected: &Response{
+				code: http.StatusOK,
+				data: &models.ModelSchema{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Spec: &models.SchemaSpec{
+						PredictionIDColumn: "prediction_id",
+						TagColumns:         []string{"tags"},
+						FeatureTypes: map[string]models.ValueType{
+							"featureA": models.Float64,
+							"featureB": models.Int64,
+							"featureC": models.Boolean,
+						},
+						ModelPredictionOutput: &models.ModelPredictionOutput{
+							RankingOutput: &models.RankingOutput{
+								PredictionGroudIDColumn: "session_id",
+								RankScoreColumn:         "score",
+								RelevanceScoreColumn:    "relevance_score",
+								OutputClass:             models.Ranking,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "success create binary classification schema",
 			vars: map[string]string{
 				"model_id": "1",
@@ -605,6 +697,38 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 			expected: &Response{
 				code: http.StatusInternalServerError,
 				data: Error{Message: "Error save model schema: peer connection is reset"},
+			},
+		},
+		{
+			desc: "model id mismatch",
+			vars: map[string]string{
+				"model_id": "1",
+			},
+			body: []byte(`{
+				"spec": {
+					"prediction_id_column":"prediction_id",
+					"tag_columns": ["tags"],
+					"feature_types": {
+						"featureA": "float64",
+						"featureB": "int64",
+						"featureC": "boolean"
+					},
+					"model_prediction_output": {
+						"prediction_group_id_column": "session_id",
+						"rank_score_column": "score",
+						"relevance_score": "relevance_score",
+						"output_class": "RankingOutput"
+					}
+				},
+				"model_id": 2
+			}`),
+			modelSchemaService: func() *mocks.ModelSchemaService {
+				mockSvc := &mocks.ModelSchemaService{}
+				return mockSvc
+			},
+			expected: &Response{
+				code: http.StatusBadRequest,
+				data: Error{Message: "Mismatch model id between request path and body"},
 			},
 		},
 	}

--- a/api/api/versions_api.go
+++ b/api/api/versions_api.go
@@ -69,7 +69,8 @@ func (c *VersionsController) PatchVersion(r *http.Request, vars map[string]strin
 		return InternalServerError("Unable to parse request body")
 	}
 
-	if err := v.Patch(versionPatch); err != nil {
+	v.Patch(versionPatch)
+	if err := v.Validate(); err != nil {
 		return BadRequest(fmt.Sprintf("Error validating version: %v", err))
 	}
 
@@ -105,7 +106,6 @@ func (c *VersionsController) ListVersions(r *http.Request, vars map[string]strin
 
 func (c *VersionsController) CreateVersion(r *http.Request, vars map[string]string, body interface{}) *Response {
 	ctx := r.Context()
-
 	versionPost, ok := body.(*models.VersionPost)
 	if !ok {
 		return BadRequest("Unable to parse request body")
@@ -140,7 +140,14 @@ func (c *VersionsController) CreateVersion(r *http.Request, vars map[string]stri
 		ModelSchema:   versionPost.ModelSchema,
 	}
 
-	version, _ = c.VersionsService.Save(ctx, version, c.FeatureToggleConfig.MonitoringConfig)
+	if err := version.Validate(); err != nil {
+		return BadRequest(fmt.Sprintf("Error validating version: %v", err))
+	}
+
+	version, err = c.VersionsService.Save(ctx, version, c.FeatureToggleConfig.MonitoringConfig)
+	if err != nil {
+		return InternalServerError(fmt.Sprintf("Failed to save version: %v", err))
+	}
 	return Created(version)
 }
 

--- a/api/api/versions_api.go
+++ b/api/api/versions_api.go
@@ -137,6 +137,7 @@ func (c *VersionsController) CreateVersion(r *http.Request, vars map[string]stri
 		ArtifactURI:   run.Info.ArtifactURI,
 		Labels:        versionPost.Labels,
 		PythonVersion: versionPost.PythonVersion,
+		ModelSchema:   versionPost.ModelSchema,
 	}
 
 	version, _ = c.VersionsService.Save(ctx, version, c.FeatureToggleConfig.MonitoringConfig)

--- a/api/api/versions_api_test.go
+++ b/api/api/versions_api_test.go
@@ -708,6 +708,170 @@ func TestPatchVersion(t *testing.T) {
 				data: Error{Message: "Error patching model version: Error creating secret: db is down"},
 			},
 		},
+		{
+			desc: "Should success update model schema",
+			vars: map[string]string{
+				"model_id":   "1",
+				"version_id": "1",
+			},
+			requestBody: &models.VersionPatch{
+				Properties: &models.KV{
+					"name":       "model-1",
+					"created_by": "anonymous",
+				},
+				ModelSchema: &models.ModelSchema{
+					Spec: &models.SchemaSpec{
+						PredictionIDColumn: "prediction_id",
+						ModelPredictionOutput: &models.ModelPredictionOutput{
+							RankingOutput: &models.RankingOutput{
+								PredictionGroudIDColumn: "session_id",
+								RankScoreColumn:         "score",
+								RelevanceScoreColumn:    "relevance_score",
+								OutputClass:             models.Ranking,
+							},
+						},
+						FeatureTypes: map[string]models.ValueType{
+							"featureA": models.Float64,
+							"featureB": models.Int64,
+							"featureC": models.Boolean,
+						},
+					},
+					ModelID: models.ID(1),
+				},
+			},
+			versionService: func() *mocks.VersionsService {
+				svc := &mocks.VersionsService{}
+				svc.On("FindByID", mock.Anything, models.ID(1), models.ID(1), mock.Anything).Return(
+					&models.Version{
+						ID:      models.ID(1),
+						ModelID: models.ID(1),
+						Model: &models.Model{
+							ID:           models.ID(1),
+							Name:         "model-1",
+							ProjectID:    models.ID(1),
+							Project:      mlp.Project{},
+							ExperimentID: 1,
+							Type:         "pyfunc",
+							MlflowURL:    "http://mlflow.com",
+						},
+						MlflowURL: "http://mlflow.com",
+					}, nil)
+				svc.On("Save", mock.Anything, &models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "pyfunc",
+						MlflowURL:    "http://mlflow.com",
+					},
+					MlflowURL: "http://mlflow.com",
+					Properties: models.KV{
+						"name":       "model-1",
+						"created_by": "anonymous",
+					},
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
+				}, mock.Anything).Return(&models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "pyfunc",
+						MlflowURL:    "http://mlflow.com",
+					},
+					MlflowURL: "http://mlflow.com",
+					Properties: models.KV{
+						"name":       "model-1",
+						"created_by": "anonymous",
+					},
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
+				}, nil)
+				return svc
+			},
+			expected: &Response{
+				code: http.StatusOK,
+				data: &models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "pyfunc",
+						MlflowURL:    "http://mlflow.com",
+					},
+					MlflowURL: "http://mlflow.com",
+					Properties: models.KV{
+						"name":       "model-1",
+						"created_by": "anonymous",
+					},
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
+				},
+			},
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
@@ -1152,6 +1316,158 @@ func TestCreateVersion(t *testing.T) {
 					},
 					MlflowURL:     "http://mlflow.com",
 					PythonVersion: DEFAULT_PYTHON_VERSION,
+				},
+			},
+		},
+		{
+			desc: "Should successfully create version with model schema",
+			vars: map[string]string{
+				"model_id": "1",
+			},
+			body: models.VersionPost{
+				ModelSchema: &models.ModelSchema{
+					Spec: &models.SchemaSpec{
+						PredictionIDColumn: "prediction_id",
+						ModelPredictionOutput: &models.ModelPredictionOutput{
+							RankingOutput: &models.RankingOutput{
+								PredictionGroudIDColumn: "session_id",
+								RankScoreColumn:         "score",
+								RelevanceScoreColumn:    "relevance_score",
+								OutputClass:             models.Ranking,
+							},
+						},
+						FeatureTypes: map[string]models.ValueType{
+							"featureA": models.Float64,
+							"featureB": models.Int64,
+							"featureC": models.Boolean,
+						},
+					},
+					ModelID: models.ID(1),
+				},
+			},
+			modelsService: func() *mocks.ModelsService {
+				svc := &mocks.ModelsService{}
+				svc.On("FindByID", mock.Anything, models.ID(1)).Return(&models.Model{
+					ID:        models.ID(1),
+					Name:      "model-1",
+					ProjectID: models.ID(1),
+					Project: mlp.Project{
+						MLFlowTrackingURL: "http://www.notinuse.com",
+					},
+					ExperimentID: 1,
+					Type:         "pyfunc",
+					MlflowURL:    "http://mlflow.com",
+					Endpoints:    nil,
+				}, nil)
+				return svc
+			},
+			mlflowClient: func() *mlfmocks.Client {
+				svc := &mlfmocks.Client{}
+				svc.On("CreateRun", "1").Return(&mlflow.Run{
+					Info: mlflow.Info{
+						RunID:       "1",
+						ArtifactURI: "artifact/url/run",
+					},
+				}, nil)
+				return svc
+			},
+			versionService: func() *mocks.VersionsService {
+				svc := &mocks.VersionsService{}
+				svc.On("Save", mock.Anything, &models.Version{
+					ModelID:       models.ID(1),
+					RunID:         "1",
+					ArtifactURI:   "artifact/url/run",
+					PythonVersion: DEFAULT_PYTHON_VERSION,
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
+				}, mock.Anything).Return(&models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "sklearn",
+						MlflowURL:    "http://mlflow.com",
+					},
+					MlflowURL:     "http://mlflow.com",
+					PythonVersion: DEFAULT_PYTHON_VERSION,
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
+				}, nil)
+				return svc
+			},
+			expected: &Response{
+				code: http.StatusCreated,
+				data: &models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "sklearn",
+						MlflowURL:    "http://mlflow.com",
+					},
+					MlflowURL:     "http://mlflow.com",
+					PythonVersion: DEFAULT_PYTHON_VERSION,
+					ModelSchema: &models.ModelSchema{
+						Spec: &models.SchemaSpec{
+							PredictionIDColumn: "prediction_id",
+							ModelPredictionOutput: &models.ModelPredictionOutput{
+								RankingOutput: &models.RankingOutput{
+									PredictionGroudIDColumn: "session_id",
+									RankScoreColumn:         "score",
+									RelevanceScoreColumn:    "relevance_score",
+									OutputClass:             models.Ranking,
+								},
+							},
+							FeatureTypes: map[string]models.ValueType{
+								"featureA": models.Float64,
+								"featureB": models.Int64,
+								"featureC": models.Boolean,
+							},
+						},
+						ModelID: models.ID(1),
+					},
 				},
 			},
 		},

--- a/api/models/model_schema.go
+++ b/api/models/model_schema.go
@@ -30,7 +30,7 @@ const (
 type ModelSchema struct {
 	ID      ID          `json:"id"`
 	Spec    *SchemaSpec `json:"spec,omitempty"`
-	ModelID ID          `json:"-"`
+	ModelID ID          `json:"model_id"`
 }
 
 type SchemaSpec struct {

--- a/api/models/version.go
+++ b/api/models/version.go
@@ -40,13 +40,15 @@ type Version struct {
 }
 
 type VersionPost struct {
-	Labels        KV     `json:"labels" gorm:"labels"`
-	PythonVersion string `json:"python_version" gorm:"python_version"`
+	Labels        KV           `json:"labels" gorm:"labels"`
+	PythonVersion string       `json:"python_version" gorm:"python_version"`
+	ModelSchema   *ModelSchema `json:"model_schema"`
 }
 
 type VersionPatch struct {
 	Properties      *KV              `json:"properties,omitempty"`
 	CustomPredictor *CustomPredictor `json:"custom_predictor,omitempty"`
+	ModelSchema     *ModelSchema     `json:"model_schema"`
 }
 
 type CustomPredictor struct {
@@ -100,6 +102,10 @@ func (v *Version) Patch(patch *VersionPatch) error {
 		}
 		v.CustomPredictor = patch.CustomPredictor
 	}
+	if patch.ModelSchema != nil {
+		v.ModelSchema = patch.ModelSchema
+	}
+
 	return nil
 }
 

--- a/api/models/version.go
+++ b/api/models/version.go
@@ -18,6 +18,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -92,21 +93,30 @@ func (kv *KV) Scan(value interface{}) error {
 	return json.Unmarshal(b, &kv)
 }
 
-func (v *Version) Patch(patch *VersionPatch) error {
+func (v *Version) Validate() error {
+	if v.CustomPredictor != nil && v.Model.Type == ModelTypeCustom {
+		if err := v.CustomPredictor.IsValid(); err != nil {
+			return err
+		}
+	}
+	if v.ModelSchema != nil {
+		if v.ModelSchema.ModelID > 0 && v.ModelSchema.ModelID != v.ModelID {
+			return fmt.Errorf("mismatch model id between version and model schema")
+		}
+	}
+	return nil
+}
+
+func (v *Version) Patch(patch *VersionPatch) {
 	if patch.Properties != nil {
 		v.Properties = *patch.Properties
 	}
 	if patch.CustomPredictor != nil && v.Model.Type == ModelTypeCustom {
-		if err := patch.CustomPredictor.IsValid(); err != nil {
-			return err
-		}
 		v.CustomPredictor = patch.CustomPredictor
 	}
 	if patch.ModelSchema != nil {
 		v.ModelSchema = patch.ModelSchema
 	}
-
-	return nil
 }
 
 func (v *Version) BeforeCreate(db *gorm.DB) error {

--- a/openapi-api-codegen.yaml
+++ b/openapi-api-codegen.yaml
@@ -1,5 +1,6 @@
 packageName: client
 enumClassPrefix: true
+useOneOfDiscriminatorLookup: true
 # Global Properties
 globalProperties:
   apiTests: false

--- a/openapi-sdk-codegen.yaml
+++ b/openapi-sdk-codegen.yaml
@@ -1,6 +1,7 @@
 projectName: merlin-sdk
 packageName: client
 generateSourceCodeOnly: true
+useOneOfDiscriminatorLookup: true
 # Global Properties
 globalProperties:
   apiTests: false

--- a/python/sdk/client/api_client.py
+++ b/python/sdk/client/api_client.py
@@ -296,6 +296,7 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
+        print(f"response status ----- {response_data.status}")
         if not 200 <= response_data.status <= 299:
             if response_data.status == 400:
                 raise BadRequestException(http_resp=response_data)
@@ -328,6 +329,7 @@ class ApiClient:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
             encoding = match.group(1) if match else "utf-8"
             response_text = response_data.data.decode(encoding)
+            print(f"response_text ------ {response_text}")
             return_data = self.deserialize(response_text, response_type)
 
         return ApiResponse(

--- a/python/sdk/client/api_client.py
+++ b/python/sdk/client/api_client.py
@@ -296,7 +296,6 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        print(f"response status ----- {response_data.status}")
         if not 200 <= response_data.status <= 299:
             if response_data.status == 400:
                 raise BadRequestException(http_resp=response_data)
@@ -329,7 +328,6 @@ class ApiClient:
                 match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
             encoding = match.group(1) if match else "utf-8"
             response_text = response_data.data.decode(encoding)
-            print(f"response_text ------ {response_text}")
             return_data = self.deserialize(response_text, response_type)
 
         return ApiResponse(

--- a/python/sdk/client/models/binary_classification_output.py
+++ b/python/sdk/client/models/binary_classification_output.py
@@ -35,7 +35,7 @@ class BinaryClassificationOutput(BaseModel):
     positive_class_label: StrictStr
     negative_class_label: StrictStr
     score_threshold: Optional[Union[StrictFloat, StrictInt]] = None
-    output_class: Optional[ModelPredictionOutputClass] = None
+    output_class: ModelPredictionOutputClass
     __properties: ClassVar[List[str]] = ["prediction_score_column", "actual_label_column", "positive_class_label", "negative_class_label", "score_threshold", "output_class"]
 
     model_config = {

--- a/python/sdk/client/models/model_prediction_output.py
+++ b/python/sdk/client/models/model_prediction_output.py
@@ -104,6 +104,26 @@ class ModelPredictionOutput(BaseModel):
         error_messages = []
         match = 0
 
+        # use oneOf discriminator to lookup the data type
+        _data_type = json.loads(json_str).get("output_class")
+        if not _data_type:
+            raise ValueError("Failed to lookup data type from the field `output_class` in the input.")
+
+        # check if data type is `BinaryClassificationOutput`
+        if _data_type == "BinaryClassificationOutput":
+            instance.actual_instance = BinaryClassificationOutput.from_json(json_str)
+            return instance
+
+        # check if data type is `RankingOutput`
+        if _data_type == "RankingOutput":
+            instance.actual_instance = RankingOutput.from_json(json_str)
+            return instance
+
+        # check if data type is `RegressionOutput`
+        if _data_type == "RegressionOutput":
+            instance.actual_instance = RegressionOutput.from_json(json_str)
+            return instance
+
         # deserialize data into BinaryClassificationOutput
         try:
             instance.actual_instance = BinaryClassificationOutput.from_json(json_str)

--- a/python/sdk/client/models/ranking_output.py
+++ b/python/sdk/client/models/ranking_output.py
@@ -33,7 +33,7 @@ class RankingOutput(BaseModel):
     rank_score_column: StrictStr
     prediction_group_id_column: StrictStr
     relevance_score_column: Optional[StrictStr] = None
-    output_class: Optional[ModelPredictionOutputClass] = None
+    output_class: ModelPredictionOutputClass
     __properties: ClassVar[List[str]] = ["rank_score_column", "prediction_group_id_column", "relevance_score_column", "output_class"]
 
     model_config = {

--- a/python/sdk/client/models/regression_output.py
+++ b/python/sdk/client/models/regression_output.py
@@ -32,7 +32,7 @@ class RegressionOutput(BaseModel):
     """ # noqa: E501
     prediction_score_column: StrictStr
     actual_score_column: Optional[StrictStr] = None
-    output_class: Optional[ModelPredictionOutputClass] = None
+    output_class: ModelPredictionOutputClass
     __properties: ClassVar[List[str]] = ["prediction_score_column", "actual_score_column", "output_class"]
 
     model_config = {

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -783,6 +783,10 @@ class ModelVersion:
         model_id = self.model.id
         base_url = guess_mlp_ui_url(self.model.project.url)
         return f"{base_url}/projects/{project_id}/models/{model_id}/versions"
+    
+    @property
+    def model_schema(self) -> Optional[ModelSchema]:
+        return self._model_schema
 
     def start(self):
         """

--- a/python/sdk/merlin/model_schema.py
+++ b/python/sdk/merlin/model_schema.py
@@ -81,18 +81,21 @@ class ModelSchema:
                 actual_label_column=prediction_output.actual_label_column,
                 positive_class_label=prediction_output.positive_class_label,
                 negative_class_label=prediction_output.negative_class_label,
-                score_threshold=prediction_output.score_threshold
+                score_threshold=prediction_output.score_threshold,
+                output_class=client.ModelPredictionOutputClass(BinaryClassificationOutput.__name__)
             ))
         elif isinstance(prediction_output, RegressionOutput):
             return client.ModelPredictionOutput(client.RegressionOutput(
                 actual_score_column=prediction_output.actual_score_column,
-                prediction_score_column=prediction_output.prediction_score_column
+                prediction_score_column=prediction_output.prediction_score_column,
+                output_class=client.ModelPredictionOutputClass(RegressionOutput.__name__)
             ))
         elif isinstance(prediction_output, RankingOutput):
             return client.ModelPredictionOutput(client.RankingOutput(
                 relevance_score_column=prediction_output.relevance_score_column,
                 prediction_group_id_column=prediction_output.prediction_group_id_column,
-                rank_score_column=prediction_output.rank_score_column
+                rank_score_column=prediction_output.rank_score_column,
+                output_class=client.ModelPredictionOutputClass(RankingOutput.__name__)
             ))
         
         raise ValueError("model prediction output is not recognized")

--- a/python/sdk/test/integration_test.py
+++ b/python/sdk/test/integration_test.py
@@ -128,7 +128,37 @@ def test_xgboost(
 
     undeploy_all_version()
 
-    with merlin.new_model_version(model_schema=ModelSchema(spec=InferenceSchema(
+    with merlin.new_model_version() as v:
+        # Upload the serialized model to MLP
+        merlin.log_model(model_dir=model_dir)
+
+    endpoint = merlin.deploy(v, deployment_mode=deployment_mode)
+    resp = requests.post(f"{endpoint.url}", json=request_json)
+
+    assert resp.status_code == 200
+    assert resp.json() is not None
+    assert len(resp.json()["predictions"]) == len(request_json["instances"])
+
+    merlin.undeploy(v)
+
+@pytest.mark.integration
+@pytest.mark.dependency()
+@pytest.mark.parametrize(
+    "deployment_mode", [DeploymentMode.RAW_DEPLOYMENT, DeploymentMode.SERVERLESS]
+)
+def test_model_schema(
+    integration_test_url, project_name, deployment_mode, use_google_oauth, requests
+):
+    merlin.set_url(integration_test_url, use_google_oauth=use_google_oauth)
+    merlin.set_project(project_name)
+    merlin.set_model(
+        f"model-schema-{deployment_mode_suffix(deployment_mode)}", ModelType.XGBOOST
+    )
+
+    model_dir = "test/xgboost-model"
+
+    undeploy_all_version()
+    model_schema = ModelSchema(spec=InferenceSchema(
         feature_types={
             "featureA": ValueType.FLOAT64,
             "featureB": ValueType.INT64,
@@ -143,10 +173,14 @@ def test_xgboost(
             negative_class_label="non_complete",
             score_threshold=0.7
         )
-    ))) as v:
+    ))
+
+    with merlin.new_model_version(model_schema=model_schema) as v:
         # Upload the serialized model to MLP
         merlin.log_model(model_dir=model_dir)
 
+    assert v.model_schema == model_schema
+    
     endpoint = merlin.deploy(v, deployment_mode=deployment_mode)
     resp = requests.post(f"{endpoint.url}", json=request_json)
 
@@ -155,6 +189,7 @@ def test_xgboost(
     assert len(resp.json()["predictions"]) == len(request_json["instances"])
 
     merlin.undeploy(v)
+
 
 
 @pytest.mark.integration

--- a/python/sdk/test/integration_test.py
+++ b/python/sdk/test/integration_test.py
@@ -179,7 +179,7 @@ def test_model_schema(
         # Upload the serialized model to MLP
         merlin.log_model(model_dir=model_dir)
 
-    assert v.model_schema == model_schema
+    assert v.model_schema.spec == model_schema.spec
     
     endpoint = merlin.deploy(v, deployment_mode=deployment_mode)
     resp = requests.post(f"{endpoint.url}", json=request_json)

--- a/python/sdk/test/model_schema_test.py
+++ b/python/sdk/test/model_schema_test.py
@@ -26,7 +26,8 @@ from merlin.observability.inference import InferenceSchema, ValueType, BinaryCla
                             actual_label_column="actual_label",
                             positive_class_label="positive",
                             negative_class_label="negative",
-                            score_threshold=0.5
+                            score_threshold=0.5,
+                            output_class=client.ModelPredictionOutputClass.BINARYCLASSIFICATIONOUTPUT
                         )
                     ) 
                 )
@@ -70,7 +71,8 @@ from merlin.observability.inference import InferenceSchema, ValueType, BinaryCla
                     model_prediction_output=client.ModelPredictionOutput(
                         client.RegressionOutput(
                             prediction_score_column="prediction_score",
-                            actual_score_column="actual_score"
+                            actual_score_column="actual_score",
+                            output_class=client.ModelPredictionOutputClass.REGRESSIONOUTPUT
                         )
                     ) 
                 )
@@ -112,7 +114,8 @@ from merlin.observability.inference import InferenceSchema, ValueType, BinaryCla
                         client.RankingOutput(
                             rank_score_column="score",
                             prediction_group_id_column="session_id",
-                            relevance_score_column="relevance_score"
+                            relevance_score_column="relevance_score",
+                            output_class=client.ModelPredictionOutputClass.RANKINGOUTPUT
                         )
                     ) 
                 )

--- a/python/sdk/test/model_test.py
+++ b/python/sdk/test/model_test.py
@@ -1333,7 +1333,8 @@ class TestModel:
                         client.RankingOutput(
                             rank_score_column="score",
                             prediction_group_id_column="session_id",
-                            relevance_score_column="relevance_score"
+                            relevance_score_column="relevance_score",
+                            output_class=client.ModelPredictionOutputClass.RANKINGOUTPUT
                         )
                     ) 
                 )

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1423,6 +1423,7 @@ components:
         - prediction_score_column
         - positive_class_label
         - negative_class_label
+        - output_class
       properties:
         prediction_score_column:
           type: string
@@ -1442,6 +1443,7 @@ components:
       required:
         - rank_score_column
         - prediction_group_id_column
+        - output_class
       properties:
         rank_score_column:
           type: string
@@ -1455,6 +1457,7 @@ components:
       type: object
       required:
         - prediction_score_column
+        - output_class
       properties:
         prediction_score_column:
           type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Previously in this https://github.com/caraml-dev/merlin/pull/518 we introduce CRUD API for model schema, also changed the version schema that aim to update model schema during version creation. While CRUID API is working correctly, create model version with model schema info is not working properly, due to the request body type that is used for the controller is not `Version` but `VersionPost`. Hence this PR try to fix that issue
# Modifications
<!-- Summarize the key code changes. -->
* `api/api/version_api.go` -> Update the model version creation by supplying model schema data from `VersionPost` to `Version`
* `api/models/version.go` -> Including `ModelSchema` field for `VersionPost` and `VersionPatch` struct to supply model schema info during model version creation or patch
*  `python/sdk/merlin/model_schema.py` -> Add `output_class` field to model prediction output
* `python/sdk/test/integration_test.py` -> Add new integration test for model schema
# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
