### PR TITLE
fix: make sure transformer property on version endpoint is not undefined

### DIFF
--- a/python/sdk/merlin/endpoint.py
+++ b/python/sdk/merlin/endpoint.py
@@ -82,6 +82,7 @@ class VersionEndpoint:
                 )
 
             env_vars: Dict[str, str] = {}
+            self._transformer: Optional[Transformer] = None
             if transformer.env_vars is not None:
                 for env_var in transformer.env_vars:
                     if env_var.name is not None and env_var.value is not None:
@@ -97,7 +98,7 @@ class VersionEndpoint:
                 resource_request=transformer_request, 
                 env_vars=env_vars,
             )
-            
+
         if log_url is not None:
             self._log_url = log_url
 
@@ -157,7 +158,7 @@ class VersionEndpoint:
         return self._resource_request
     
     @property
-    def transformer(self) -> Transformer:
+    def transformer(self) -> Optional[Transformer]:
         return self._transformer
     
     @property


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
The "transformer" property could be undefined in the event where transformer is None, because the private property, _transformer is not set in that case.

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug in which transformer property is undefined for model version when there is no transformer found for the end point.
```
