### PR TITLE
fix: Retraining model for PyFunc E2E test

### DIFF
--- a/python/sdk/test/pyfunc_integration_test.py
+++ b/python/sdk/test/pyfunc_integration_test.py
@@ -17,14 +17,16 @@ import warnings
 from test.utils import undeploy_all_version
 
 import joblib
-import merlin
 import numpy as np
 import pytest
 import xgboost as xgb
 from merlin.model import ModelType, PyFuncModel, PyFuncV3Model
 from merlin.pyfunc import ModelInput, ModelOutput, Values
 from merlin.resource_request import ResourceRequest
+from sklearn import svm
 from sklearn.datasets import load_iris
+
+import merlin
 
 warnings.filterwarnings("ignore")
 
@@ -88,6 +90,35 @@ class ModelObservabilityModel(PyFuncV3Model):
         return {"predictions": model_output.predictions.data}
 
 
+def train_xgboost_model(X, y):
+    model_1_dir = "test/pyfunc/"
+    BST_FILE = "model_1.bst"
+    dtrain = xgb.DMatrix(X, label=y)
+    param = {
+        "max_depth": 6,
+        "eta": 0.1,
+        "silent": 1,
+        "nthread": 4,
+        "num_class": 3,
+        "objective": "multi:softprob",
+    }
+    xgb_model = xgb.train(params=param, dtrain=dtrain)
+    model_1_path = os.path.join(model_1_dir, BST_FILE)
+    xgb_model.save_model(model_1_path)
+    return model_1_path
+
+
+def train_sklearn_model(X, y):
+    model_2_dir = "test/pyfunc/"
+    MODEL_FILE = "model_2.joblib"
+    model_2_path = os.path.join(model_2_dir, MODEL_FILE)
+
+    clf = svm.SVC(gamma="scale", probability=True)
+    clf.fit(X, y)
+    joblib.dump(clf, model_2_path)
+    return model_2_path
+
+
 @pytest.mark.pyfunc
 @pytest.mark.integration
 @pytest.mark.dependency()
@@ -98,11 +129,16 @@ def test_pyfunc(integration_test_url, project_name, use_google_oauth, requests):
 
     undeploy_all_version()
     with merlin.new_model_version() as v:
+        iris = load_iris()
+        y = iris["target"]
+        X = iris["data"]
+        xgb_path = train_xgboost_model(X, y)
+        sklearn_path = train_sklearn_model(X, y)
         v.log_pyfunc_model(
             model_instance=EnsembleModel(),
             conda_env="test/pyfunc/env.yaml",
             code_dir=["test"],
-            artifacts={"xgb_model": XGB_PATH, "sklearn_model": SKLEARN_PATH},
+            artifacts={"xgb_model": xgb_path, "sklearn_model": sklearn_path},
         )
 
     endpoint = merlin.deploy(v)
@@ -128,11 +164,16 @@ def test_pyfunc_image_builder_resource_request(
 
     undeploy_all_version()
     with merlin.new_model_version() as v:
+        iris = load_iris()
+        y = iris["target"]
+        X = iris["data"]
+        xgb_path = train_xgboost_model(X, y)
+        sklearn_path = train_sklearn_model(X, y)
         v.log_pyfunc_model(
             model_instance=EnsembleModel(),
             conda_env="test/pyfunc/env.yaml",
             code_dir=["test"],
-            artifacts={"xgb_model": XGB_PATH, "sklearn_model": SKLEARN_PATH},
+            artifacts={"xgb_model": xgb_path, "sklearn_model": sklearn_path},
         )
 
     image_builder_resource_request = ResourceRequest(
@@ -196,15 +237,17 @@ def test_pyfunc_model_observability(
     undeploy_all_version()
     with merlin.new_model_version() as v:
         iris = load_iris()
-        y = iris['target']
-        X = iris['data']
+        y = iris["target"]
+        X = iris["data"]
+        xgb_path = train_xgboost_model(X, y)
 
-        v.log_pyfunc_model(model_instance=ModelObservabilityModel(),
-                           conda_env="test/pyfunc/env.yaml",
-                           code_dir=["test"],
-                           artifacts={"xgb_model": XGB_PATH})
+        v.log_pyfunc_model(
+            model_instance=ModelObservabilityModel(),
+            conda_env="test/pyfunc/env.yaml",
+            code_dir=["test"],
+            artifacts={"xgb_model": xgb_path},
+        )
 
-    
     endpoint = merlin.deploy(v, enable_model_observability=True)
 
     resp = requests.post(f"{endpoint.url}", json=request_json)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Currently PyFunc E2E test is using pre-built model artifact, this will running fine when the dependency used for the model artifact is the same with the server. In scenario where dependency is different between artifact and the server, the artifact load will be failed in the PyFunc server, hence we need to retraining the model and using the output of that as artifact for PyFunc server in E2E script

# Modifications
<!-- Summarize the key code changes. -->
Retraining xgboost and sklearn model 

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
