### PR TITLE
preload pyfunc v2 model to avoid pydantic schema generation error

### DIFF
--- a/python/batch-predictor/main.py
+++ b/python/batch-predictor/main.py
@@ -26,6 +26,9 @@ from merlinpyspark.sink import create_sink
 from pyspark import SparkConf, SparkContext
 from pyspark.sql import SparkSession
 
+# Import the classes so that Pydantic can cache the schema. See https://github.com/caraml-dev/merlin/pull/535
+from merlin.model import PyFuncModel, PyFuncV2Model, PyFuncV3Model
+
 try:
     import pyspark
 except ImportError:

--- a/python/pyfunc-server/pyfuncserver/model/model.py
+++ b/python/pyfunc-server/pyfuncserver/model/model.py
@@ -17,6 +17,8 @@ from enum import Enum
 
 import grpc
 from caraml.upi.v1 import upi_pb2
+# Import the classes so that Pydantic can cache the schema. See https://github.com/caraml-dev/merlin/pull/535
+from merlin.model import PyFuncModel as MerlinPyFuncModel, PyFuncV2Model as MerlinPyFuncV2Model, PyFuncV3Model as MerlinPyfuncV3Model
 from merlin.protocol import Protocol
 from merlin.pyfunc import PYFUNC_EXTRA_ARGS_KEY, PYFUNC_GRPC_CONTEXT, PYFUNC_MODEL_INPUT_KEY, PYFUNC_PROTOCOL_KEY, PyFuncOutput
 from mlflow import pyfunc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Due to a bug that was resolved in https://github.com/mlflow/mlflow/pull/8722/files , the current version of Mlflow used by Merlin can potentially introduce some side effect by removing package from sys.modules.

One such side effect occurs when the user's Mlflow Pyfunc code happens to contain a subdirectory named `typing` . When appending the Pyfunc code to sys.path, Mlflow also unintentionally remove the `typing` standard module due to name clash, which clear some module level cache.

We have recently migrated from swagger to OpenAPI for code generation, and as a result, the Merlin Pyfunc model (in merlin.model) is now based on Pydantic model. The removal of `typing` standard module from sys.modules affect pydantic ability to resolve some field types correctly, which results in schema generation error.

Ideally, we should upgrade Mlflow version to resolve this. But the fix is only introduce is version >2.0, which makes migration difficult. Hence, the alternative is to import Merlin pyfunc model prior to calling pyfunc.load_model. Importing the Pyfunc model allows pydantic to cache the schema for the class, which allows Pyfunc model to be instantiated correctly even though the `typing` modules is removed from sys.modules.

# Modifications
<!-- Summarize the key code changes. -->
Import Pyfunc models prior to calling pyfunc.load_model.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
