### PR TITLE
chore(batch-predictor,pyfunc-server): Bump up merlin-sdk versions in batch predictor and pyfunc server

### DIFF
--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -1,6 +1,6 @@
 cloudpickle==2.0.0
 findspark==2.0.1
-merlin-sdk<0.43.0
+merlin-sdk==0.44.0
 mlflow==1.26.1
 pyarrow>=0.14.1,<11.0.0
 pyspark==3.0.1

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -4,7 +4,7 @@ cloudpickle==2.0.0
 confluent-kafka==2.3.0
 grpcio-health-checking
 grpcio-reflection
-merlin-sdk<0.43.0
+merlin-sdk==0.44.0
 numpy>=1.8.2
 orjson>=2.6.8
 prometheus-client


### PR DESCRIPTION
# Description
This PR pins the `merlin-sdk` versions of the batch predictor and pyfunc server to the latest version available. (This is a temporary fix before we modify the CICD workflow to publish new batch predictors and pyfunc servers that are pinned to the latest `merlin-sdk` versions.)

# Modifications
- Pin `merlin-sdk` versions of the batch predictor and pyfunc server to `==0.44.0`

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
