### PR TITLE
feat(api): Expose tolerations and node selectors for batch jobs

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -472,6 +472,13 @@ jobs:
         run: ./deploy-merlin.sh ${{ env.INGRESS_HOST }} ${{ env.LOCAL_REGISTRY }}:${{ env.LOCAL_REGISTRY_PORT }} ${{ needs.create-version.outputs.version }} ${{ github.ref }} ${{ env.MERLIN_CHART_VERSION }}
       - name: Prune docker system to make some space
         run: docker system prune --all --force
+        # This step is needed to free up around 24GiB of storage on the GitHub runner to allow the e2e tests to pass
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this will remove tools that are actually needed (like Python, which is needed),
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
       - name: Print space consumption
         run: sudo df -h
       - name: Run E2E Test

--- a/api/batch/resource_test.go
+++ b/api/batch/resource_test.go
@@ -120,6 +120,17 @@ var (
 			Value: envServiceAccountPath,
 		},
 	}
+
+	defaultToleration = v12.Toleration{
+		Key:      "batch-job",
+		Operator: v12.TolerationOpEqual,
+		Value:    "true",
+		Effect:   v12.TaintEffectNoSchedule,
+	}
+
+	defaultNodeSelector = map[string]string{
+		"node-workload-type": "batch",
+	}
 )
 
 func TestCreateSparkApplicationResource(t *testing.T) {
@@ -643,7 +654,7 @@ func TestCreateSparkApplicationResource(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			sp, err := CreateSparkApplicationResource(test.arg)
+			sp, err := testBatchJobTemplater.CreateSparkApplicationResource(test.arg)
 			if test.wantErr {
 				assert.Equal(t, test.wantErrMessage, err.Error())
 				return

--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -396,7 +396,10 @@ func initBatchControllers(cfg *config.Config, db *gorm.DB, mlpAPIClient mlp.APIC
 			GcpProject:  env.GcpProject,
 		}
 
-		ctl := batch.NewController(predictionJobStorage, mlpAPIClient, sparkClient, kubeClient, manifestManager, envMetadata)
+		batchJobTemplator := batch.NewBatchJobTemplater(cfg.BatchConfig)
+
+		ctl := batch.NewController(predictionJobStorage, mlpAPIClient, sparkClient, kubeClient, manifestManager,
+			envMetadata, batchJobTemplator)
 		stopCh := make(chan struct{})
 		go ctl.Run(stopCh)
 

--- a/api/config/batch.go
+++ b/api/config/batch.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Merlin Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+type BatchConfig struct {
+	// Tolerations for Jobs Specification
+	Tolerations []v1.Toleration
+	// Node Selectors for Jobs Specification
+	NodeSelectors map[string]string
+}

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	DbConfig                  DatabaseConfig     `validate:"required"`
 	ClusterConfig             ClusterConfig      `validate:"required"`
 	ImageBuilderConfig        ImageBuilderConfig `validate:"required"`
+	BatchConfig               BatchConfig
 	AuthorizationConfig       AuthorizationConfig
 	MlpAPIConfig              MlpAPIConfig `validate:"required"`
 	FeatureToggleConfig       FeatureToggleConfig

--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,15 @@ ImageBuilderConfig:
     - "--snapshot-mode=redo"
     - "--use-new-run"
 
+BatchConfig:
+  Tolerations:
+    - Effect: NoSchedule
+      Key: batch-job
+      Operator: Equal
+      Value: "true"
+  NodeSelectors:
+    node-workload-type: "batch"
+
 AuthorizationConfig:
   AuthorizationEnabled: false
 

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -33,4 +33,4 @@ kubectl create namespace ${E2E_PROJECT_NAME} --dry-run=client -o yaml | kubectl 
 cd ../../python/sdk
 pip install pipenv==2023.7.23
 pipenv install --dev --skip-lock --python ${PYTHON_VERSION}
-pipenv run pytest -n=1 -W=ignore --cov=merlin -m "not (gpu or feast or batch or pyfunc or local_server_test or cli or customtransformer)" --durations=0
+pipenv run pytest -n=4 -W=ignore --cov=merlin -m "not (gpu or feast or batch or pyfunc or local_server_test or cli or customtransformer)" --durations=0

--- a/scripts/e2e/values-e2e.yaml
+++ b/scripts/e2e/values-e2e.yaml
@@ -15,6 +15,14 @@ config:
     EncryptionKey: password
   StandardTransformerConfig:
     ImageName: ghcr.io/caraml-dev/merlin-transformer:0.31.3
+  BatchConfig:
+    Tolerations:
+      - Effect: NoSchedule
+        Key: batch-job
+        Operator: Equal
+        Value: "true"
+    NodeSelectors:
+      node-workload-type: "batch"
   AuthorizationConfig:
     AuthorizationEnabled: false
 imageBuilder:


### PR DESCRIPTION
# Description
This PR introduces changes to expose tolerations and node selectors that can be configured for batch jobs. Previously, these fields were hardcoded and there was no way to change them other than by making changes to the Merlin API server. With the new changes, these fields can be configured via the Merlin API server config values file.

For this to be done, a new `batchJobTemplater` attribute of a new `BatchJobTemplater` type is added to the batch controller, just like how the real-time Merlin model controller [has](https://github.com/caraml-dev/merlin/blob/683884464ced1da2565b9a1194bc370a17cb317b/api/cluster/controller.go#L94) a `kfServingResourceTemplater` that propagates default configuration values for real-time models to the model specs.

This new `BatchJobTemplater` struct only carries the new configs corresponding to the tolerations and node selectors that are set on the Merlin API server level, and 'adopts' the functions `CreateSparkApplicationResource`, `createSpec`, `createDriverSpec` and `createExecutorSpec` that were previously merely functions (i.e. these are now made methods of the `BatchJobTemplater` struct).

🚨 This PR also adds a new GitHub action to e2e tests to clean up disk storage on the GitHub runner to allow the e2e tests to pass.

# Modifications
- `api/batch/controller.go` - Addition of the `batchJobTemplater` attribute to the batch controller
- `api/batch/resource.go` - Addition of the new `BatchJobTemplater` struct and refactoring of its associated methods
- `api/config/batch.go` - Addition of a new `BatchConfig` struct to contain the tolerations and node selectors to be added to batch jobs
- `.github/workflows/merlin.yml` - Adds new GitHub action to e2e tests to clean up disk storage on the GitHub runner to allow the e2e tests to pass

# Tests
- [x] Running new batch jobs with custom tolerations/node selectors

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
None
```
