### PR TITLE
fix(image-building): Update process_conda_env.sh

### DIFF
--- a/python/batch-predictor/docker/process_conda_env.sh
+++ b/python/batch-predictor/docker/process_conda_env.sh
@@ -19,8 +19,12 @@ echo "Processing conda environment file: ${CONDA_ENV_PATH}"
 echo "Current conda environment file content:"
 cat "${CONDA_ENV_PATH}"
 
+# Remove `mlflow` constraint
+yq --inplace 'del(.dependencies[].pip[] | select(. == "mlflow*"))' "${CONDA_ENV_PATH}"
+yq --inplace ".dependencies[].pip += [\"mlflow\"]" "${CONDA_ENV_PATH}"
+
 # Remove `merlin-sdk` from conda's pip dependencies
-yq --inplace 'del(.dependencies[].pip[] | select(. == "*merlin-sdk*"))' "${CONDA_ENV_PATH}"
+yq --inplace 'del(.dependencies[].pip[] | select(. == "merlin-sdk*"))' "${CONDA_ENV_PATH}"
 
 # Add `${MERLIN_DEP}` with its constaint (`${MERLIN_DEP_CONSTRAINT}`) to conda's pip dependencies, if not exist
 yq --inplace "with(.dependencies[].pip; select(all_c(. != \"*${MERLIN_DEP}*\")) | . += [\"${MERLIN_DEP}${MERLIN_DEP_CONSTRAINT}\"] )" "${CONDA_ENV_PATH}"

--- a/python/pyfunc-server/docker/process_conda_env.sh
+++ b/python/pyfunc-server/docker/process_conda_env.sh
@@ -19,6 +19,10 @@ echo "Processing conda environment file: ${CONDA_ENV_PATH}"
 echo "Current conda environment file content:"
 cat "${CONDA_ENV_PATH}"
 
+# Remove `mlflow` constraint
+yq --inplace 'del(.dependencies[].pip[] | select(. == "mlflow*"))' "${CONDA_ENV_PATH}"
+yq --inplace ".dependencies[].pip += [\"mlflow\"]" "${CONDA_ENV_PATH}"
+
 # Remove `merlin-sdk` from conda's pip dependencies
 yq --inplace 'del(.dependencies[].pip[] | select(. == "*merlin-sdk*"))' "${CONDA_ENV_PATH}"
 

--- a/ui/src/pages/version/components/forms/steps/TransformerStep.js
+++ b/ui/src/pages/version/components/forms/steps/TransformerStep.js
@@ -21,7 +21,7 @@ export const TransformerStep = ({ maxAllowedReplica }) => {
   const { errors } = useContext(FormValidationContext);
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="m">f
+    <EuiFlexGroup direction="column" gutterSize="m">
       <EuiFlexItem grow={false}>
         <SelectTransformerPanel
           transformer={transformer}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

When users specify the version of mlflow in their pyfunc-based's conda.yaml, the image building might return an error like this:

```
The conflict is caused by:
    The user requested mlflow==1.23.0
    merlin-batch-predictor 0.41.0rc3 depends on mlflow==1.26.1
...
```

It's because of the version of their mlflow on their conda.yaml does not match the version set by merlin-sdk.

# Modifications
<!-- Summarize the key code changes. -->

Update process_conda_env.sh to remove the mlflow version constraint.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
