### PR TITLE
fix(ui): Update min and step size of autoscaling target field

### DIFF
--- a/ui/src/pages/version/components/forms/components/AutoscalingPolicyFormGroup.js
+++ b/ui/src/pages/version/components/forms/components/AutoscalingPolicyFormGroup.js
@@ -128,7 +128,10 @@ export const AutoscalingPolicyFormGroup = ({
       <EuiFormRow label="Target">
         <EuiFieldNumber
           onChange={onTargetValueChange}
-          min={1}
+          // The min value is set as 0.005 because it's the smallest value, when rounded to 2 decimal places, gives
+          // 0.01, the smallest value accepted as an autoscaling target (concurrency).
+          min={0.005}
+          step={"any"}
           value={autoscalingPolicy.target_value}
         />
       </EuiFormRow>


### PR DESCRIPTION
# Description
This PR introduces a fix to address a tiny UI bug whereby a red line appears when an autoscaling target value that is outside the configured step size (e.g. 1.003 when the step size is 1) is set: 
![Screenshot 2024-05-09 at 2 16 06 PM](https://github.com/caraml-dev/merlin/assets/36802364/85c7d35d-31bf-406b-9312-9a6cb729f36b)

The fix implemented is exactly the same as what has been done for Turing here: https://github.com/caraml-dev/turing/pull/380#discussion_r1595000003.

# Modifications
- `ui/src/pages/version/components/forms/components/AutoscalingPolicyFormGroup.js` - Update to some props passed to the `EuiFieldNumber` component

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
None
```
