### PR TITLE
feat: Support HTTP predictor for UPI

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -251,10 +251,10 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 	envVarsMap := envVars.ToMap()
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe], "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe], "true") {
-		livenessProbeConfig = createLivenessProbeSpec(modelService.Protocol, fmt.Sprintf("/v1/models/%s", modelService.Name))
+		livenessProbeConfig = createLivenessProbeSpec(modelService.PredictorProtocol(), fmt.Sprintf("/v1/models/%s", modelService.Name))
 	}
 
-	containerPorts := createContainerPorts(modelService.Protocol, modelService.DeploymentMode)
+	containerPorts := createContainerPorts(modelService.PredictorProtocol(), modelService.DeploymentMode)
 	storageUri := utils.CreateModelLocation(modelService.ArtifactURI)
 	var predictorSpec kservev1beta1.PredictorSpec
 	switch modelService.Type {
@@ -857,7 +857,7 @@ func createPyFuncDefaultEnvVars(svc *models.Service) (models.EnvVars, error) {
 		},
 		models.EnvVar{
 			Name:  envProtocol,
-			Value: fmt.Sprint(svc.Protocol),
+			Value: fmt.Sprint(svc.PredictorProtocol()),
 		},
 		models.EnvVar{
 			Name:  envProject,

--- a/api/models/service.go
+++ b/api/models/service.go
@@ -86,12 +86,12 @@ func NewService(model *Model, version *Version, modelOpt *ModelOption, endpoint 
 		CurrentIsvcName:             endpoint.InferenceServiceName,
 		EnabledModelObservability:   endpoint.EnableModelObservability,
 		ModelSchema:                 version.ModelSchema,
-		PredictorUPIOverHTTPEnabled: predictorUPIOverHTTPEnabled(endpoint.Transformer),
+		PredictorUPIOverHTTPEnabled: predictorUPIOverHTTPEnabled(endpoint.Transformer, endpoint.Protocol),
 	}
 }
 
-func predictorUPIOverHTTPEnabled(transformer *Transformer) bool {
-	if transformer == nil {
+func predictorUPIOverHTTPEnabled(transformer *Transformer, modelProtocol protocol.Protocol) bool {
+	if transformer == nil || !transformer.Enabled || modelProtocol != protocol.UpiV1 {
 		return false
 	}
 	for _, val := range transformer.EnvVars {
@@ -107,7 +107,7 @@ func predictorUPIOverHTTPEnabled(transformer *Transformer) bool {
 }
 
 func (svc *Service) PredictorProtocol() protocol.Protocol {
-	if svc.Protocol == protocol.UpiV1 && svc.PredictorUPIOverHTTPEnabled {
+	if svc.PredictorUPIOverHTTPEnabled {
 		return protocol.HttpJson
 	}
 	return svc.Protocol

--- a/api/models/service_test.go
+++ b/api/models/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/caraml-dev/merlin/mlp"
 	"github.com/caraml-dev/merlin/pkg/protocol"
+	transformerpkg "github.com/caraml-dev/merlin/pkg/transformer"
 	"github.com/stretchr/testify/assert"
 	"knative.dev/pkg/apis"
 )
@@ -227,6 +228,60 @@ func TestNewService(t *testing.T) {
 				DeploymentMode:    endpoint.DeploymentMode,
 				AutoscalingPolicy: endpoint.AutoscalingPolicy,
 				Protocol:          endpoint.Protocol,
+			},
+		},
+		{
+			name: "STD transformer UPI - Predictor using HTTP",
+			args: args{
+				model:    model,
+				version:  version,
+				modelOpt: &ModelOption{},
+				endpoint: &VersionEndpoint{
+					RevisionID: revisionID,
+					Protocol:   protocol.UpiV1,
+					Transformer: &Transformer{
+						TransformerType: StandardTransformerType,
+						EnvVars: EnvVars{
+							{
+								Name:  transformerpkg.PredictorUPIHTTPEnabled,
+								Value: "true",
+							},
+						},
+					},
+				},
+			},
+			want: &Service{
+				Name:            fmt.Sprintf("%s-%s-r%s", model.Name, version.ID.String(), revisionID),
+				ModelName:       model.Name,
+				ModelVersion:    version.ID.String(),
+				RevisionID:      revisionID,
+				Namespace:       model.Project.Name,
+				ArtifactURI:     version.ArtifactURI,
+				Type:            model.Type,
+				Options:         &ModelOption{},
+				ResourceRequest: endpoint.ResourceRequest,
+				EnvVars:         endpoint.EnvVars,
+				Metadata: Metadata{
+					App:       model.Name,
+					Component: ComponentModelVersion,
+					Labels:    serviceLabels,
+					Stream:    model.Project.Stream,
+					Team:      model.Project.Team,
+				},
+				Transformer: &Transformer{
+					TransformerType: StandardTransformerType,
+					EnvVars: EnvVars{
+						{
+							Name:  transformerpkg.PredictorUPIHTTPEnabled,
+							Value: "true",
+						},
+					},
+				},
+				Logger:                      endpoint.Logger,
+				DeploymentMode:              endpoint.DeploymentMode,
+				AutoscalingPolicy:           endpoint.AutoscalingPolicy,
+				Protocol:                    protocol.UpiV1,
+				PredictorUPIOverHTTPEnabled: true,
 			},
 		},
 	}

--- a/api/pkg/transformer/constant.go
+++ b/api/pkg/transformer/constant.go
@@ -28,5 +28,7 @@ const (
 	KafkaConnectTimeoutMS    = "KAFKA_CONNECT_TIMEOUT_MS"
 	KafkaSerialization       = "KAFKA_SERIALIZATION_FORMAT"
 
+	PredictorUPIHTTPEnabled = "PREDICTOR_UPI_HTTP_ENABLED"
+
 	PromNamespace = "merlin_transformer"
 )

--- a/api/pkg/transformer/server/config/options.go
+++ b/api/pkg/transformer/server/config/options.go
@@ -50,4 +50,7 @@ type Options struct {
 	ModelGRPCKeepAliveTime time.Duration `envconfig:"MODEL_GRPC_KEEP_ALIVE_TIME" default:"60s"`
 	// Duration of PING that considered as TIMEOUT
 	ModelGRPCKeepAliveTimeout time.Duration `envconfig:"MODEL_GRPC_KEEP_ALIVE_TIMEOUT" default:"5s"`
+
+	// PyFunc UPI over HTTP flag
+	PredictorUPIHTTPEnabled bool `envconfig:"PREDICTOR_UPI_HTTP_ENABLED" default:"false"`
 }

--- a/api/pkg/transformer/server/grpc/predictor.go
+++ b/api/pkg/transformer/server/grpc/predictor.go
@@ -1,0 +1,158 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/afex/hystrix-go/hystrix"
+	hystrixGo "github.com/afex/hystrix-go/hystrix"
+	hystrixpkg "github.com/caraml-dev/merlin/pkg/hystrix"
+	"github.com/caraml-dev/merlin/pkg/transformer/server/config"
+	upiv1 "github.com/caraml-dev/universal-prediction-interface/gen/go/grpc/caraml/upi/v1"
+	"github.com/go-coldbrew/grpcpool"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+type upiPredictorClient interface {
+	predict(ctx context.Context, payload *upiv1.PredictValuesRequest) (*upiv1.PredictValuesResponse, error)
+	close() error
+}
+
+func newUPIPredictorClient(opts *config.Options) (upiPredictorClient, error) {
+	if opts.PredictorUPIHTTPEnabled {
+		return newHTTPClient(opts)
+	}
+	return newGRPCClient(opts)
+}
+
+type grpcClient struct {
+	conn      grpcpool.ConnPool
+	upiClient upiv1.UniversalPredictionServiceClient
+	opts      *config.Options
+}
+
+func newGRPCClient(opts *config.Options) (*grpcClient, error) {
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	if opts.ModelGRPCKeepAliveEnabled {
+		dialOpts = append(dialOpts, grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Timeout:             opts.ModelGRPCKeepAliveTime,
+			Time:                opts.ModelGRPCKeepAliveTimeout,
+			PermitWithoutStream: true,
+		}))
+	}
+
+	connPool, err := grpcpool.DialContext(context.Background(), opts.ModelPredictURL, uint(opts.ModelServerConnCount), dialOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	hystrix.ConfigureCommand(opts.ModelGRPCHystrixCommandName, hystrix.CommandConfig{
+		Timeout:                hystrixpkg.DurationToInt(opts.ModelTimeout, time.Millisecond),
+		MaxConcurrentRequests:  opts.ModelHystrixMaxConcurrentRequests,
+		RequestVolumeThreshold: opts.ModelHystrixRequestVolumeThreshold,
+		SleepWindow:            opts.ModelHystrixSleepWindowMs,
+		ErrorPercentThreshold:  opts.ModelHystrixErrorPercentageThreshold,
+	})
+
+	modelClient := upiv1.NewUniversalPredictionServiceClient(connPool)
+	return &grpcClient{
+		conn:      connPool,
+		upiClient: modelClient,
+		opts:      opts,
+	}, nil
+}
+
+func (cli *grpcClient) predict(ctx context.Context, payload *upiv1.PredictValuesRequest) (*upiv1.PredictValuesResponse, error) {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+
+	var modelResponse *upiv1.PredictValuesResponse
+	err := hystrix.Do(cli.opts.ModelGRPCHystrixCommandName, func() error {
+		response, err := cli.upiClient.PredictValues(ctx, (*upiv1.PredictValuesRequest)(payload), grpc.WaitForReady(true))
+		if err != nil {
+			return err
+		}
+		modelResponse = response
+		return nil
+	}, nil)
+
+	if err != nil {
+		return nil, err
+	}
+	return modelResponse, nil
+}
+
+func (cli *grpcClient) close() error {
+	return cli.conn.Close()
+}
+
+func newHTTPClient(opts *config.Options) (*httpClient, error) {
+	hystrixConfig := hystrixGo.CommandConfig{
+		Timeout:                int(opts.ModelTimeout / time.Millisecond),
+		MaxConcurrentRequests:  opts.ModelHystrixMaxConcurrentRequests,
+		RequestVolumeThreshold: opts.ModelHystrixRequestVolumeThreshold,
+		SleepWindow:            opts.ModelHystrixSleepWindowMs,
+		ErrorPercentThreshold:  opts.ModelHystrixErrorPercentageThreshold,
+	}
+	cl := &http.Client{
+		Timeout: opts.ModelTimeout,
+	}
+	client := hystrixpkg.NewClient(cl, &hystrixConfig, opts.ModelHTTPHystrixCommandName)
+	return &httpClient{client: client, opts: opts}, nil
+}
+
+type httpClient struct {
+	client hystrixHttpClient
+	opts   *config.Options
+}
+
+type hystrixHttpClient interface {
+	Do(request *http.Request) (*http.Response, error)
+}
+
+func (cli *httpClient) predict(ctx context.Context, payload *upiv1.PredictValuesRequest) (*upiv1.PredictValuesResponse, error) {
+	payloadBytes, err := protojson.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	predictURL := getUrl(fmt.Sprintf("%s/v1/models/%s:predict", cli.opts.ModelPredictURL, cli.opts.ModelFullName))
+	req, err := http.NewRequestWithContext(ctx, "POST", predictURL, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Length", fmt.Sprint(len(payloadBytes)))
+
+	res, err := cli.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close() //nolint: errcheck
+
+	modelResponseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	var upiResponse upiv1.PredictValuesResponse
+	if err := protojson.Unmarshal(modelResponseBody, &upiResponse); err != nil {
+		return nil, err
+	}
+	return &upiResponse, nil
+}
+
+func (cli *httpClient) close() error {
+	return nil
+}

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -400,13 +400,6 @@ func (us *UPIServer) modelPredictHTTP(ctx context.Context, payload *upiv1.Predic
 		return nil, err
 	}
 
-	// reqHeaders := req.Header
-	// md, _ := metadata.FromIncomingContext(ctx)
-	// for k, vv := range md {
-	// 	for _, v := range vv {
-	// 		reqHeaders.Set(k, v)
-	// 	}
-	// }
 	req.Header.Set("Content-Length", fmt.Sprint(len(payloadBytes)))
 
 	res, err := us.httpClient.Do(req)

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -400,13 +400,13 @@ func (us *UPIServer) modelPredictHTTP(ctx context.Context, payload *upiv1.Predic
 		return nil, err
 	}
 
-	reqHeaders := req.Header
-	md, _ := metadata.FromIncomingContext(ctx)
-	for k, vv := range md {
-		for _, v := range vv {
-			reqHeaders.Set(k, v)
-		}
-	}
+	// reqHeaders := req.Header
+	// md, _ := metadata.FromIncomingContext(ctx)
+	// for k, vv := range md {
+	// 	for _, v := range vv {
+	// 		reqHeaders.Set(k, v)
+	// 	}
+	// }
 	req.Header.Set("Content-Length", fmt.Sprint(len(payloadBytes)))
 
 	res, err := us.httpClient.Do(req)

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -1,10 +1,8 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -14,7 +12,6 @@ import (
 	"time"
 
 	"github.com/afex/hystrix-go/hystrix"
-	hystrixGo "github.com/afex/hystrix-go/hystrix"
 	mErrors "github.com/caraml-dev/merlin/pkg/errors"
 	hystrixpkg "github.com/caraml-dev/merlin/pkg/hystrix"
 	"github.com/caraml-dev/merlin/pkg/transformer/pipeline"
@@ -43,7 +40,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 var (
@@ -55,9 +51,7 @@ type UPIServer struct {
 	upiv1.UnimplementedUniversalPredictionServiceServer
 
 	opts                  *config.Options
-	modelClient           upiv1.UniversalPredictionServiceClient
-	conn                  grpcpool.ConnPool
-	httpClient            hystrixHttpClient
+	predictorClient       upiPredictorClient
 	instrumentationRouter *mux.Router
 	logger                *zap.Logger
 	tracer                trace.Tracer
@@ -76,44 +70,19 @@ type UPIServer struct {
 	PredictionLogHandler func(ctx context.Context, predictionResult *types.PredictionResult)
 }
 
-type hystrixHttpClient interface {
-	Do(request *http.Request) (*http.Response, error)
-}
-
-func newHTTPHystrixClient(commandName string, o *config.Options) *hystrixpkg.Client {
-	hystrixConfig := hystrixGo.CommandConfig{
-		Timeout:                int(o.ModelTimeout / time.Millisecond),
-		MaxConcurrentRequests:  o.ModelHystrixMaxConcurrentRequests,
-		RequestVolumeThreshold: o.ModelHystrixRequestVolumeThreshold,
-		SleepWindow:            o.ModelHystrixSleepWindowMs,
-		ErrorPercentThreshold:  o.ModelHystrixErrorPercentageThreshold,
-	}
-	cl := &http.Client{
-		Timeout: o.ModelTimeout,
-	}
-	return hystrixpkg.NewClient(cl, &hystrixConfig, commandName)
-}
-
 // NewUPIServer creates GRPC server that implement UPI Service
 func NewUPIServer(opts *config.Options, handler *pipeline.Handler, instrumentationRouter *mux.Router, logger *zap.Logger) (*UPIServer, error) {
 
+	upiPredictorClient, err := newUPIPredictorClient(opts)
+	if err != nil {
+		return nil, err
+	}
 	svr := &UPIServer{
 		opts:                  opts,
 		instrumentationRouter: instrumentationRouter,
+		predictorClient:       upiPredictorClient,
 		logger:                logger,
 		tracer:                otel.Tracer("pkg/transformer/server/grpc"),
-	}
-
-	if opts.PredictorUPIHTTPEnabled {
-		modelHttpClient := newHTTPHystrixClient(opts.ModelHTTPHystrixCommandName, opts)
-		svr.httpClient = modelHttpClient
-	} else {
-		modelClient, connPool, err := createModelUPIGrpcClient(opts)
-		if err != nil {
-			return nil, err
-		}
-		svr.modelClient = modelClient
-		svr.conn = connPool
 	}
 
 	if handler != nil {
@@ -216,7 +185,7 @@ func (us *UPIServer) Run() {
 	}
 
 	us.logger.Info("shutting down standard transformer")
-	if err := us.conn.Close(); err != nil {
+	if err := us.predictorClient.close(); err != nil {
 		us.logger.Error(fmt.Sprintf("failed to close connection %v", err))
 	}
 	us.logger.Info("closed connection to model prediction server")
@@ -350,11 +319,7 @@ func (us *UPIServer) predict(ctx context.Context, payload *upiv1.PredictValuesRe
 	defer span.End()
 
 	predictStartTime := time.Now()
-	modelCallFunc := us.modelPredictGRPC
-	if us.opts.PredictorUPIHTTPEnabled {
-		modelCallFunc = us.modelPredictHTTP
-	}
-	modelResponse, err := modelCallFunc(ctx, payload)
+	modelResponse, err := us.predictorClient.predict(ctx, payload)
 	predictionDurationMs := time.Since(predictStartTime).Milliseconds()
 	if err != nil {
 		instrumentation.RecordPredictionLatency(false, float64(predictionDurationMs))
@@ -365,58 +330,6 @@ func (us *UPIServer) predict(ctx context.Context, payload *upiv1.PredictValuesRe
 	}
 	instrumentation.RecordPredictionLatency(true, float64(predictionDurationMs))
 	return modelResponse, nil
-}
-
-func (us *UPIServer) modelPredictGRPC(ctx context.Context, payload *upiv1.PredictValuesRequest) (*upiv1.PredictValuesResponse, error) {
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		ctx = metadata.NewOutgoingContext(ctx, md)
-	}
-
-	var modelResponse *upiv1.PredictValuesResponse
-	err := hystrix.Do(us.opts.ModelGRPCHystrixCommandName, func() error {
-		response, err := us.modelClient.PredictValues(ctx, (*upiv1.PredictValuesRequest)(payload), grpc.WaitForReady(true))
-		if err != nil {
-			return err
-		}
-		modelResponse = response
-		return nil
-	}, nil)
-
-	if err != nil {
-		return nil, err
-	}
-	return modelResponse, nil
-}
-
-func (us *UPIServer) modelPredictHTTP(ctx context.Context, payload *upiv1.PredictValuesRequest) (*upiv1.PredictValuesResponse, error) {
-	payloadBytes, err := protojson.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	predictURL := getUrl(fmt.Sprintf("%s/v1/models/%s:predict", us.opts.ModelPredictURL, us.opts.ModelFullName))
-	req, err := http.NewRequestWithContext(ctx, "POST", predictURL, bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Length", fmt.Sprint(len(payloadBytes)))
-
-	res, err := us.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close() //nolint: errcheck
-
-	modelResponseBody, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, err
-	}
-	var upiResponse upiv1.PredictValuesResponse
-	if err := protojson.Unmarshal(modelResponseBody, &upiResponse); err != nil {
-		return nil, err
-	}
-	return &upiResponse, nil
 }
 
 func getMetadata(ctx context.Context) map[string]string {

--- a/api/pkg/transformer/server/grpc/server.go
+++ b/api/pkg/transformer/server/grpc/server.go
@@ -413,7 +413,7 @@ func (us *UPIServer) modelPredictHTTP(ctx context.Context, payload *upiv1.Predic
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer res.Body.Close() //nolint: errcheck
 
 	modelResponseBody, err := io.ReadAll(res.Body)
 	if err != nil {

--- a/api/pkg/transformer/server/grpc/server_test.go
+++ b/api/pkg/transformer/server/grpc/server_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -16,6 +19,7 @@ import (
 	pipelineMocks "github.com/caraml-dev/merlin/pkg/transformer/pipeline/mocks"
 	"github.com/caraml-dev/merlin/pkg/transformer/server/config"
 	"github.com/caraml-dev/merlin/pkg/transformer/server/grpc/mocks"
+	"github.com/caraml-dev/merlin/pkg/transformer/server/rest"
 	"github.com/caraml-dev/merlin/pkg/transformer/spec"
 	"github.com/caraml-dev/merlin/pkg/transformer/symbol"
 	"github.com/caraml-dev/merlin/pkg/transformer/types"
@@ -26,6 +30,7 @@ import (
 	feastTypes "github.com/feast-dev/feast/sdk/go/protos/feast/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -3465,6 +3470,2326 @@ func TestUPIServer_PredictValues(t *testing.T) {
 	}
 }
 
+func TestUPIServer_PredictValues_HTTP_Model(t *testing.T) {
+	type mockFeast struct {
+		request         *feastSdk.OnlineFeaturesRequest
+		expectedRequest *feastSdk.OnlineFeaturesRequest
+		response        *feastSdk.OnlineFeaturesResponse
+		err             error
+	}
+	tests := []struct {
+		name                  string
+		specYamlPath          string
+		mockFeasts            []mockFeast
+		logProducer           *pipelineMocks.PredictionLogProducer
+		request               *upiv1.PredictValuesRequest
+		preprocessOutput      *upiv1.PredictValuesRequest
+		modelOutput           *upiv1.PredictValuesResponse
+		modelOutputStatusCode int
+		modelOutputErr        error
+		want                  *upiv1.PredictValuesResponse
+		expectedErr           error
+	}{
+		{
+			name:         "simple postprocess",
+			specYamlPath: "../../pipeline/testdata/upi/simple_preprocess_postprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_customer_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "driver_id",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+						},
+					},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_customer_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "driver_id",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+						},
+					},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			modelOutput: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "prediction_result",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+			modelOutputStatusCode: http.StatusOK,
+			want: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "output_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "country",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "simple postprocess with prediction log",
+			specYamlPath: "../../pipeline/testdata/upi/valid_transformation_with_prediction_log.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_customer_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "driver_id",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+						},
+					},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_customer_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "driver_id",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "customer_id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+						},
+					},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			modelOutput: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "prediction_result",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+			modelOutputStatusCode: http.StatusOK,
+			want: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "output_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "country",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+								{
+									StringValue: "indonesia",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "passthrough",
+			specYamlPath: "../../pipeline/testdata/upi/valid_passthrough.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "table1",
+					Columns: []*upiv1.Column{
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "customer_name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									StringValue: "driver1",
+								},
+								{
+									StringValue: "customer1",
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									StringValue: "driver2",
+								},
+								{
+									StringValue: "customer2",
+								},
+								{
+									IntegerValue: 2,
+								},
+							},
+						},
+					},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "table1",
+					Columns: []*upiv1.Column{
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "customer_name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									StringValue: "driver1",
+								},
+								{
+									StringValue: "customer1",
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									StringValue: "driver2",
+								},
+								{
+									StringValue: "customer2",
+								},
+								{
+									IntegerValue: 2,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables:    []*upiv1.Table{},
+					Variables: []*upiv1.Variable{},
+				},
+				PredictionContext: []*upiv1.Variable{
+					{
+						Name:        "country",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "indonesia",
+					},
+					{
+						Name:        "timezone",
+						Type:        upiv1.Type_TYPE_STRING,
+						StringValue: "asia/jakarta",
+					},
+				},
+			},
+			modelOutput: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+			modelOutputStatusCode: http.StatusOK,
+			want: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "table_transformations",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "transformed_driver_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "rating",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "previous_vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-2",
+								},
+								{
+									DoubleValue: 2.5,
+								},
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 3,
+								},
+							},
+						},
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-1",
+								},
+								{
+									DoubleValue: -2.5,
+								},
+								{
+									DoubleValue: 0.75,
+								},
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutput: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+			modelOutputStatusCode: http.StatusOK,
+			want: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "table_transformations; model prediction timeout",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "transformed_driver_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "rating",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "previous_vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-2",
+								},
+								{
+									DoubleValue: 2.5,
+								},
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 3,
+								},
+							},
+						},
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-1",
+								},
+								{
+									DoubleValue: -2.5,
+								},
+								{
+									DoubleValue: 0.75,
+								},
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutputErr:        fmt.Errorf("timeout"),
+			modelOutputStatusCode: http.StatusInternalServerError,
+			expectedErr:           status.Error(codes.Internal, "predict err: got 5xx response code: 500"),
+		},
+		{
+			name:         "table_transformations; model prediction timeout from hystrix",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "transformed_driver_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "name",
+							Type: upiv1.Type_TYPE_STRING,
+						},
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "rating",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "previous_vehicle",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "row2",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-2",
+								},
+								{
+									DoubleValue: 2.5,
+								},
+								{
+									DoubleValue: 0.5,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 3,
+								},
+							},
+						},
+						{
+							RowId: "row1",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1111,
+								},
+								{
+									StringValue: "driver-1",
+								},
+								{
+									DoubleValue: -2.5,
+								},
+								{
+									DoubleValue: 0.75,
+								},
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutputErr:        hystrix.ErrTimeout,
+			modelOutputStatusCode: http.StatusInternalServerError,
+			expectedErr:           status.Error(codes.Internal, "predict err: got 5xx response code: 500"),
+		},
+		{
+			name:         "table_transformations; errors table is not defined in request",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "random_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											StringValue: "motorcycle",
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: table 'driver_table' is not declared"),
+		},
+		{
+			name:         "table_transformations; one of value for cyclical encoder is nil (test_time column)",
+			specYamlPath: "../../pipeline/testdata/upi/valid_table_transformer_preprocess.yaml",
+			mockFeasts:   []mockFeast{},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "previous_vehicle",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "rating",
+									Type: upiv1.Type_TYPE_DOUBLE,
+								},
+								{
+									Name: "test_time",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IsNull: true,
+										},
+										{
+											StringValue: "suv",
+										},
+										{
+											DoubleValue: 4,
+										},
+										{
+											IsNull: true,
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											StringValue: "sedan",
+										},
+										{
+											StringValue: "mpv",
+										},
+										{
+											DoubleValue: 3,
+										},
+										{
+											IntegerValue: 90,
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			expectedErr: status.Error(codes.InvalidArgument, "preprocess err: error executing preprocess operation: *pipeline.TableTransformOp: invalid input: there is missing value on column test_time, cyclical encoding fails"),
+		},
+		{
+			name:         "table_transformations with feast",
+			specYamlPath: "../../pipeline/testdata/upi/valid_feast_preprocess.yaml",
+			mockFeasts: []mockFeast{
+				{
+					request: &feastSdk.OnlineFeaturesRequest{
+						Project: "default", // used as identifier for mocking. must match config
+					},
+					response: &feastSdk.OnlineFeaturesResponse{
+						RawResponse: &serving.GetOnlineFeaturesResponseV2{
+							Metadata: &serving.GetOnlineFeaturesResponseMetadata{
+								FieldNames: &serving.FieldList{
+									Val: []string{
+										"driver_id",
+										"driver_feature_1",
+										"driver_feature_2",
+									},
+								},
+							},
+							Results: []*serving.GetOnlineFeaturesResponseV2_FieldVector{
+								{
+									Values: []*feastTypes.Value{
+										feastSdk.Int64Val(1),
+										feastSdk.DoubleVal(1111),
+										feastSdk.DoubleVal(2222),
+									},
+									Statuses: []serving.FieldStatus{
+										serving.FieldStatus_PRESENT,
+										serving.FieldStatus_PRESENT,
+										serving.FieldStatus_PRESENT,
+									},
+								},
+								{
+									Values: []*feastTypes.Value{
+										feastSdk.Int64Val(2),
+										feastSdk.DoubleVal(3333),
+										feastSdk.DoubleVal(4444),
+									},
+									Statuses: []serving.FieldStatus{
+										serving.FieldStatus_PRESENT,
+										serving.FieldStatus_PRESENT,
+										serving.FieldStatus_PRESENT,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "result_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_feature_1",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "driver_feature_2",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 1111,
+								},
+								{
+									DoubleValue: 2222,
+								},
+							},
+						},
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 3333,
+								},
+								{
+									DoubleValue: 4444,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables:    []*upiv1.Table{},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			modelOutput: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+			modelOutputStatusCode: http.StatusOK,
+			want: &upiv1.PredictValuesResponse{
+				PredictionResultTable: &upiv1.Table{
+					Name: "model_prediction_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "probability",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "1",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.2,
+								},
+							},
+						},
+						{
+							RowId: "2",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.3,
+								},
+							},
+						},
+						{
+							RowId: "3",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.4,
+								},
+							},
+						},
+						{
+							RowId: "4",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.5,
+								},
+							},
+						},
+						{
+							RowId: "5",
+							Values: []*upiv1.Value{
+								{
+									DoubleValue: 0.6,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:         "table_transformations with feast; timeout calling feast",
+			specYamlPath: "../../pipeline/testdata/upi/valid_feast_preprocess.yaml",
+			mockFeasts: []mockFeast{
+				{
+					request: &feastSdk.OnlineFeaturesRequest{
+						Project: "default", // used as identifier for mocking. must match config
+					},
+					err: hystrix.ErrTimeout,
+				},
+			},
+			request: &upiv1.PredictValuesRequest{
+				TransformerInput: &upiv1.TransformerInput{
+					Tables: []*upiv1.Table{
+						{
+							Name: "driver_table",
+							Columns: []*upiv1.Column{
+								{
+									Name: "id",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+								{
+									Name: "name",
+									Type: upiv1.Type_TYPE_STRING,
+								},
+								{
+									Name: "row_number",
+									Type: upiv1.Type_TYPE_INTEGER,
+								},
+							},
+							Rows: []*upiv1.Row{
+								{
+									RowId: "row1",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 1,
+										},
+										{
+											StringValue: "driver-1",
+										},
+										{
+											IntegerValue: 0,
+										},
+									},
+								},
+								{
+									RowId: "row2",
+									Values: []*upiv1.Value{
+										{
+											IntegerValue: 2,
+										},
+										{
+											StringValue: "driver-2",
+										},
+										{
+											IntegerValue: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []*upiv1.Variable{
+						{
+							Name:         "customer_id",
+							Type:         upiv1.Type_TYPE_INTEGER,
+							IntegerValue: 1111,
+						},
+					},
+				},
+			},
+			preprocessOutput: &upiv1.PredictValuesRequest{
+				PredictionTable: &upiv1.Table{
+					Name: "result_table",
+					Columns: []*upiv1.Column{
+						{
+							Name: "rank",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "customer_id",
+							Type: upiv1.Type_TYPE_INTEGER,
+						},
+						{
+							Name: "driver_feature_1",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+						{
+							Name: "driver_feature_2",
+							Type: upiv1.Type_TYPE_DOUBLE,
+						},
+					},
+					Rows: []*upiv1.Row{
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 0,
+								},
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 1111,
+								},
+								{
+									DoubleValue: 2222,
+								},
+							},
+						},
+						{
+							RowId: "",
+							Values: []*upiv1.Value{
+								{
+									IntegerValue: 1,
+								},
+								{
+									IntegerValue: 2,
+								},
+								{
+									IntegerValue: 1111,
+								},
+								{
+									DoubleValue: 3333,
+								},
+								{
+									DoubleValue: 4444,
+								},
+							},
+						},
+					},
+				},
+				TransformerInput: &upiv1.TransformerInput{
+					Tables:    []*upiv1.Table{},
+					Variables: []*upiv1.Variable{},
+				},
+			},
+			expectedErr: status.Error(codes.DeadlineExceeded, "preprocess err: error executing preprocess operation: *pipeline.FeastOp: deadline exceeded: hystrix: timeout"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// clientMock := &mocks.UniversalPredictionServiceClient{}
+			// clientMock.On("PredictValues", mock.Anything, mock.MatchedBy(func(req *upiv1.PredictValuesRequest) bool {
+			// 	return proto.Equal(tt.preprocessOutput, req)
+			// }), mock.Anything).Return(tt.modelOutput, tt.modelOutputErr)
+			modelServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+
+				assert.Nil(t, err)
+
+				var actualRequest upiv1.PredictValuesRequest
+				err = protojson.Unmarshal(body, &actualRequest)
+				require.NoError(t, err)
+				assert.True(t, proto.Equal(tt.preprocessOutput, &actualRequest))
+
+				w.Header().Add("Content-Type", "application/json")
+
+				w.WriteHeader(tt.modelOutputStatusCode)
+				resp, err := protojson.Marshal(tt.modelOutput)
+				require.NoError(t, err)
+				_, err = w.Write(resp)
+				assert.NoError(t, err)
+			}))
+			mockFeast := &feastMocks.Client{}
+			feastClients := feast.Clients{}
+			feastClients[spec.ServingSource_BIGTABLE] = mockFeast
+			feastClients[spec.ServingSource_REDIS] = mockFeast
+
+			for _, m := range tt.mockFeasts {
+				project := m.request.Project
+				expectedRequest := m.expectedRequest
+				mockFeast.On("GetOnlineFeatures", mock.Anything, mock.MatchedBy(func(req *feastSdk.OnlineFeaturesRequest) bool {
+					if expectedRequest != nil {
+						// Some of entitiy might be cached that's why we check that request coming to feast
+						// is subset of expected request
+						for _, reqEntity := range req.Entities {
+							expectedReq, _ := json.Marshal(expectedRequest)
+							actualReq, _ := json.Marshal(reqEntity)
+							assert.Contains(t, string(expectedReq), string(actualReq))
+						}
+
+						assert.Equal(t, expectedRequest.Features, req.Features)
+					}
+					return req.Project == project
+				})).Return(m.response, m.err)
+			}
+			opts := &config.Options{
+				ModelGRPCHystrixCommandName: "grpcHandler",
+				ModelName:                   "initial",
+				Project:                     "sample",
+				ModelVersion:                "1",
+				PredictorUPIHTTPEnabled:     true,
+				ModelPredictURL:             modelServer.URL,
+			}
+
+			logProducerMock := tt.logProducer
+			us, err := createTransformerServer(tt.specYamlPath, feastClients, opts, nil, logProducerMock)
+			assert.NoError(t, err)
+
+			got, err := us.PredictValues(context.Background(), tt.request)
+			assert.Equal(t, tt.expectedErr, err)
+			if tt.expectedErr != nil {
+				return
+			}
+			proto.Equal(tt.want, got)
+		})
+	}
+}
+
 func createTransformerServer(transformerConfigPath string, feastClients feast.Clients, options *config.Options, modelClient upiv1.UniversalPredictionServiceClient, logProducer pipeline.PredictionLogProducer) (*UPIServer, error) {
 	yamlBytes, err := os.ReadFile(transformerConfigPath)
 	if err != nil {
@@ -3529,6 +5854,11 @@ func createTransformerServer(transformerConfigPath string, feastClients feast.Cl
 	handler := pipeline.NewHandler(compiledPipeline, logger)
 	noOpTracer := trace.NewNoopTracerProvider()
 	otel.SetTracerProvider(noOpTracer)
+
+	if options.PredictorUPIHTTPEnabled {
+		return NewUPIServer(options, handler, rest.NewInstrumentationRouter(), logger)
+	}
+
 	transformerServer := &UPIServer{
 		opts:        options,
 		modelClient: modelClient,

--- a/api/pkg/transformer/server/grpc/server_test.go
+++ b/api/pkg/transformer/server/grpc/server_test.go
@@ -600,7 +600,7 @@ func TestUPIServer_PredictValues_WithMockPreprocessAndPostprocessHandler(t *test
 			clientMock.On("PredictValues", mock.Anything, incomingReq, mock.Anything).Return(tt.expectedModelOutput, tt.modelErr)
 			noOpTracer := trace.NewNoopTracerProvider()
 			us := &UPIServer{
-				modelClient: clientMock,
+				predictorClient: &grpcClient{upiClient: clientMock, opts: &config.Options{ModelGRPCHystrixCommandName: "gRPCCommand"}},
 				opts: &config.Options{
 					ModelGRPCHystrixCommandName: "grpcHandler",
 				},
@@ -5860,10 +5860,10 @@ func createTransformerServer(transformerConfigPath string, feastClients feast.Cl
 	}
 
 	transformerServer := &UPIServer{
-		opts:        options,
-		modelClient: modelClient,
-		logger:      logger,
-		tracer:      noOpTracer.Tracer(""),
+		opts:            options,
+		predictorClient: &grpcClient{upiClient: modelClient, opts: options},
+		logger:          logger,
+		tracer:          noOpTracer.Tracer(""),
 	}
 
 	transformerServer.ContextModifier = handler.EmbedEnvironment

--- a/api/pkg/transformer/server/rest/server.go
+++ b/api/pkg/transformer/server/rest/server.go
@@ -151,7 +151,6 @@ func (s *HTTPServer) PredictHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer resp.Body.Close() //nolint: errcheck
-
 	modelResponseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		s.logger.Error("error reading model response", zap.Error(err))

--- a/python/sdk/test/pyfunc_upi_integration_test.py
+++ b/python/sdk/test/pyfunc_upi_integration_test.py
@@ -5,7 +5,6 @@ from time import sleep
 from typing import List
 
 import grpc
-import merlin
 import pandas as pd
 import pytest
 import xgboost as xgb
@@ -18,13 +17,11 @@ from merlin.protocol import Protocol
 from merlin.transformer import StandardTransformer
 from sklearn.datasets import load_iris
 
+import merlin
+
 
 class IrisClassifier(PyFuncModel):
-    target_names = [
-        "setosa",
-        "versicolor",
-        "virginica"
-    ]
+    target_names = ["setosa", "versicolor", "virginica"]
 
     target_name = "iris-species"
 
@@ -32,36 +29,49 @@ class IrisClassifier(PyFuncModel):
         self._model = xgb.Booster(model_file=artifacts["xgb_model"])
 
     def infer(self, request: dict, **kwargs):
-        result = self._predict(request['instances'])
-        return {
-            "predictions": result.tolist()
-        }
+        result = self._predict(request["instances"])
+        return {"predictions": result.tolist()}
 
-    def upiv1_infer(self, request: upi_pb2.PredictValuesRequest,
-                    context: grpc.ServicerContext) -> upi_pb2.PredictValuesResponse:
+    def upiv1_infer(
+        self, request: upi_pb2.PredictValuesRequest, context: grpc.ServicerContext
+    ) -> upi_pb2.PredictValuesResponse:
         features_df, _ = table_to_df(request.prediction_table)
         prediction_result_df = self._predict(features_df)
         return self._create_response(prediction_result_df, request)
 
-    def _create_response(self, predictions: pd.DataFrame, request: upi_pb2.PredictValuesRequest) -> upi_pb2.PredictValuesResponse:
+    def _create_response(
+        self, predictions: pd.DataFrame, request: upi_pb2.PredictValuesRequest
+    ) -> upi_pb2.PredictValuesResponse:
         prediction_result_table = df_to_table(predictions, "prediction_result")
-        response_metadata = upi_pb2.ResponseMetadata(prediction_id=request.metadata.prediction_id)
-        return upi_pb2.PredictValuesResponse(prediction_result_table=prediction_result_table, target_name=self.target_name, metadata=response_metadata)
+        response_metadata = upi_pb2.ResponseMetadata(
+            prediction_id=request.metadata.prediction_id
+        )
+        return upi_pb2.PredictValuesResponse(
+            prediction_result_table=prediction_result_table,
+            target_name=self.target_name,
+            metadata=response_metadata,
+        )
 
     def _predict(self, features: pd.DataFrame) -> pd.DataFrame:
         features_matrix = xgb.DMatrix(features)
-        return pd.DataFrame(self._model.predict(features_matrix), columns = self.target_names)
+        return pd.DataFrame(
+            self._model.predict(features_matrix), columns=self.target_names
+        )
 
 
 class SimpleForwarder(PyFuncModel):
     target_name = "probability"
+
     def infer(self, request: dict, **kwargs):
         return request
 
-    def upiv1_infer(self, request: upi_pb2.PredictValuesRequest,
-                    context: grpc.ServicerContext) -> upi_pb2.PredictValuesResponse:
-        return upi_pb2.PredictValuesResponse(prediction_result_table=request.prediction_table, target_name=self.target_name)
-
+    def upiv1_infer(
+        self, request: upi_pb2.PredictValuesRequest, context: grpc.ServicerContext
+    ) -> upi_pb2.PredictValuesResponse:
+        return upi_pb2.PredictValuesResponse(
+            prediction_result_table=request.prediction_table,
+            target_name=self.target_name,
+        )
 
 
 @pytest.mark.pyfunc
@@ -75,10 +85,12 @@ def test_deploy(integration_test_url, project_name, use_google_oauth, requests):
     with merlin.new_model_version() as v:
         xgb_path, xgb_model = train_xgboost_model()
 
-        v.log_pyfunc_model(model_instance=IrisClassifier(),
-                           conda_env="test/pyfunc/env.yaml",
-                           code_dir=["test"],
-                           artifacts={"xgb_model": xgb_path})
+        v.log_pyfunc_model(
+            model_instance=IrisClassifier(),
+            conda_env="test/pyfunc/env.yaml",
+            code_dir=["test"],
+            artifacts={"xgb_model": xgb_path},
+        )
 
     endpoint = merlin.deploy(v, protocol=Protocol.UPI_V1)
 
@@ -92,23 +104,32 @@ def test_deploy(integration_test_url, project_name, use_google_oauth, requests):
     validate_iris_upi(xgb_model, stub)
     merlin.undeploy(v)
 
+
 @pytest.mark.pyfunc
 @pytest.mark.integration
-def test_pyfunc_with_standard_transformer(integration_test_url, project_name, use_google_oauth, requests):
+def test_pyfunc_with_standard_transformer(
+    integration_test_url, project_name, use_google_oauth, requests
+):
     merlin.set_url(integration_test_url, use_google_oauth=use_google_oauth)
     merlin.set_project(project_name)
     merlin.set_model("pyfunc-upi-std", ModelType.PYFUNC)
 
     undeploy_all_version()
     with merlin.new_model_version() as v:
-        v.log_pyfunc_model(model_instance=SimpleForwarder(),
-                           conda_env="test/pyfunc/env.yaml",
-                           code_dir=["test"])
+        v.log_pyfunc_model(
+            model_instance=SimpleForwarder(),
+            conda_env="test/pyfunc/env.yaml",
+            code_dir=["test"],
+        )
 
     transformer_config_path = os.path.join(
         "test/transformer", "upi_standard_transformer_no_feast.yaml"
     )
-    transformer = StandardTransformer(config_file=transformer_config_path, enabled=True)
+    transformer = StandardTransformer(
+        config_file=transformer_config_path,
+        enabled=True,
+        env_vars={"PREDICTOR_UPI_HTTP_ENABLED": "true"},
+    )
     endpoint = merlin.deploy(v, transformer=transformer, protocol=Protocol.UPI_V1)
 
     assert endpoint.protocol == Protocol.UPI_V1
@@ -142,13 +163,15 @@ def test_serve_traffic(integration_test_url, project_name, use_google_oauth, req
     with merlin.new_model_version() as v:
         xgb_path, xgb_model = train_xgboost_model()
 
-        v.log_pyfunc_model(model_instance=IrisClassifier(),
-                           conda_env="test/pyfunc/env.yaml",
-                           code_dir=["test"],
-                           artifacts={"xgb_model": xgb_path})
+        v.log_pyfunc_model(
+            model_instance=IrisClassifier(),
+            conda_env="test/pyfunc/env.yaml",
+            code_dir=["test"],
+            artifacts={"xgb_model": xgb_path},
+        )
 
     endpoint = merlin.deploy(v, protocol=Protocol.UPI_V1)
-    model_endpoint = merlin.serve_traffic({endpoint:100})
+    model_endpoint = merlin.serve_traffic({endpoint: 100})
 
     assert model_endpoint.protocol == Protocol.UPI_V1
     assert model_endpoint.status == Status.SERVING
@@ -171,7 +194,7 @@ def test_model():
     request = create_upi_request_from_iris_dataset()
     response = pyfunc_model.upiv1_infer(request, {})
 
-    X = load_iris()['data']
+    X = load_iris()["data"]
     y = xgb_model.predict(xgb.DMatrix(X))
     exp_df = pd.DataFrame(y, columns=IrisClassifier.target_names)
     exp_table = df_to_table(exp_df, "prediction_result")
@@ -186,7 +209,7 @@ def validate_iris_upi(model, stub):
     assert response.metadata.prediction_id == request.metadata.prediction_id
     assert response.target_name == request.target_name
 
-    X = load_iris()['data']
+    X = load_iris()["data"]
     y = model.predict(xgb.DMatrix(X))
     exp_df = pd.DataFrame(y, columns=IrisClassifier.target_names)
     exp_table = df_to_table(exp_df, "prediction_result")
@@ -199,69 +222,76 @@ def train_xgboost_model():
     BST_FILE = "model_1.bst"
 
     iris = load_iris()
-    y = iris['target']
-    X = iris['data']
+    y = iris["target"]
+    X = iris["data"]
 
     dtrain = xgb.DMatrix(X, label=y)
-    param = {'max_depth': 6,
-             'eta': 0.1,
-             'silent': 1,
-             'nthread': 4,
-             'num_class': 3,
-             'objective': 'multi:softprob'
-             }
+    param = {
+        "max_depth": 6,
+        "eta": 0.1,
+        "silent": 1,
+        "nthread": 4,
+        "num_class": 3,
+        "objective": "multi:softprob",
+    }
     xgb_model = xgb.train(params=param, dtrain=dtrain)
     model_path = os.path.join(model_dir, BST_FILE)
     xgb_model.save_model(model_path)
     return model_path, xgb_model
 
+
 def create_simple_forwarder_request() -> upi_pb2.PredictValuesRequest:
     target_name = SimpleForwarder.target_name
-    cols = ["id", "name", "vehicle", "previous_vehicle", "rating", "test_time", "row_number"]
+    cols = [
+        "id",
+        "name",
+        "vehicle",
+        "previous_vehicle",
+        "rating",
+        "test_time",
+        "row_number",
+    ]
     indices = ["row1", "row2"]
     rows = [
         [1, "driver-1", "motorcycle", "suv", 4.0, 90, 0],
-        [2, "driver-2", "sedan", "mpv", 3.0, 90, 1]
+        [2, "driver-2", "sedan", "mpv", 3.0, 90, 1],
     ]
     driver_df = pd.DataFrame(columns=cols, data=rows, index=indices)
     driver_table = df_to_table(driver_df, "driver_table")
     variables: List[variable_pb2.Variable] = [
-        variable_pb2.Variable(name="customer_id", type=type_pb2.TYPE_INTEGER, integer_value=1111)
+        variable_pb2.Variable(
+            name="customer_id", type=type_pb2.TYPE_INTEGER, integer_value=1111
+        )
     ]
     return upi_pb2.PredictValuesRequest(
         target_name=target_name,
         transformer_input=upi_pb2.TransformerInput(
-            tables=[driver_table],
-            variables=variables
-        )
+            tables=[driver_table], variables=variables
+        ),
     )
+
 
 def simple_forwarder_response() -> upi_pb2.PredictValuesResponse:
     target_name = SimpleForwarder.target_name
     cols = ["customer_id", "name", "rank", "rating", "vehicle", "previous_vehicle"]
     indices = ["row2", "row1"]
-    rows = [
-        [1111, "driver-2", 2.5, 0.5, 2, 3],
-        [1111, "driver-1", -2.5, 0.75, 0, 1]
-    ]
+    rows = [[1111, "driver-2", 2.5, 0.5, 2, 3], [1111, "driver-1", -2.5, 0.75, 0, 1]]
     response_df = pd.DataFrame(columns=cols, data=rows, index=indices)
     response_table = df_to_table(response_df, "transformed_driver_table")
     return upi_pb2.PredictValuesResponse(
-        target_name=target_name,
-        prediction_result_table=response_table
+        target_name=target_name, prediction_result_table=response_table
     )
+
 
 def create_upi_request_from_iris_dataset() -> upi_pb2.PredictValuesRequest:
     target_name = IrisClassifier.target_name
     iris_dataset = load_iris()
-    X = iris_dataset['data']
+    X = iris_dataset["data"]
     df = pd.DataFrame(X, columns=iris_dataset.feature_names)
 
     prediction_table = df_to_table(df, "features")
     return upi_pb2.PredictValuesRequest(
         target_name=target_name,
         prediction_table=prediction_table,
-        metadata=upi_pb2.RequestMetadata(
-            prediction_id=str(uuid.uuid1())
-        )
+        metadata=upi_pb2.RequestMetadata(prediction_id=str(uuid.uuid1())),
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
We faced issue with scalability of PyFunc model in gRPC, compare to PyFunc http, the gRPC  PyFunc needs more pods to serve the same amount of traffic. To solve this issue we add support for gRPC UPI to call predictor that use HTTP 1 protocol. User can enables it by specifying transformer env variable `PREDICTOR_UPI_HTTP_ENABLED` and set it to true
# Modifications
<!-- Summarize the key code changes. -->
* `api/pkg/transformer/server/grpc/server.go` -> Model predictor http support
* `api/cluster/resource/templater.go` 
  * Change the predictor protocol to `HTTP_JSON`, remove h2c container port and change liveness probe
# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
