### PR TITLE
fix(ui): Fix unmovable replica count in TransformerStep

### DIFF
--- a/ui/src/pages/version/components/forms/steps/TransformerStep.js
+++ b/ui/src/pages/version/components/forms/steps/TransformerStep.js
@@ -14,7 +14,7 @@ import { SelectTransformerPanel } from "../components/SelectTransformerPanel";
 
 export const TransformerStep = ({ maxAllowedReplica }) => {
   const {
-    data: { transformer, logger, protocol },
+    data: { transformer, logger, protocol, environment_name },
     onChangeHandler,
   } = useContext(FormContext);
   const { onChange } = useOnChangeHandler(onChangeHandler);
@@ -34,6 +34,7 @@ export const TransformerStep = ({ maxAllowedReplica }) => {
         <>
           <EuiFlexItem grow={false}>
             <ResourcesPanel
+              environment={environment_name}
               isGPUEnabled={false}
               resourcesConfig={transformer.resource_request}
               onChangeHandler={onChange("transformer.resource_request")}


### PR DESCRIPTION
# Description
This PR fixes a tiny bug whereby the replica count slider of a transformer is not movable. This happens because the value `environment` in the `ResourcesPanel` component is `undefined`, and this happens because the `TransformerStep` component that uses it doesn't pass any value for environment as a prop, unlike `ModelStep`. As such, this PR modifies `TransformerStep` to pass the `environment_name` (the environment selected by the user in `ModelStep`) as a prop to `ResourcesPanel`.

![Screenshot 2024-04-02 at 6 57 13 PM](https://github.com/caraml-dev/merlin/assets/36802364/a54003cd-a382-47a6-9917-78d6a47da791)

# Modifications
- `ui/src/pages/version/components/forms/steps/TransformerStep.js` - Make `TransformerStep` pass `environment_name` to `ResourcesPanel`. 

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
