### PR TITLE
feat: reuse the same bigquery table for multiple model versions for Arize BQ Sink

### DIFF
--- a/python/observation-publisher/Makefile
+++ b/python/observation-publisher/Makefile
@@ -14,7 +14,12 @@ pip-compile:
 .PHONY: test
 test:
 	@echo "Running tests..."
-	@python -m pytest
+	@python -m pytest -m "not integration"
+
+.PHONY: test-integration
+integration-test:
+	@echo "Running integration tests..."
+	@python -m pytest -m "integration"
 
 .PHONY: run
 run:

--- a/python/observation-publisher/publisher/__main__.py
+++ b/python/observation-publisher/publisher/__main__.py
@@ -35,6 +35,7 @@ def start_consumer(cfg: PublisherConfig) -> None:
     prediction_log_consumer.start_polling(
         observation_sinks=observation_sinks,
         inference_schema=inference_schema,
+        model_version=cfg.environment.model_version,
     )
 
 

--- a/python/observation-publisher/publisher/metric.py
+++ b/python/observation-publisher/publisher/metric.py
@@ -1,5 +1,5 @@
 from pandas import Timestamp
-from prometheus_client import Gauge, Counter
+from prometheus_client import Counter, Gauge
 
 
 class MetricWriter(object):
@@ -21,6 +21,7 @@ class MetricWriter(object):
             self.total_prediction_logs_processed_counter = Counter(
                 "total_prediction_logs_processed",
                 "The total number of prediction logs processed by the publisher",
+                ["model_id", "model_version"],
             )
             self._initialized = True
 

--- a/python/observation-publisher/publisher/prediction_log_parser.py
+++ b/python/observation-publisher/publisher/prediction_log_parser.py
@@ -7,7 +7,10 @@ from google.protobuf.internal.well_known_types import ListValue, Struct
 from merlin.observability.inference import InferenceSchema, ValueType
 from typing_extensions import Self
 
+SESSION_ID_COLUMN = "session_id"
+ROW_ID_COLUMN = "row_id"
 PREDICTION_LOG_TIMESTAMP_COLUMN = "request_timestamp"
+MODEL_VERSION_COLUMN = "model_version"
 
 
 @dataclass

--- a/python/observation-publisher/pyproject.toml
+++ b/python/observation-publisher/pyproject.toml
@@ -2,6 +2,9 @@
 addopts = [
     "--import-mode=importlib",
 ]
+markers = [
+    "integration: mark a test as integration test"
+]
 
 [tool.mypy]
 exclude = "test.*"

--- a/python/observation-publisher/requirements-dev.txt
+++ b/python/observation-publisher/requirements-dev.txt
@@ -5,3 +5,4 @@ types-PyYAML==6.0.12.12
 types-jmespath==1.0.2.7
 mypy==1.7.1
 mypy-extensions==1.0.0
+db-dtypes==1.2.0

--- a/python/observation-publisher/requirements.in
+++ b/python/observation-publisher/requirements.in
@@ -1,6 +1,6 @@
 confluent-kafka>=2.3.0
 caraml-upi-protos>=1.0.0
-arize==7.7.*
+arize>=7.7.0
 hydra-core>=1.3.0
 pandas>=1.0.0
 google-cloud-bigquery

--- a/python/observation-publisher/requirements.txt
+++ b/python/observation-publisher/requirements.txt
@@ -8,6 +8,8 @@
     # via -r requirements.in
 alembic==1.13.0
     # via mlflow
+annotated-types==0.6.0
+    # via pydantic
 antlr4-python3-runtime==4.9.3
     # via
     #   hydra-core
@@ -74,7 +76,9 @@ flask==2.3.3
 gitdb==4.0.11
     # via gitpython
 gitpython==3.1.40
-    # via mlflow
+    # via
+    #   merlin-sdk
+    #   mlflow
 google-api-core==2.15.0
     # via
     #   google-cloud-bigquery
@@ -191,6 +195,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
+pydantic==2.5.3
+    # via merlin-sdk
+pydantic-core==2.14.6
+    # via pydantic
 pygments==2.17.2
     # via rich
 pyjwt==2.8.0
@@ -266,6 +274,8 @@ typing-extensions==4.9.0
     # via
     #   -r requirements.in
     #   alembic
+    #   pydantic
+    #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json

--- a/python/observation-publisher/tests/common_fixtures.py
+++ b/python/observation-publisher/tests/common_fixtures.py
@@ -1,0 +1,13 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def bq_project() -> str:
+    return os.environ.get("INTEGRATION_TEST_BQ_PROJECT")
+
+
+@pytest.fixture
+def bq_dataset() -> str:
+    return os.environ.get("INTEGRATION_TEST_BQ_DATASET")

--- a/python/observation-publisher/tests/test_config.py
+++ b/python/observation-publisher/tests/test_config.py
@@ -4,14 +4,9 @@ from hydra import compose, initialize
 from merlin.observability.inference import InferenceSchema, ValueType
 from omegaconf import OmegaConf
 
-from publisher.config import (
-    Environment,
-    ObservationSinkConfig,
-    ObservationSinkType,
-    ObservationSource,
-    ObservationSourceConfig,
-    PublisherConfig,
-)
+from publisher.config import (Environment, ObservationSinkConfig,
+                              ObservationSinkType, ObservationSource,
+                              ObservationSourceConfig, PublisherConfig)
 
 
 def test_config_initialization():

--- a/python/observation-publisher/tests/test_observation_sink.py
+++ b/python/observation-publisher/tests/test_observation_sink.py
@@ -1,18 +1,79 @@
+import dataclasses
+import time
 from datetime import datetime
 from typing import Optional
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 from arize.pandas.logger import Client
-from merlin.observability.inference import (
-    BinaryClassificationOutput,
-    InferenceSchema,
-    RankingOutput,
-    ValueType,
-)
+from dateutil import tz
+from google.cloud.bigquery import Client as BigQueryClient
+from google.cloud.bigquery import SchemaField
+from merlin.observability.inference import (BinaryClassificationOutput,
+                                            InferenceSchema, RankingOutput,
+                                            ValueType)
+from pandas._testing import assert_frame_equal
 from requests import Response
 
-from publisher.observation_sink import ArizeSink
+from publisher.observation_sink import (ArizeSink, BigQueryConfig,
+                                        BigQueryRetryConfig, BigQuerySink)
+from tests.common_fixtures import bq_dataset, bq_project
+
+
+@pytest.fixture
+def binary_classification_inference_schema() -> InferenceSchema:
+    return InferenceSchema(
+        feature_types={
+            "rating": ValueType.FLOAT64,
+        },
+        model_prediction_output=BinaryClassificationOutput(
+            prediction_score_column="prediction_score",
+            actual_label_column="actual_label",
+            positive_class_label="fraud",
+            negative_class_label="non fraud",
+            score_threshold=0.5,
+        ),
+    )
+
+
+@pytest.fixture
+def binary_classification_inference_logs() -> pd.DataFrame:
+    request_timestamp = datetime(2024, 1, 1, 0, 0, 0).astimezone(tz.UTC)
+    return pd.DataFrame.from_records(
+        [
+            [0.8, 0.4, "1234", "a", request_timestamp, "0.1.0", "non fraud"],
+            [0.5, 0.9, "1234", "b", request_timestamp, "0.1.0", "fraud"],
+        ],
+        columns=[
+            "rating",
+            "prediction_score",
+            "session_id",
+            "row_id",
+            "request_timestamp",
+            "model_version",
+            "_prediction_label",
+        ],
+    )
+
+
+@pytest.fixture
+def ranking_inference_logs() -> pd.DataFrame:
+    request_timestamp = datetime(2024, 1, 1, 0, 0, 0).astimezone(tz.UTC)
+    return pd.DataFrame.from_records(
+        [
+            [5.0, 1.0, "1234", "1001", request_timestamp],
+            [4.0, 0.9, "1234", "1002", request_timestamp],
+            [3.0, 0.8, "1234", "1003", request_timestamp],
+        ],
+        columns=[
+            "rating",
+            "rank_score",
+            "session_id",
+            "row_id",
+            "request_timestamp",
+        ],
+    )
 
 
 class MockResponse(Response):
@@ -36,43 +97,24 @@ class MockArizeClient(Client):
         )
 
 
-def test_binary_classification_model_preprocessing_for_arize():
-    inference_schema = InferenceSchema(
-        feature_types={
-            "rating": ValueType.FLOAT64,
-        },
-        model_prediction_output=BinaryClassificationOutput(
-            prediction_score_column="prediction_score",
-            actual_label_column="actual_label",
-            positive_class_label="fraud",
-            negative_class_label="non fraud",
-            score_threshold=0.5,
-        ),
-    )
+def test_binary_classification_model_preprocessing_for_arize(
+    binary_classification_inference_schema: InferenceSchema,
+    binary_classification_inference_logs: pd.DataFrame,
+):
     arize_client = MockArizeClient(api_key="test", space_key="test")
     arize_sink = ArizeSink(
-        inference_schema,
+        binary_classification_inference_schema,
         "test-model",
         "0.1.0",
         arize_client,
     )
-    request_timestamp = datetime.now()
-    input_df = pd.DataFrame.from_records(
-        [
-            [0.8, 0.4, "1234a", request_timestamp],
-            [0.5, 0.9, "1234b", request_timestamp],
-        ],
-        columns=[
-            "rating",
-            "prediction_score",
-            "prediction_id",
-            "request_timestamp",
-        ],
-    )
-    arize_sink.write(input_df)
+    arize_sink.write(binary_classification_inference_logs)
 
 
-def test_ranking_model_preprocessing_for_arize():
+def test_ranking_model_preprocessing_for_arize(
+    binary_classification_inference_logs: pd.DataFrame,
+    ranking_inference_logs: pd.DataFrame,
+):
     inference_schema = InferenceSchema(
         feature_types={
             "rating": ValueType.FLOAT64,
@@ -83,21 +125,6 @@ def test_ranking_model_preprocessing_for_arize():
             relevance_score_column="relevance_score_column",
         ),
     )
-    request_timestamp = datetime.now()
-    input_df = pd.DataFrame.from_records(
-        [
-            [5.0, 1.0, "1234", "1001", request_timestamp],
-            [4.0, 0.9, "1234", "1001", request_timestamp],
-            [3.0, 0.8, "1234", "1001", request_timestamp],
-        ],
-        columns=[
-            "rating",
-            "rank_score",
-            "prediction_id",
-            "order_id",
-            "request_timestamp",
-        ],
-    )
     arize_client = MockArizeClient(api_key="test", space_key="test")
     arize_sink = ArizeSink(
         inference_schema,
@@ -105,4 +132,105 @@ def test_ranking_model_preprocessing_for_arize():
         "0.1.0",
         arize_client,
     )
-    arize_sink.write(input_df)
+    arize_sink.write(ranking_inference_logs)
+
+
+@pytest.mark.integration
+def test_bigquery_sink_schema_migration(
+    bq_project: str,
+    bq_dataset: str,
+    binary_classification_inference_schema: InferenceSchema,
+    binary_classification_inference_logs: pd.DataFrame,
+):
+    client = BigQueryClient()
+    client.delete_table(
+        f"{bq_project}.{bq_dataset}.prediction_log_test_model", not_found_ok=True
+    )
+    bq_sink = BigQuerySink(
+        binary_classification_inference_schema,
+        "test-model",
+        "0.1.0",
+        config=BigQueryConfig(
+            project=bq_project,
+            dataset=bq_dataset,
+            ttl_days=14,
+            retry=BigQueryRetryConfig(
+                enabled=True, retry_attempts=3, retry_interval_seconds=10
+            ),
+        ),
+    )
+    bq_sink.write(binary_classification_inference_logs)
+    migrated_schema = dataclasses.replace(binary_classification_inference_schema)
+    migrated_schema.feature_types = {
+        "rating_v2": ValueType.FLOAT64,
+    }
+    migrated_bq_sink = BigQuerySink(
+        migrated_schema,
+        "test-model",
+        "0.2.0",
+        config=BigQueryConfig(
+            project=bq_project,
+            dataset=bq_dataset,
+            ttl_days=14,
+            retry=BigQueryRetryConfig(
+                enabled=True, retry_attempts=5, retry_interval_seconds=30
+            ),
+        ),
+    )
+    migrated_inference_logs = binary_classification_inference_logs.rename(
+        columns={"rating": "rating_v2"}
+    )
+    migrated_inference_logs["model_version"] = "0.2.0"
+    migrated_bq_sink.write(migrated_inference_logs)
+    version_update_bq_sink = BigQuerySink(
+        migrated_schema,
+        "test-model",
+        "0.3.0",
+        config=BigQueryConfig(
+            project=bq_project,
+            dataset=bq_dataset,
+            ttl_days=14,
+        ),
+    )
+    version_update_inference_logs = migrated_inference_logs.copy()
+    version_update_inference_logs["model_version"] = "0.3.0"
+    version_update_bq_sink.write(version_update_inference_logs)
+
+    table = client.get_table(f"{bq_project}.{bq_dataset}.prediction_log_test_model")
+    assert table.schema == [
+        SchemaField(name="session_id", field_type="STRING"),
+        SchemaField(name="row_id", field_type="STRING"),
+        SchemaField(name="request_timestamp", field_type="TIMESTAMP"),
+        SchemaField(name="model_version", field_type="STRING"),
+        SchemaField(name="rating", field_type="FLOAT"),
+        SchemaField(name="prediction_score", field_type="FLOAT"),
+        SchemaField(name="_prediction_label", field_type="STRING"),
+        SchemaField(name="rating_v2", field_type="FLOAT"),
+    ]
+    df = client.query(
+        "SELECT * FROM `{}.{}.prediction_log_test_model`".format(bq_project, bq_dataset)
+    ).to_dataframe()
+    df.reset_index(drop=True, inplace=True)
+    event_timestamp = datetime(2024, 1, 1, 0, 0, 0).astimezone(tz.UTC)
+    expected_df = pd.DataFrame.from_records(
+        [
+            [0.8, 0.4, "1234", "a", event_timestamp, "0.1.0", "non fraud", None],
+            [0.5, 0.9, "1234", "b", event_timestamp, "0.1.0", "fraud", None],
+            [None, 0.4, "1234", "a", event_timestamp, "0.2.0", "non fraud", 0.8],
+            [None, 0.9, "1234", "b", event_timestamp, "0.2.0", "fraud", 0.5],
+            [None, 0.4, "1234", "a", event_timestamp, "0.3.0", "non fraud", 0.8],
+            [None, 0.9, "1234", "b", event_timestamp, "0.3.0", "fraud", 0.5],
+        ],
+        columns=[
+            "rating",
+            "prediction_score",
+            "session_id",
+            "row_id",
+            "request_timestamp",
+            "model_version",
+            "_prediction_label",
+            "rating_v2",
+        ],
+    )
+    expected_df.reset_index(drop=True, inplace=True)
+    assert_frame_equal(df, expected_df, check_like=True)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
The current sink create a new bigquery table per model version. This makes it harder to implement Arize ground truth ingestion, because the ground truth provided by the users are typically model version agnostic.

# Modifications
<!-- Summarize the key code changes. -->
- A single table will be used per model id, rather than model version
- A new column, model_version, is added.
- session id and row id are used in favor of prediction id as the concept of prediction id in Arize differs from Merlin

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
