### PR TITLE
fix(image-builder): use google keychain for Artifact Registry domains

### DIFF
--- a/api/pkg/imagebuilder/imagebuilder.go
+++ b/api/pkg/imagebuilder/imagebuilder.go
@@ -362,7 +362,7 @@ func (c *imageBuilder) imageExists(imageName, imageTag string) bool {
 // GCP container registry and artifact registry domains are used to determine which keychain to use when interacting with container registry.
 // This is needed because GCP registries use different authentication method than other container registry.
 func getGCPSubDomains() []string {
-	return []string{ "gcr.io", "pkg.dev" }
+	return []string{"gcr.io", "pkg.dev"}
 }
 
 // ImageExists returns true if the versioned image (tag) already exist in the image repository.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
To pull images from GCR image-builder checks if the image name contains "gcr.io". The new Artifact Registry uses different domain names, for example `asia-docker.pkg.dev`.


# Modifications
<!-- Summarize the key code changes. -->

- Use google keychain for `pkg.dev` domains too.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
