### PR TITLE
Fix PDB and VS not deleted

### DIFF
--- a/api/cluster/controller.go
+++ b/api/cluster/controller.go
@@ -252,7 +252,7 @@ func (c *controller) Deploy(ctx context.Context, modelService *models.Service) (
 
 	if c.deploymentConfig.PodDisruptionBudget.Enabled {
 		// Create / update pdb
-		pdbs := createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
+		pdbs := generatePDBSpecs(modelService, c.deploymentConfig.PodDisruptionBudget)
 		if err := c.deployPodDisruptionBudgets(ctx, pdbs); err != nil {
 			log.Errorf("unable to create pdb: %v", err)
 			return nil, errors.Wrapf(err, fmt.Sprintf("%v", ErrUnableToCreatePDB))
@@ -321,7 +321,7 @@ func (c *controller) Delete(ctx context.Context, modelService *models.Service) (
 	}
 
 	if c.deploymentConfig.PodDisruptionBudget.Enabled {
-		pdbs := createPodDisruptionBudgets(modelService, c.deploymentConfig.PodDisruptionBudget)
+		pdbs := generatePDBSpecs(modelService, c.deploymentConfig.PodDisruptionBudget)
 		if err := c.deletePodDisruptionBudgets(ctx, pdbs); err != nil {
 			log.Errorf("unable to delete pdb %v", err)
 			return nil, ErrUnableToDeletePDB

--- a/api/cluster/pdb.go
+++ b/api/cluster/pdb.go
@@ -73,7 +73,7 @@ func (cfg PodDisruptionBudget) BuildPDBSpec() (*policyv1.PodDisruptionBudget, er
 	return pdb, nil
 }
 
-func createPodDisruptionBudgets(modelService *models.Service, pdbConfig config.PodDisruptionBudgetConfig) []*PodDisruptionBudget {
+func generatePDBSpecs(modelService *models.Service, pdbConfig config.PodDisruptionBudgetConfig) []*PodDisruptionBudget {
 	pdbs := []*PodDisruptionBudget{}
 
 	// Only create PDB if: ceil(minReplica * minAvailablePercent) < minReplica

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	metav1cfg "k8s.io/client-go/applyconfigurations/meta/v1"
-	policyv1cfg "k8s.io/client-go/applyconfigurations/policy/v1"
 
 	"github.com/caraml-dev/merlin/config"
 	"github.com/caraml-dev/merlin/models"
@@ -32,7 +31,7 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 	tests := []struct {
 		name    string
 		fields  fields
-		want    *policyv1cfg.PodDisruptionBudgetSpecApplyConfiguration
+		want    *policyv1.PodDisruptionBudget
 		wantErr bool
 	}{
 		{
@@ -44,10 +43,21 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 				MaxUnavailablePercentage: nil,
 				MinAvailablePercentage:   &defaultInt,
 			},
-			want: &policyv1cfg.PodDisruptionBudgetSpecApplyConfiguration{
-				MinAvailable: &defaultIntOrString,
-				Selector: &metav1cfg.LabelSelectorApplyConfiguration{
-					MatchLabels: defaultLabels,
+			want: &policyv1.PodDisruptionBudget{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "policy/v1",
+					Kind:       "PodDisruptionBudget",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn-sample-s-1-model-pdb",
+					Namespace: "pdb-test",
+					Labels:    defaultLabels,
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: defaultLabels,
+					},
+					MinAvailable: &defaultIntOrString,
 				},
 			},
 			wantErr: false,
@@ -61,10 +71,21 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 				MaxUnavailablePercentage: &defaultInt,
 				MinAvailablePercentage:   &defaultInt,
 			},
-			want: &policyv1cfg.PodDisruptionBudgetSpecApplyConfiguration{
-				MinAvailable: &defaultIntOrString,
-				Selector: &metav1cfg.LabelSelectorApplyConfiguration{
-					MatchLabels: defaultLabels,
+			want: &policyv1.PodDisruptionBudget{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "policy/v1",
+					Kind:       "PodDisruptionBudget",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sklearn-sample-s-1-model-pdb",
+					Namespace: "pdb-test",
+					Labels:    defaultLabels,
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: defaultLabels,
+					},
+					MinAvailable: &defaultIntOrString,
 				},
 			},
 			wantErr: false,

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -124,7 +124,7 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 	}
 }
 
-func TestCreatePodDisruptionBudgets(t *testing.T) {
+func Test_generatePDBSpecs(t *testing.T) {
 	err := models.InitKubernetesLabeller("gojek.com/", "dev")
 	assert.Nil(t, err)
 
@@ -343,7 +343,7 @@ func TestCreatePodDisruptionBudgets(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			pdbs := createPodDisruptionBudgets(tt.modelService, tt.pdbConfig)
+			pdbs := generatePDBSpecs(tt.modelService, tt.pdbConfig)
 			assert.Equal(t, tt.expected, pdbs)
 		})
 	}

--- a/api/cluster/virtual_service.go
+++ b/api/cluster/virtual_service.go
@@ -222,6 +222,6 @@ func (c *controller) deployVirtualService(ctx context.Context, vsCfg *VirtualSer
 		Patch(ctx, vsCfg.Name, types.ApplyPatchType, vsJSON, metav1.PatchOptions{FieldManager: "application/apply-patch", Force: &forceEnabled})
 }
 
-func (c *controller) deleteVirtualService(ctx context.Context, name, namespace string) error {
-	return c.istioClient.VirtualServices(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+func (c *controller) deleteVirtualService(ctx context.Context, vsCfg *VirtualService) error {
+	return c.istioClient.VirtualServices(vsCfg.Namespace).Delete(ctx, vsCfg.Name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

This PR solves two bugs:

1. Previous PDB not deleted when redeployed
   a. The previous implementation only used Apply to create a new revision's PDB without deleting the previous revision's PDB.
  b. This PR uses Patch instead of Apply so it will only use one PDB to every revision
2. Virtual service not deleted when undeployed
   a. This issue happens due to condition logic that would only delete VS with revision > 1. Removing this condition solve the issue.
   b. This condition was created to maintain backward compatibility to VS without revision, but the implementation is faulty.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
