### PR TITLE
fix: Add protocol default value for version and model endpoints & relax supported enum in OpenAPI

### DIFF
--- a/db-migrations/37_update_protocol_default.down.sql
+++ b/db-migrations/37_update_protocol_default.down.sql
@@ -1,0 +1,1 @@
+-- Do nothing

--- a/db-migrations/37_update_protocol_default.up.sql
+++ b/db-migrations/37_update_protocol_default.up.sql
@@ -1,0 +1,12 @@
+-- Updating default protocol for version endpoints
+update 
+    version_endpoints
+set protocol = 'HTTP_JSON'
+where protocol is null or protocol = '';
+
+
+-- Updating default protocol for model endpoints
+update 
+    model_endpoints
+set protocol = 'HTTP_JSON'
+where protocol is null or protocol = '';

--- a/python/sdk/client/models/deployment_mode.py
+++ b/python/sdk/client/models/deployment_mode.py
@@ -36,6 +36,7 @@ class DeploymentMode(str, Enum):
     """
     SERVERLESS = 'serverless'
     RAW_DEPLOYMENT = 'raw_deployment'
+    EMPTY = ''
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/python/sdk/client/models/protocol.py
+++ b/python/sdk/client/models/protocol.py
@@ -36,6 +36,7 @@ class Protocol(str, Enum):
     """
     HTTP_JSON = 'HTTP_JSON'
     UPI_V1 = 'UPI_V1'
+    EMPTY = ''
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1844,6 +1844,7 @@ components:
       enum:
       - serverless
       - raw_deployment
+      - ""
     Container:
       type: object
       properties:
@@ -2216,6 +2217,7 @@ components:
       enum:
       - HTTP_JSON
       - UPI_V1
+      - ""
   securitySchemes:
     Bearer:
       type: apiKey


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Version endpoints and model endpoints that are deployed before `protocol` is introduced will have empty string or `null` value. This will be a problem when new SDK is published, the new SDK has strict validation regarding the enum value and type of each response from server. For empty string value of protocol in old model(version) endpoints, the new SDK will return error since the acceptable value for protocol is `UPI_V1` and `HTTP_JSON`, hence this PR will add default value for protocol to reduce this issue arise in the future.

Also this PR will relax the enum for `DeploymentMode` and `Protocol` so it can accept empty string as enum value. This is to reduce chances error during deserialize model API response that containing model endpoints rule that has version_endpoints data with empty protocol or deployment mode. Modifying model endpoint rule by using sql will require complex jsonb query hence for now we just relax the enum value
# Modifications
<!-- Summarize the key code changes. -->
Add database script to update protocol default value for model_endpoints and version_endpoints
# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
