### PR TITLE
Draft: bug: fix pydantic error for batch prediction job executor

### DIFF
--- a/python/batch-predictor/merlinpyspark/model.py
+++ b/python/batch-predictor/merlinpyspark/model.py
@@ -14,6 +14,8 @@
 
 import numpy as np
 import pandas
+# Import the classes so that Pydantic can cache the schema. See https://github.com/caraml-dev/merlin/pull/535
+from merlin.model import PyFuncModel, PyFuncV2Model, PyFuncV3Model
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 from pyspark.sql import SparkSession

--- a/python/batch-predictor/merlinpyspark/sink.py
+++ b/python/batch-predictor/merlinpyspark/sink.py
@@ -16,6 +16,8 @@ from abc import ABC, abstractmethod
 
 from pyspark.sql import DataFrame
 
+# Import the classes so that Pydantic can cache the schema. See https://github.com/caraml-dev/merlin/pull/535
+from merlin.model import PyFuncModel, PyFuncV2Model, PyFuncV3Model
 from merlinpyspark.config import SinkConfig, BigQuerySinkConfig
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
In https://github.com/caraml-dev/merlin/pull/535 , we fixed the issue with pydantic schema generation by preloading the Pyfunc model classes. This was done for the driver script for batch prediction job and the start up script for real time Pyfunc model, but did not include merlinpyspark/model.py, which is called within the spark executor.

# Modifications
<!-- Summarize the key code changes. -->
Preload the pyfunc model for merlinpyspark/model.py

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
