### PR TITLE
fix: Add resource request's max replica validation

### DIFF
--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -157,6 +157,7 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 	}
 
 	validationRules := []requestValidator{
+		resourceRequestValidation(newEndpoint),
 		customModelValidation(model, version),
 		upiModelValidation(model, newEndpoint.Protocol),
 		newVersionEndpointValidation(version, env.Name),
@@ -218,6 +219,7 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 	}
 
 	validationRules := []requestValidator{
+		resourceRequestValidation(newEndpoint),
 		customModelValidation(model, version),
 		updateRequestValidation(endpoint, newEndpoint),
 		modelObservabilityValidation(newEndpoint, model),

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1264,7 +1264,7 @@ class ModelVersion:
                     default_resource_request.min_replica
                 )
 
-            if target_resource_request.max_replica is None:
+            if target_resource_request.max_replica is None or target_resource_request.max_replica < 1:
                 target_resource_request.max_replica = (
                     default_resource_request.max_replica
                 )

--- a/python/sdk/merlin/resource_request.py
+++ b/python/sdk/merlin/resource_request.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
+
 from typing import Optional
 
 import client
+
 
 class ResourceRequest:
     """
@@ -46,7 +48,7 @@ class ResourceRequest:
             cpu_request=response.cpu_request,
             memory_request=response.memory_request,
             gpu_request=response.gpu_request,
-            gpu_name=response.gpu_name
+            gpu_name=response.gpu_name,
         )
 
     @property
@@ -99,7 +101,10 @@ class ResourceRequest:
 
     def validate(self):
         if self._min_replica is None and self._max_replica is None:
-            return 
+            return
 
         if self._min_replica > self._max_replica:
             raise Exception("Min replica must be less or equal to max replica")
+
+        if self._max_replica == 0:
+            raise Exception("Max replica must be greater than 0")

--- a/python/sdk/merlin/resource_request.py
+++ b/python/sdk/merlin/resource_request.py
@@ -106,5 +106,5 @@ class ResourceRequest:
         if self._min_replica > self._max_replica:
             raise Exception("Min replica must be less or equal to max replica")
 
-        if self._max_replica == 0:
+        if self._max_replica < 1:
             raise Exception("Max replica must be greater than 0")

--- a/python/sdk/test/resource_request_test.py
+++ b/python/sdk/test/resource_request_test.py
@@ -18,17 +18,23 @@ from merlin.resource_request import ResourceRequest
 
 
 @pytest.mark.unit
-def test_resource_request_validate():
-    resource_request = ResourceRequest(1, 2, "100m", "128Mi")
-    resource_request.validate()
+def test_resource_request():
+    # Valid resource_request
+    ResourceRequest(
+        min_replica=1, max_replica=2, cpu_request="100m", memory_request="128Mi"
+    )
 
-    resource_request.min_replica = 10
+    # Valid resource_request even though min_replica and max_replica are None
+    ResourceRequest(cpu_request="100m", memory_request="128Mi")
+
     with pytest.raises(
         Exception, match="Min replica must be less or equal to max replica"
     ):
-        resource_request.validate()
+        ResourceRequest(
+            min_replica=100, max_replica=2, cpu_request="100m", memory_request="128Mi"
+        )
 
-    resource_request.min_replica = 0
-    resource_request.max_replica = 0
     with pytest.raises(Exception, match="Max replica must be greater than 0"):
-        resource_request.validate()
+        ResourceRequest(
+            min_replica=0, max_replica=0, cpu_request="100m", memory_request="128Mi"
+        )

--- a/python/sdk/test/resource_request_test.py
+++ b/python/sdk/test/resource_request_test.py
@@ -28,6 +28,18 @@ def test_resource_request():
     ResourceRequest(cpu_request="100m", memory_request="128Mi")
 
     with pytest.raises(
+        TypeError,
+        match="'>' not supported between instances of 'int' and 'NoneType'",
+    ):
+        ResourceRequest(min_replica=1, cpu_request="100m", memory_request="128Mi")
+
+    with pytest.raises(
+        TypeError,
+        match="'>' not supported between instances of 'NoneType' and 'int'",
+    ):
+        ResourceRequest(max_replica=1, cpu_request="100m", memory_request="128Mi")
+
+    with pytest.raises(
         Exception, match="Min replica must be less or equal to max replica"
     ):
         ResourceRequest(

--- a/python/sdk/test/resource_request_test.py
+++ b/python/sdk/test/resource_request_test.py
@@ -23,5 +23,12 @@ def test_resource_request_validate():
     resource_request.validate()
 
     resource_request.min_replica = 10
-    with pytest.raises(Exception, match="Min replica must be less or equal to max replica"):
+    with pytest.raises(
+        Exception, match="Min replica must be less or equal to max replica"
+    ):
+        resource_request.validate()
+
+    resource_request.min_replica = 0
+    resource_request.max_replica = 0
+    with pytest.raises(Exception, match="Max replica must be greater than 0"):
         resource_request.validate()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

This PR adds validation on resource request max replicas value to avoid the 0 value. The validations were added on API and SDK.

This is to avoid the bug if max replicas = 0 that will result in the no-upper limit of replicas for the inference service which could scaled up indefinitely till the entire cluster exhausted.

# Modifications
<!-- Summarize the key code changes. -->

1. Add max replicas < 1 validation in API
2. Add max replicas < 1 validation in SDK

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
* merlin-sdk will raise an Exception if ResourceRequest object is initialized with max_repilcas=0.
```
