### PR TITLE
fix: Fix null pointer crash when deployment is not exist but secret exist …

### DIFF
--- a/api/pkg/observability/deployment/deployment.go
+++ b/api/pkg/observability/deployment/deployment.go
@@ -102,8 +102,17 @@ func (c *deployer) GetDeployedManifest(ctx context.Context, data *models.WorkerD
 	if err != nil {
 		return nil, err
 	}
-	if depl == nil && secret == nil {
-		return nil, err
+
+	if depl == nil {
+		if secret != nil {
+			log.Warnf("deployment %s is not exist but secret name exist %s", deploymentName, secretName)
+		}
+		return nil, nil
+	}
+
+	if secret == nil {
+		log.Warnf("deployment %s exist without associated secret", deploymentName)
+		return nil, nil
 	}
 
 	isDeploymentRolledOut, err := deploymentRolledOut(depl, data.Revision, false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
We faced nil crash on merlin during observability publisher, this is due to deployment not exist but secret is exist which probably because of this [line](https://github.com/caraml-dev/merlin/blob/main/api/pkg/observability/deployment/deployment.go#L453) or deployment manifest is deleted manually. Regardless the cause, the fix is to treat such case as deployment not exist so the incoming job can be processed
# Modifications
<!-- Summarize the key code changes. -->
Modify `GetDeployedManifest` by returning nil manifest and no error if such case happen, so the incoming job can run and correct the deployment state
# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
