### PR TITLE
add support for observability for xgboost standard model

### DIFF
--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -1479,7 +1479,7 @@ func TestCreateEndpoint(t *testing.T) {
 			feastCoreMock: func() *feastmocks.CoreServiceClient {
 				return &feastmocks.CoreServiceClient{}
 			},
-			expected: BadRequest("Request validation failed: model type should be pyfunc or pyfunc_v3 if want to enable model observablity"),
+			expected: BadRequest("Request validation failed: tensorflow: observability cannot be enabled not for this model type"),
 		},
 		{
 			desc: "Should return 400 if UPI is not supported",
@@ -4828,7 +4828,7 @@ func TestUpdateEndpoint(t *testing.T) {
 			},
 		},
 		{
-			desc: "Should 400 if new endpoint enable model observability but the model is not pyfunc_v3",
+			desc: "Should 400 if new endpoint enable model observability but the model is not one of the supported model type",
 			vars: map[string]string{
 				"model_id":    "1",
 				"version_id":  "1",
@@ -4939,7 +4939,7 @@ func TestUpdateEndpoint(t *testing.T) {
 			},
 			expected: &Response{
 				code: http.StatusBadRequest,
-				data: Error{Message: "Request validation failed: model type should be pyfunc or pyfunc_v3 if want to enable model observablity"},
+				data: Error{Message: "Request validation failed: tensorflow: observability cannot be enabled not for this model type"},
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Currently, observability publisher cannot be deployed automatically for xgboost standard model because the current validator assumes that the support is only enabled on pyfuncv3 model. Since we update the Merlin logger to send prediction log, it is now possible to support xgboost standard model.

We will still need to check whether this will work for other types of standard model as well. But for the time being, we will enable this only for xgboost.

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
