### PR TITLE
Bump dependencies for batch-predictor and pyfunc-server

### DIFF
--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -2,5 +2,5 @@ cloudpickle==2.0.0
 findspark==2.0.1
 merlin-sdk==0.40.1
 mlflow==1.26.1
-pyarrow>=0.14.1,<=11.0.0
+pyarrow>=0.14.1,<11.0.0
 pyspark==3.0.1

--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -2,5 +2,5 @@ cloudpickle==2.0.0
 findspark==2.0.1
 merlin-sdk==0.40.1
 mlflow==1.26.1
-pyarrow>=0.14.1,<=9.0.0
+pyarrow>=0.14.1,<=11.0.0
 pyspark==3.0.1

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -5,8 +5,8 @@ confluent-kafka==2.3.0
 grpcio-health-checking
 grpcio-reflection
 merlin-sdk==0.40.1
-numpy >= 1.8.2
+numpy>=1.8.2
 orjson>=2.6.8
-prometheus_client==0.14.1
+prometheus-client
 tornado
 uvloop


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

From internal testing, there are some models with dependencies conflict, similar to what we encounter on #555: 

1. Some batch jobs use pyarrow==10.0.1
2. Some pyfunc models use newer prometheus-client

# Modifications

1. Increase the upper limit of pyarrow
2. Remove the constraint of prometheus-client. From their [release notes](https://github.com/prometheus/client_python/releases), there should no breaking change.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
