### PR TITLE
fix(api): Fix autoscaler target string parsing to not drop decimal numbers

### DIFF
--- a/api/cluster/resource/templater_gpu_test.go
+++ b/api/cluster/resource/templater_gpu_test.go
@@ -1211,7 +1211,7 @@ func TestCreateInferenceServiceSpecWithGPU(t *testing.T) {
 						knautoscaling.InitialScaleAnnotationKey:               fmt.Sprint(testPredictorScale),
 						knautoscaling.ClassAnnotationKey:                      knautoscaling.KPA,
 						knautoscaling.MetricAnnotationKey:                     knautoscaling.Concurrency,
-						knautoscaling.TargetAnnotationKey:                     "2",
+						knautoscaling.TargetAnnotationKey:                     "2.00",
 					},
 					Labels: map[string]string{
 						"gojek.com/app":          modelSvc.Metadata.App,

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -1596,6 +1596,28 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "serverless deployment using concurrency autoscaling where target after rounding < 0.01",
+			modelSvc: &models.Service{
+				Name:           modelSvc.Name,
+				ModelName:      modelSvc.ModelName,
+				ModelVersion:   modelSvc.ModelVersion,
+				Namespace:      project.Name,
+				ArtifactURI:    modelSvc.ArtifactURI,
+				Type:           models.ModelTypeTensorflow,
+				Options:        &models.ModelOption{},
+				Metadata:       modelSvc.Metadata,
+				DeploymentMode: deployment.ServerlessDeploymentMode,
+				AutoscalingPolicy: &autoscaling.AutoscalingPolicy{
+					MetricsType: autoscaling.Concurrency,
+					TargetValue: 0.004,
+				},
+				Protocol: protocol.HttpJson,
+			},
+			resourcePercentage: queueResourcePercentage,
+			deploymentScale:    defaultDeploymentScale,
+			wantErr:            true,
+		},
+		{
 			name: "serverless deployment using rps autoscaling",
 			modelSvc: &models.Service{
 				Name:           modelSvc.Name,

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -1561,7 +1561,7 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 						kserveconstant.DeploymentMode:                         string(kserveconstant.Serverless),
 						knautoscaling.ClassAnnotationKey:                      knautoscaling.KPA,
 						knautoscaling.MetricAnnotationKey:                     knautoscaling.Concurrency,
-						knautoscaling.TargetAnnotationKey:                     "2",
+						knautoscaling.TargetAnnotationKey:                     "2.00",
 						knautoscaling.InitialScaleAnnotationKey:               fmt.Sprint(testPredictorScale),
 					},
 					Labels: map[string]string{

--- a/api/cluster/resource/utils.go
+++ b/api/cluster/resource/utils.go
@@ -27,7 +27,10 @@ func toKNativeAutoscalerMetrics(metricsType autoscaling.MetricsType, metricsValu
 		targetValue := fmt.Sprintf("%.0f", metricsValue)
 		return knautoscaling.RPS, targetValue, nil
 	case autoscaling.Concurrency:
-		targetValue := fmt.Sprintf("%.0f", metricsValue)
+		targetValue := fmt.Sprintf("%.2f", metricsValue)
+		if targetValue == "0.00" {
+			return "", "", fmt.Errorf("concurrency target %v should be at least 0.01", metricsValue)
+		}
 		return knautoscaling.Concurrency, targetValue, nil
 	default:
 		return "", "", fmt.Errorf("unsuppported autoscaler metrics on serverless deployment: %s", metricsType)

--- a/python/sdk/test/conftest.py
+++ b/python/sdk/test/conftest.py
@@ -16,6 +16,7 @@ import os
 
 import mlflow
 import pytest
+import uuid
 import requests as requests_lib
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -82,11 +83,9 @@ def model(project, mlflow_url, api_client):
 @pytest.fixture
 def version(project, model, mlflow_url, api_client):
     mlflow.set_tracking_uri(mlflow_url)
-    run_id = None
-    if not mlflow.get_experiment_by_name("unit_test_experiment"):
-        run_id = mlflow.create_experiment(
-            name="unit_test_experiment"
-        )
+    run_id = mlflow.create_experiment(
+        name=f"unit_test_experiment_{uuid.uuid4()}"
+    )
     r = mlflow.start_run(experiment_id=run_id)
     mlflow.end_run()
     v = cl.Version(


### PR DESCRIPTION
# Description
As of present, users who have set a concurrency target=1 for their deployments and would like them to scale up even earlier (i.e. before the actual concurrency reaches 1) are unable to do so by simply setting the target as any float < 1 (e.g. 0.7), as the Merlin API server rounds it to the nearest integer. This was done so because the autoscaling target annotation in the Knative service manifest `autoscaling.knative.dev/target`, _**seems to require**_ an [INTEGER](https://knative.dev/docs/serving/autoscaling/concurrency/#soft-limit). 

However, when we tried setting the value of the aforementioned annotation with a variety of values (including float values < 1 and 0), we noticed that float values < 1 surprisingly work and correctly modifies the `autoscaler_target_concurrency_per_pod` metric (this values is calculated by the formula `target_concurrency = user_specified_target * target_utilization (default 70)` generated. On the other hand, setting values such as 0 or anything < 0.01 will cause the Knative admission webhook to return an [error](https://github.com/knative/serving/blob/b1c026628485c16c8a9191553b6adde280f2d2b0/pkg/apis/autoscaling/annotation_validation.go#L115) like the one shown below:

```
Warning  InternalError  21s (x16 over 3m5s)  v1beta1Controllers  fails to reconcile predictor: admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: target 0 should be at least 0.01: spec.template.metadata.annotations.autoscaling.knative.dev/target
```

As such, this PR makes a tiny change to the concurrency (only) target annotation value, by allowing values up to 2 decimal places (as such values from 0.01 - 0.99 are now allowed) to be set. Values below 0.01 after rounding will cause an error to be returned - this prevents the deployment from being stuck in a pending state because the Knative webhook rejects the annotation's value.

# Modifications
- `api/cluster/resource/utils.go` - Changing of the rounding of the concurrency target annotation value from the closest integer to the closest 2 decimal places

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
Users that have previously set an autoscaling concurrency target of 0.01 - 1 will now experience earlier scaling up of their deployments and can no longer set 0 as an autoscaling concurrency target.
```
