### PR TITLE
fix: Only use columns that already defined in inference schema

### DIFF
--- a/python/observation-publisher/publisher/prediction_log_consumer.py
+++ b/python/observation-publisher/publisher/prediction_log_consumer.py
@@ -10,20 +10,22 @@ from caraml.upi.v1.prediction_log_pb2 import PredictionLog
 from confluent_kafka import Consumer, KafkaException
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from merlin.observability.inference import InferenceSchema, ObservationType
-
 from publisher.config import ObservationSource, ObservationSourceConfig
 from publisher.metric import MetricWriter
 from publisher.observation_sink import ObservationSink
-from publisher.prediction_log_parser import (PREDICTION_LOG_MODEL_VERSION_COLUMN,
-                                             PREDICTION_LOG_TIMESTAMP_COLUMN,
-                                             PredictionLogFeatureTable,
-                                             PredictionLogResultsTable)
+from publisher.prediction_log_parser import (
+    PREDICTION_LOG_MODEL_VERSION_COLUMN,
+    PREDICTION_LOG_TIMESTAMP_COLUMN,
+    PredictionLogFeatureTable,
+    PredictionLogResultsTable,
+)
 
 
 class PredictionLogConsumer(abc.ABC):
     """
     Abstract class for consuming prediction logs from a streaming source, then write to one or multiple sinks
     """
+
     def __init__(self, buffer_capacity: int, buffer_max_duration_seconds: int):
         self.buffer_capacity = buffer_capacity
         self.buffer_max_duration_seconds = buffer_max_duration_seconds
@@ -92,7 +94,8 @@ class PredictionLogConsumer(abc.ABC):
                     len(buffered_logs)
                 )
                 write_tasks = [
-                    Thread(target=sink.write, args=(df.copy(),)) for sink in observation_sinks
+                    Thread(target=sink.write, args=(df.copy(),))
+                    for sink in observation_sinks
                 ]
                 for task in write_tasks:
                     task.start()

--- a/python/observation-publisher/tests/test_prediction_log_consumer.py
+++ b/python/observation-publisher/tests/test_prediction_log_consumer.py
@@ -7,7 +7,6 @@ from caraml.upi.v1.prediction_log_pb2 import PredictionLog
 from merlin.observability.inference import (BinaryClassificationOutput,
                                             InferenceSchema, ValueType)
 from pandas._testing import assert_frame_equal
-
 from publisher.prediction_log_consumer import log_batch_to_dataframe
 
 
@@ -97,7 +96,7 @@ def test_log_to_dataframe():
             score_threshold=0.5,
         ),
         session_id_column="order_id",
-        row_id_column="driver_id"
+        row_id_column="driver_id",
     )
     input_columns = [
         "acceptance_rate",
@@ -147,10 +146,180 @@ def test_log_to_dataframe():
     )
     expected_df = pd.DataFrame.from_records(
         [
-            [0.8, 24, "FOOD", 0.9, "fraud", "1234", "a", request_timestamp, model_version],
-            [0.5, 2, "RIDE", 0.5, "fraud", "1234", "b", request_timestamp, model_version],
-            [1.0, 13, "CAR", 0.4, "non fraud", "5678", "c", request_timestamp, model_version],
-            [0.4, 60, "RIDE", 0.2, "non fraud", "5678", "d", request_timestamp, model_version],
+            [
+                0.8,
+                24,
+                "FOOD",
+                0.9,
+                "fraud",
+                "1234",
+                "a",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.5,
+                2,
+                "RIDE",
+                0.5,
+                "fraud",
+                "1234",
+                "b",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                1.0,
+                13,
+                "CAR",
+                0.4,
+                "non fraud",
+                "5678",
+                "c",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.4,
+                60,
+                "RIDE",
+                0.2,
+                "non fraud",
+                "5678",
+                "d",
+                request_timestamp,
+                model_version,
+            ],
+        ],
+        columns=[
+            "acceptance_rate",
+            "minutes_since_last_order",
+            "service_type",
+            "prediction_score",
+            "_prediction_label",
+            "order_id",
+            "driver_id",
+            "request_timestamp",
+            "model_version",
+        ],
+    )
+    assert_frame_equal(prediction_logs_df, expected_df, check_like=True)
+
+
+def test_log_to_dataframe_containing_unnecessary_fields():
+    model_id = "test_model"
+    model_version = "0.1.0"
+    inference_schema = InferenceSchema(
+        feature_types={
+            "acceptance_rate": ValueType.FLOAT64,
+            "minutes_since_last_order": ValueType.INT64,
+            "service_type": ValueType.STRING,
+        },
+        model_prediction_output=BinaryClassificationOutput(
+            prediction_score_column="prediction_score",
+            actual_score_column="actual_score",
+            positive_class_label="fraud",
+            negative_class_label="non fraud",
+            score_threshold=0.5,
+        ),
+        session_id_column="order_id",
+        row_id_column="driver_id",
+    )
+    input_columns = [
+        "acceptance_rate",
+        "distance",
+        "driver_id",
+        "minutes_since_last_order",
+        "order_id",
+        "service_type",
+    ]
+    output_columns = ["prediction_score", "prediction_tag"]
+    request_timestamp = datetime(2021, 1, 1, 0, 0, 0)
+    prediction_logs = [
+        new_prediction_log(
+            session_id="1234",
+            model_id=model_id,
+            model_version=model_version,
+            input_columns=input_columns,
+            input_data=[
+                [0.8, 11.2, 1, 24, "FOOD_1", "FOOD"],
+                [0.5, 10.1, 11, 2, "RIDE_11", "RIDE"],
+            ],
+            output_columns=output_columns,
+            output_data=[
+                [0.9, "ok"],
+                [0.5, "neutral"],
+            ],
+            request_timestamp=request_timestamp,
+            row_ids=["a", "b"],
+        ),
+        new_prediction_log(
+            session_id="5678",
+            model_id=model_id,
+            model_version=model_version,
+            input_columns=input_columns,
+            input_data=[
+                [1.0, 2.2, 1, 13, "CAR_1", "CAR"],
+                [0.4, 3.3, 11, 60, "RIDE_11", "RIDE"],
+            ],
+            output_columns=output_columns,
+            output_data=[
+                [0.4, "bad"],
+                [0.2, "bad"],
+            ],
+            request_timestamp=request_timestamp,
+            row_ids=["c", "d"],
+        ),
+    ]
+    prediction_logs_df = log_batch_to_dataframe(
+        prediction_logs, inference_schema, model_version
+    )
+    expected_df = pd.DataFrame.from_records(
+        [
+            [
+                0.8,
+                24,
+                "FOOD",
+                0.9,
+                "fraud",
+                "1234",
+                "a",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.5,
+                2,
+                "RIDE",
+                0.5,
+                "fraud",
+                "1234",
+                "b",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                1.0,
+                13,
+                "CAR",
+                0.4,
+                "non fraud",
+                "5678",
+                "c",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.4,
+                60,
+                "RIDE",
+                0.2,
+                "non fraud",
+                "5678",
+                "d",
+                request_timestamp,
+                model_version,
+            ],
         ],
         columns=[
             "acceptance_rate",
@@ -245,7 +414,7 @@ def test_standard_model_log_to_dataframe():
             score_threshold=0.5,
         ),
         session_id_column="order_id",
-        row_id_column="driver_id"
+        row_id_column="driver_id",
     )
     request_timestamp = datetime(2021, 1, 1, 0, 0, 0)
     prediction_logs = [
@@ -285,10 +454,50 @@ def test_standard_model_log_to_dataframe():
     )
     expected_df = pd.DataFrame.from_records(
         [
-            [0.8, 24, "FOOD", 0.9, "fraud", "1234", "a", request_timestamp, model_version],
-            [0.5, 2, "RIDE", 0.5, "fraud", "1234", "b", request_timestamp, model_version],
-            [1.0, 13, "CAR", 0.4, "non fraud", "5678", "c", request_timestamp, model_version],
-            [0.4, 60, "RIDE", 0.2, "non fraud", "5678", "d", request_timestamp, model_version],
+            [
+                0.8,
+                24,
+                "FOOD",
+                0.9,
+                "fraud",
+                "1234",
+                "a",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.5,
+                2,
+                "RIDE",
+                0.5,
+                "fraud",
+                "1234",
+                "b",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                1.0,
+                13,
+                "CAR",
+                0.4,
+                "non fraud",
+                "5678",
+                "c",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.4,
+                60,
+                "RIDE",
+                0.2,
+                "non fraud",
+                "5678",
+                "d",
+                request_timestamp,
+                model_version,
+            ],
         ],
         columns=[
             "acceptance_rate",
@@ -323,7 +532,7 @@ def test_one_dimensional_prediction_output_to_dataframe():
             score_threshold=0.5,
         ),
         session_id_column="order_id",
-        row_id_column="driver_id"
+        row_id_column="driver_id",
     )
     request_timestamp = datetime(2021, 1, 1, 0, 0, 0)
     prediction_logs = [
@@ -348,8 +557,28 @@ def test_one_dimensional_prediction_output_to_dataframe():
     )
     expected_df = pd.DataFrame.from_records(
         [
-            [0.8, 24, "FOOD", 0.9, "fraud", "1234", "a", request_timestamp, model_version],
-            [0.5, 2, "RIDE", 0.5, "fraud", "1234", "b", request_timestamp, model_version],
+            [
+                0.8,
+                24,
+                "FOOD",
+                0.9,
+                "fraud",
+                "1234",
+                "a",
+                request_timestamp,
+                model_version,
+            ],
+            [
+                0.5,
+                2,
+                "RIDE",
+                0.5,
+                "fraud",
+                "1234",
+                "b",
+                request_timestamp,
+                model_version,
+            ],
         ],
         columns=[
             "acceptance_rate",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
Observation publisher only cares for columns that already defined in inference schema, all additional columns should be dropped. 
# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
