### PR TITLE
bug: fix json field typo for ranking output

### DIFF
--- a/api/api/model_schema_api_test.go
+++ b/api/api/model_schema_api_test.go
@@ -62,7 +62,7 @@ func TestModelSchemaController_GetAllSchemas(t *testing.T) {
 							},
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 								},
@@ -108,7 +108,7 @@ func TestModelSchemaController_GetAllSchemas(t *testing.T) {
 							},
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 								},
@@ -296,7 +296,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 					"model_prediction_output": {
 						"prediction_group_id_column": "session_id",
 						"rank_score_column": "score",
-						"relevance_score": "relevance_score",
+						"relevance_score_column": "relevance_score",
 						"output_class": "RankingOutput"
 					}
 				}
@@ -315,7 +315,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -335,7 +335,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -360,7 +360,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -387,7 +387,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 					"model_prediction_output": {
 						"prediction_group_id_column": "session_id",
 						"rank_score_column": "score",
-						"relevance_score": "relevance_score",
+						"relevance_score_column": "relevance_score",
 						"output_class": "RankingOutput"
 					}
 				},
@@ -407,7 +407,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -427,7 +427,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -452,7 +452,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -665,7 +665,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 					"model_prediction_output": {
 						"prediction_group_id_column": "session_id",
 						"rank_score_column": "score",
-						"relevance_score": "relevance_score",
+						"relevance_score_column": "relevance_score",
 						"output_class": "RankingOutput"
 					}
 				}
@@ -684,7 +684,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -716,7 +716,7 @@ func TestModelSchemaController_CreateOrUpdateSchema(t *testing.T) {
 					"model_prediction_output": {
 						"prediction_group_id_column": "session_id",
 						"rank_score_column": "score",
-						"relevance_score": "relevance_score",
+						"relevance_score_column": "relevance_score",
 						"output_class": "RankingOutput"
 					}
 				},

--- a/api/api/versions_api_test.go
+++ b/api/api/versions_api_test.go
@@ -724,7 +724,7 @@ func TestPatchVersion(t *testing.T) {
 						PredictionIDColumn: "prediction_id",
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -778,7 +778,7 @@ func TestPatchVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -814,7 +814,7 @@ func TestPatchVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -855,7 +855,7 @@ func TestPatchVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -888,7 +888,7 @@ func TestPatchVersion(t *testing.T) {
 						PredictionIDColumn: "prediction_id",
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -1448,7 +1448,7 @@ func TestCreateVersion(t *testing.T) {
 						PredictionIDColumn: "prediction_id",
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,
@@ -1501,7 +1501,7 @@ func TestCreateVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -1534,7 +1534,7 @@ func TestCreateVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -1572,7 +1572,7 @@ func TestCreateVersion(t *testing.T) {
 							PredictionIDColumn: "prediction_id",
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 									OutputClass:             models.Ranking,
@@ -1600,7 +1600,7 @@ func TestCreateVersion(t *testing.T) {
 						PredictionIDColumn: "prediction_id",
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 								OutputClass:             models.Ranking,

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -241,7 +241,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 				},
 				ModelPredictionOutput: &models.ModelPredictionOutput{
 					RankingOutput: &models.RankingOutput{
-						PredictionGroudIDColumn: "session_id",
+						PredictionGroupIDColumn: "session_id",
 						RankScoreColumn:         "score",
 						RelevanceScoreColumn:    "relevance_score",
 					},
@@ -868,7 +868,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 							},

--- a/api/models/model_schema.go
+++ b/api/models/model_schema.go
@@ -126,9 +126,9 @@ type BinaryClassificationOutput struct {
 }
 
 type RankingOutput struct {
-	PredictionGroudIDColumn string                     `json:"prediction_group_id_column"`
+	PredictionGroupIDColumn string                     `json:"prediction_group_id_column"`
 	RankScoreColumn         string                     `json:"rank_score_column"`
-	RelevanceScoreColumn    string                     `json:"relevance_score"`
+	RelevanceScoreColumn    string                     `json:"relevance_score_column"`
 	OutputClass             ModelPredictionOutputClass `json:"output_class" validate:"required"`
 }
 

--- a/api/service/model_schema_service_test.go
+++ b/api/service/model_schema_service_test.go
@@ -66,7 +66,7 @@ func Test_modelSchemaService_List(t *testing.T) {
 							},
 							ModelPredictionOutput: &models.ModelPredictionOutput{
 								RankingOutput: &models.RankingOutput{
-									PredictionGroudIDColumn: "session_id",
+									PredictionGroupIDColumn: "session_id",
 									RankScoreColumn:         "score",
 									RelevanceScoreColumn:    "relevance_score",
 								},
@@ -114,7 +114,7 @@ func Test_modelSchemaService_List(t *testing.T) {
 						},
 						ModelPredictionOutput: &models.ModelPredictionOutput{
 							RankingOutput: &models.RankingOutput{
-								PredictionGroudIDColumn: "session_id",
+								PredictionGroupIDColumn: "session_id",
 								RankScoreColumn:         "score",
 								RelevanceScoreColumn:    "relevance_score",
 							},

--- a/api/storage/model_schema_storage_test.go
+++ b/api/storage/model_schema_storage_test.go
@@ -69,7 +69,7 @@ func Test_modelSchemaStorage_Save(t *testing.T) {
 
 		schema.Spec.ModelPredictionOutput = &models.ModelPredictionOutput{
 			RankingOutput: &models.RankingOutput{
-				PredictionGroudIDColumn: "session_id",
+				PredictionGroupIDColumn: "session_id",
 				RankScoreColumn:         "score",
 				RelevanceScoreColumn:    "relevance_score",
 				OutputClass:             models.Ranking,
@@ -81,7 +81,7 @@ func Test_modelSchemaStorage_Save(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, newSchema.Spec.ModelPredictionOutput, &models.ModelPredictionOutput{
 			RankingOutput: &models.RankingOutput{
-				PredictionGroudIDColumn: "session_id",
+				PredictionGroupIDColumn: "session_id",
 				RankScoreColumn:         "score",
 				RelevanceScoreColumn:    "relevance_score",
 				OutputClass:             models.Ranking,
@@ -239,7 +239,7 @@ func Test_modelSchemaStorage_FindAll_Delete(t *testing.T) {
 					},
 					ModelPredictionOutput: &models.ModelPredictionOutput{
 						RankingOutput: &models.RankingOutput{
-							PredictionGroudIDColumn: "session_id",
+							PredictionGroupIDColumn: "session_id",
 							RankScoreColumn:         "score",
 							RelevanceScoreColumn:    "relevance_score",
 							OutputClass:             models.Ranking,
@@ -344,7 +344,7 @@ func Test_modelSchemaStorage_FindByID(t *testing.T) {
 
 		schema.Spec.ModelPredictionOutput = &models.ModelPredictionOutput{
 			RankingOutput: &models.RankingOutput{
-				PredictionGroudIDColumn: "session_id",
+				PredictionGroupIDColumn: "session_id",
 				RankScoreColumn:         "score",
 				RelevanceScoreColumn:    "relevance_score",
 				OutputClass:             models.Ranking,
@@ -356,7 +356,7 @@ func Test_modelSchemaStorage_FindByID(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, newSchema.Spec.ModelPredictionOutput, &models.ModelPredictionOutput{
 			RankingOutput: &models.RankingOutput{
-				PredictionGroudIDColumn: "session_id",
+				PredictionGroupIDColumn: "session_id",
 				RankScoreColumn:         "score",
 				RelevanceScoreColumn:    "relevance_score",
 				OutputClass:             models.Ranking,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
There's a typo in the json field annotation, which makes it not possible to deploy model with ranking output schema.

Additional changes: fix a typo for the RankingOutput fields

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
