### PR TITLE
fix: Update path of batch-predictor's main.py

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ ImageBuilderConfig:
     DockerfilePath: docker/app.Dockerfile
     BuildContextURI: git://github.com/gojek/merlin.git#refs/tags/v0.37.0
     BuildContextSubPath: python
-    MainAppPath: /home/spark/main.py
+    MainAppPath: /home/spark/merlin-spark-app/main.py
   BuildNamespace: mlp
   DockerRegistry: ghcr.io/caraml-dev
   BuildTimeout: 10m

--- a/python/batch-predictor/docker/base.Dockerfile
+++ b/python/batch-predictor/docker/base.Dockerfile
@@ -81,6 +81,6 @@ RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/${MI
     $CONDA_DIR/bin/conda clean -afy && \
     echo "source $CONDA_DIR/etc/profile.d/conda.sh" >> $HOME/.bashrc
 
-COPY batch-predictor/docker/main.py ${HOME}/main.py
+COPY batch-predictor/docker/main.py ${HOME}/merlin-spark-app/main.py
 COPY batch-predictor/docker/merlin_entrypoint.sh /usr/bin/merlin_entrypoint.sh
 COPY batch-predictor/docker/process_conda_env.sh /usr/bin/process_conda_env.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description

To maintain backward compatibility with images created prior to 0.41, we will revert the merlin-batch-predictor's main.py location.

# Modifications
<!-- Summarize the key code changes. -->

Update batch-predictor's main.py location.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
