### PR TITLE
fix(ui): Replace deprecated props in EuiDescriptionList

### DIFF
--- a/ui/src/components/ContainerConfigTable.js
+++ b/ui/src/components/ContainerConfigTable.js
@@ -46,8 +46,7 @@ export const ContainerConfigTable = ({ config: { image, command, args } }) => {
       textStyle="reverse"
       type="responsiveColumn"
       listItems={items}
-      titleProps={{ style: { width: "30%" } }}
-      descriptionProps={{ style: { width: "70%" } }}
+      columnWidths={[1, 4]}
     />
   );
 };

--- a/ui/src/components/HorizontalDescriptionList.js
+++ b/ui/src/components/HorizontalDescriptionList.js
@@ -20,8 +20,6 @@ import { EuiDescriptionList, EuiFlexGroup, EuiFlexItem } from "@elastic/eui";
 
 export const HorizontalDescriptionList = ({
   listItems,
-  titleProps,
-  descriptionProps,
   ...props
 }) => (
   <EuiFlexGroup
@@ -31,8 +29,6 @@ export const HorizontalDescriptionList = ({
     {listItems.map((item, idx) => (
       <EuiFlexItem {...item.flexProps} key={idx}>
         <EuiDescriptionList
-          titleProps={titleProps}
-          descriptionProps={descriptionProps}
           listItems={[item]}
         />
       </EuiFlexItem>
@@ -42,6 +38,4 @@ export const HorizontalDescriptionList = ({
 
 HorizontalDescriptionList.propTypes = {
   listItems: PropTypes.array.isRequired,
-  titleProps: PropTypes.object,
-  descriptionProps: PropTypes.object
 };


### PR DESCRIPTION
# Description
With the update of the Elastic UI library, the `titleProps` and `descriptionProps` props of the `EuiDescriptionList` component have been deprecated. This PR removes those props and replaces them where necessary.

# Modifications
- Remove/replace `titleProps` and `descriptionProps` props of the `EuiDescriptionList` component

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
None
```
