### PR TITLE
fix merged env vars, new vars should overwrite the old one

### DIFF
--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -231,8 +231,8 @@ func (k *endpointService) override(left *models.VersionEndpoint, right *models.V
 
 	// override env vars
 	// Configure environment variables for Pyfunc model
-	if len(right.EnvVars) > 0 {
-		left.EnvVars = models.MergeEnvVars(left.EnvVars, right.EnvVars)
+	if right.EnvVars != nil {
+		left.EnvVars = right.EnvVars
 	}
 
 	// override protocol

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -669,6 +669,12 @@ func TestDeployEndpoint(t *testing.T) {
 								CPURequest:    resource.MustParse("1"),
 								MemoryRequest: resource.MustParse("1Gi"),
 							},
+							EnvVars: models.EnvVars{
+								{
+									Name:  "TF_MODEL_NAME",
+									Value: "saved_model.pb",
+								},
+							},
 							Logger: &models.Logger{
 								Model: &models.LoggerConfig{
 									Enabled: true,
@@ -697,6 +703,12 @@ func TestDeployEndpoint(t *testing.T) {
 						CPURequest:    resource.MustParse("1"),
 						MemoryRequest: resource.MustParse("1Gi"),
 					},
+					EnvVars: models.EnvVars{
+						{
+							Name:  "NUM_OF_ITERATION",
+							Value: "1",
+						},
+					},
 					Logger: &models.Logger{
 						Model: &models.LoggerConfig{
 							Enabled: true,
@@ -722,6 +734,12 @@ func TestDeployEndpoint(t *testing.T) {
 					MaxReplica:    4,
 					CPURequest:    resource.MustParse("1"),
 					MemoryRequest: resource.MustParse("1Gi"),
+				},
+				EnvVars: models.EnvVars{
+					{
+						Name:  "NUM_OF_ITERATION",
+						Value: "1",
+					},
 				},
 				Logger: &models.Logger{
 					DestinationURL: loggerDestinationURL,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
When user want to deploy and add the environment variables of Merlin model's endpoint, instead of overwriting the old environment variables with the new variables, both of the variables will be [appended instead](https://github.com/caraml-dev/merlin/blob/5b37909b8ee3972469f2fd2a4677596af78c7f99/api/service/version_endpoint_service.go#L235). E.g.

- Current endpoint's vars: `A = false`
- New endpoint's vars: `B = true`
- Final deployed endpoint's vars: `A = false, B = true`

These changes are intended to fix it, so when user updates the endpoint environment variables, it will overwrite the old environment variables.

# Modifications
<!-- Summarize the key code changes. -->

Modify the `override` function, which is use to override left endpoint with right endpoint, so it will replace the environment variables of the left (old) version endpoint with right (new) version endpoint's environment variables.

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
deploying or redeploying model's endpoint with environment variables will now replace all old environment variables with new ones
```
