### PR TITLE
chore(api): Fix client endpoint examples after OpenAPI3 migration

### DIFF
--- a/api/client/examples/model-endpoints/main.go
+++ b/api/client/examples/model-endpoints/main.go
@@ -77,7 +77,7 @@ func main() {
 
 			log.Println("  Model endpoints:")
 			for _, modelEndpoint := range modelEndpoints {
-				log.Printf("  - %s: %s\n", modelEndpoint.EnvironmentName, modelEndpoint.Url)
+				log.Printf("  - %v: %v\n", modelEndpoint.EnvironmentName, modelEndpoint.Url)
 			}
 		}
 	}

--- a/api/client/examples/model-endpoints/main.go
+++ b/api/client/examples/model-endpoints/main.go
@@ -28,13 +28,18 @@ func main() {
 	}
 
 	cfg := client.NewConfiguration()
-	cfg.BasePath = basePath
+	cfg.Servers = client.ServerConfigurations{
+		{
+			URL:         basePath,
+			Description: "Merlin base path",
+		},
+	}
 	cfg.HTTPClient = httpClient
 
 	apiClient := client.NewAPIClient(cfg)
 
 	// Get all projects
-	projects, _, err := apiClient.ProjectApi.ProjectsGet(ctx, nil)
+	projects, _, err := apiClient.ProjectAPI.ProjectsGet(ctx).Execute()
 	if err != nil {
 		panic(err)
 	}
@@ -49,7 +54,7 @@ func main() {
 
 		// Get all models in the given project
 
-		models, _, err := apiClient.ModelsApi.ProjectsProjectIdModelsGet(ctx, project.Id, nil)
+		models, _, err := apiClient.ModelsAPI.ProjectsProjectIdModelsGet(ctx, project.Id).Execute()
 		if err != nil {
 			panic(err)
 		}
@@ -60,7 +65,7 @@ func main() {
 			log.Println("- Model:", model.Name)
 
 			// Get all model's endpoints
-			modelEndpoints, _, err := apiClient.ModelEndpointsApi.ModelsModelIdEndpointsGet(ctx, model.Id)
+			modelEndpoints, _, err := apiClient.ModelEndpointsAPI.ModelsModelIdEndpointsGet(ctx, *model.Id).Execute()
 			if err != nil {
 				panic(err)
 			}

--- a/api/client/examples/project-endpoints/main.go
+++ b/api/client/examples/project-endpoints/main.go
@@ -66,7 +66,7 @@ func main() {
 
 		log.Println("Model endpoints:")
 		for _, modelEndpoint := range modelEndpoints {
-			log.Printf("- %s in %s: %s\n", modelEndpoint.Model.Name, modelEndpoint.EnvironmentName, modelEndpoint.Url)
+			log.Printf("- %s in %v: %v\n", modelEndpoint.Model.Name, modelEndpoint.EnvironmentName, modelEndpoint.Url)
 		}
 	}
 }

--- a/api/client/examples/project-endpoints/main.go
+++ b/api/client/examples/project-endpoints/main.go
@@ -28,13 +28,18 @@ func main() {
 	}
 
 	cfg := client.NewConfiguration()
-	cfg.BasePath = basePath
+	cfg.Servers = client.ServerConfigurations{
+		{
+			URL:         basePath,
+			Description: "Merlin base path",
+		},
+	}
 	cfg.HTTPClient = httpClient
 
 	apiClient := client.NewAPIClient(cfg)
 
 	// Get all projects
-	projects, _, err := apiClient.ProjectApi.ProjectsGet(ctx, nil)
+	projects, _, err := apiClient.ProjectAPI.ProjectsGet(ctx).Execute()
 	if err != nil {
 		panic(err)
 	}
@@ -48,7 +53,7 @@ func main() {
 		log.Println("Project:", project.Name)
 
 		// Get all model endpoints in the given project
-		modelEndpoints, _, err := apiClient.ModelEndpointsApi.ProjectsProjectIdModelEndpointsGet(ctx, project.Id, nil)
+		modelEndpoints, _, err := apiClient.ModelEndpointsAPI.ProjectsProjectIdModelEndpointsGet(ctx, project.Id).Execute()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
# Description
With the model schemas and client migration to OpenAPI3 performed in #513, a variety of structs/functions/methods were changed (most are just autogenerated code), including the autogenerated `NewConfiguration()` function from the [api/client/configuration.go](https://github.com/caraml-dev/merlin/blob/main/api/client/configuration.go#L89) file. 

However, there are some places where these changed entities are used and whose surrounding code do not seem to take into account the new changes. Thankfully this occurs only in the example code snippets - this PR updates the code in these examples so any IDE wouldn't show any syntax errors there anymore.

Thanks @jonathanv28 (and his IDE) for catching these 😅
![Screenshot 2024-03-26 at 10 52 56](https://github.com/caraml-dev/merlin/assets/36802364/d8f5a510-1c3d-4d47-9b31-1d93cc728dce)

# Modifications
- `api/client/examples/model-endpoints/main.go` - Update to code expecting pre-OpenAPI3 structs/functions/methods 
- `api/client/examples/project-endpoints/main.go` - Update to code expecting pre-OpenAPI3 structs/functions/methods 

# Tests
NONE

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
