### PR TITLE
feat: handle scenarios where there is no row id but only a single prediction row

### DIFF
--- a/api/pkg/inference-logger/logger/mlobs_sink.go
+++ b/api/pkg/inference-logger/logger/mlobs_sink.go
@@ -80,6 +80,11 @@ func (m *MLObsSink) newPredictionLog(rawLogEntry *LogEntry) (*upiv1.PredictionLo
 	if err != nil {
 		return nil, err
 	}
+	// If there is only one prediction, session id alone is enough to for unique prediction id
+	if len(standardModelRequest.Instances) == 1 && standardModelRequest.RowIds == nil {
+		standardModelRequest.RowIds = []string{""}
+	}
+
 	if len(standardModelRequest.RowIds) != len(standardModelResponse.Predictions) {
 		return nil, fmt.Errorf("%w: number of row ids and predictions do not match", ErrMalformedLogEntry)
 	}

--- a/api/pkg/inference-logger/logger/mlobs_sink_test.go
+++ b/api/pkg/inference-logger/logger/mlobs_sink_test.go
@@ -77,7 +77,19 @@ func TestLogEntryToPredictionLogConversion(t *testing.T) {
 			nil,
 		},
 		{
-			"empty row ids",
+			"empty row ids, multiple rows",
+			&StandardModelRequest{
+				SessionId: "1234",
+				Instances: [][]*float64{
+					{asInstanceValue(1.0)},
+					{asInstanceValue(2.0)},
+				},
+			},
+			newTestStandardModelResponse([]float64{0.0}),
+			ErrMalformedLogEntry,
+		},
+		{
+			"empty row ids, single rows",
 			&StandardModelRequest{
 				SessionId: "1234",
 				Instances: [][]*float64{
@@ -85,7 +97,7 @@ func TestLogEntryToPredictionLogConversion(t *testing.T) {
 				},
 			},
 			newTestStandardModelResponse([]float64{0.0}),
-			ErrMalformedLogEntry,
+			nil,
 		},
 		{
 			"missing session id",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
In some cases, the user is not able to provide a meaningful row id, because there is only a single prediction row and session id alone will uniquely identify the prediction in this case.  We can handle this case by creating an array of row id with a single empty string element if there is only one prediction but row id is not defined.

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
