### PR TITLE
cherry-pick: Add resource request's max replica validation (#588) for hotfix

### DIFF
--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -157,6 +157,7 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 	}
 
 	validationRules := []requestValidator{
+		resourceRequestValidation(newEndpoint),
 		customModelValidation(model, version),
 		upiModelValidation(model, newEndpoint.Protocol),
 		newVersionEndpointValidation(version, env.Name),
@@ -218,6 +219,7 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 	}
 
 	validationRules := []requestValidator{
+		resourceRequestValidation(newEndpoint),
 		customModelValidation(model, version),
 		updateRequestValidation(endpoint, newEndpoint),
 		modelObservabilityValidation(newEndpoint, model),

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -24,7 +24,6 @@ from time import sleep
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import docker
-import mlflow
 import pyprind
 from docker import APIClient
 from docker.models.containers import Container
@@ -34,21 +33,13 @@ from mlflow.pyfunc import PythonModel
 from mlflow.tracking.client import MlflowClient
 
 import client
-from client import (
-    EndpointApi,
-    EnvironmentApi,
-    ModelEndpointsApi,
-    ModelsApi,
-    SecretApi,
-    VersionApi,
-    VersionImageApi,
-)
+import mlflow
+from client import (EndpointApi, EnvironmentApi, ModelEndpointsApi, ModelsApi,
+                    SecretApi, VersionApi, VersionImageApi)
 from merlin import pyfunc
-from merlin.autoscaling import (
-    RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY,
-    SERVERLESS_DEFAULT_AUTOSCALING_POLICY,
-    AutoscalingPolicy,
-)
+from merlin.autoscaling import (RAW_DEPLOYMENT_DEFAULT_AUTOSCALING_POLICY,
+                                SERVERLESS_DEFAULT_AUTOSCALING_POLICY,
+                                AutoscalingPolicy)
 from merlin.batch.config import PredictionJobConfig
 from merlin.batch.job import PredictionJob
 from merlin.batch.sink import BigQuerySink
@@ -63,13 +54,9 @@ from merlin.pyfunc import run_pyfunc_local_server
 from merlin.requirements import process_conda_env
 from merlin.resource_request import ResourceRequest
 from merlin.transformer import Transformer
-from merlin.util import (
-    autostr,
-    download_files_from_gcs,
-    extract_optional_value_with_default,
-    guess_mlp_ui_url,
-    valid_name_check,
-)
+from merlin.util import (autostr, download_files_from_gcs,
+                         extract_optional_value_with_default, guess_mlp_ui_url,
+                         valid_name_check)
 from merlin.validation import validate_model_dir
 from merlin.version_image import VersionImage
 
@@ -1229,6 +1216,9 @@ class ModelVersion:
         )
 
         current_endpoint = self._get_endpoint_in_environment(target_env_name)
+        default_resource_request = ModelVersion._get_default_resource_request(
+            target_env_name, env_list
+        )
 
         target_deployment_mode = None
         target_protocol = None
@@ -1244,9 +1234,7 @@ class ModelVersion:
         if current_endpoint is None:
             target_deployment_mode = DeploymentMode.SERVERLESS.value
             target_protocol = Protocol.HTTP_JSON.value
-            target_resource_request = ModelVersion._get_default_resource_request(
-                target_env_name, env_list
-            )
+            target_resource_request = default_resource_request
             target_autoscaling_policy = ModelVersion._get_default_autoscaling_policy(
                 deployment_mode.value
                 if deployment_mode is not None
@@ -1270,6 +1258,17 @@ class ModelVersion:
                 cpu_request=resource_request.cpu_request,
                 memory_request=resource_request.memory_request,
             )
+
+            if target_resource_request.min_replica is None:
+                target_resource_request.min_replica = (
+                    default_resource_request.min_replica
+                )
+
+            if target_resource_request.max_replica is None or target_resource_request.max_replica < 1:
+                target_resource_request.max_replica = (
+                    default_resource_request.max_replica
+                )
+
             if (
                 resource_request.gpu_request is not None
                 and resource_request.gpu_name is not None

--- a/python/sdk/merlin/resource_request.py
+++ b/python/sdk/merlin/resource_request.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
+
 from typing import Optional
 
 import client
+
 
 class ResourceRequest:
     """
@@ -46,7 +48,7 @@ class ResourceRequest:
             cpu_request=response.cpu_request,
             memory_request=response.memory_request,
             gpu_request=response.gpu_request,
-            gpu_name=response.gpu_name
+            gpu_name=response.gpu_name,
         )
 
     @property
@@ -99,7 +101,10 @@ class ResourceRequest:
 
     def validate(self):
         if self._min_replica is None and self._max_replica is None:
-            return 
+            return
 
         if self._min_replica > self._max_replica:
             raise Exception("Min replica must be less or equal to max replica")
+
+        if self._max_replica < 1:
+            raise Exception("Max replica must be greater than 0")

--- a/python/sdk/test/resource_request_test.py
+++ b/python/sdk/test/resource_request_test.py
@@ -18,10 +18,35 @@ from merlin.resource_request import ResourceRequest
 
 
 @pytest.mark.unit
-def test_resource_request_validate():
-    resource_request = ResourceRequest(1, 2, "100m", "128Mi")
-    resource_request.validate()
+def test_resource_request():
+    # Valid resource_request
+    ResourceRequest(
+        min_replica=1, max_replica=2, cpu_request="100m", memory_request="128Mi"
+    )
 
-    resource_request.min_replica = 10
-    with pytest.raises(Exception, match="Min replica must be less or equal to max replica"):
-        resource_request.validate()
+    # Valid resource_request even though min_replica and max_replica are None
+    ResourceRequest(cpu_request="100m", memory_request="128Mi")
+
+    with pytest.raises(
+        TypeError,
+        match="'>' not supported between instances of 'int' and 'NoneType'",
+    ):
+        ResourceRequest(min_replica=1, cpu_request="100m", memory_request="128Mi")
+
+    with pytest.raises(
+        TypeError,
+        match="'>' not supported between instances of 'NoneType' and 'int'",
+    ):
+        ResourceRequest(max_replica=1, cpu_request="100m", memory_request="128Mi")
+
+    with pytest.raises(
+        Exception, match="Min replica must be less or equal to max replica"
+    ):
+        ResourceRequest(
+            min_replica=100, max_replica=2, cpu_request="100m", memory_request="128Mi"
+        )
+
+    with pytest.raises(Exception, match="Max replica must be greater than 0"):
+        ResourceRequest(
+            min_replica=0, max_replica=0, cpu_request="100m", memory_request="128Mi"
+        )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->

This PR adds validation on resource request max replicas value to avoid the 0 value. The validations were added on API and SDK.

This is to avoid the bug if max replicas = 0 that will result in the no-upper limit of replicas for the inference service which could scaled up indefinitely till the entire cluster exhausted.

# Modifications
<!-- Summarize the key code changes. -->

1. Add max replicas < 1 validation in API
2. Add max replicas < 1 validation in SDK

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models -->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below. If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md -->

```release-note
* merlin-sdk will raise an Exception if ResourceRequest object is initialized with max_repilcas=0.
```