### PR TITLE
Fix image building test for batch job

### DIFF
--- a/python/sdk/test/build_image_integration_test.py
+++ b/python/sdk/test/build_image_integration_test.py
@@ -1,8 +1,16 @@
-from test.batch_integration_test import IrisClassifier
+from test.batch_integration_test import (
+    MODEL_PATH,
+    MODEL_PATH_ARTIFACT_KEY,
+    IrisClassifier,
+)
 from test.pyfunc_integration_test import EnvVarModel
 
-import merlin
+import joblib
 import pytest
+from sklearn import svm
+from sklearn.datasets import load_iris
+
+import merlin
 from merlin.model import ModelType
 
 
@@ -34,12 +42,18 @@ def test_build_image_batch(integration_test_url, project_name, use_google_oauth)
     merlin.set_project(project_name)
     merlin.set_model("build-image-batch", ModelType.PYFUNC_V2)
 
+    clf = svm.SVC(gamma="scale")
+    iris = load_iris()
+    X, y = iris.data, iris.target
+    clf.fit(X, y)
+    joblib.dump(clf, MODEL_PATH)
+
     with merlin.new_model_version() as v:
         v.log_pyfunc_model(
             model_instance=IrisClassifier(),
             conda_env="test/batch/model/env.yaml",
             code_dir=["test"],
-            artifacts={"model_path": "test/batch/model/model.joblib"},
+            artifacts={MODEL_PATH_ARTIFACT_KEY: MODEL_PATH},
         )
 
     image = merlin.build_image(v)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

The image building test for batch job requires the model artifact to be available first (trained and saved in a path).

This PR fixes the missing step training and saving the model artifact mentioned above.

# Modifications
<!-- Summarize the key code changes. -->

Add model training step first before image building test.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
