### PR TITLE
feat: Remove kafka lag metric and its scheduled calculation process

### DIFF
--- a/python/observation-publisher/publisher/metric.py
+++ b/python/observation-publisher/publisher/metric.py
@@ -23,12 +23,6 @@ class MetricWriter(object):
                 "The total number of prediction logs processed by the publisher",
                 ["model_id", "model_version", "merlin_project"],
             )
-
-            self.kafka_consumer_lag_gauge = Gauge(
-                "kafka_consumer_lag",
-                "The number of unprocess message in kafka",
-                ["model_id", "model_version", "merlin_project", "partition"],
-            )
             self._initialized = True
 
     def __new__(cls):
@@ -70,17 +64,3 @@ class MetricWriter(object):
             model_version=self.model_version,
             merlin_project=self.merlin_project,
         ).inc(value)
-
-    def update_kafka_lag(self, total_lag: int, partition: int):
-        """
-        Update the kafka_consumer_lag gauge with the given value
-        :param total_lag:
-        :param partition:
-        :return:
-        """
-        self.kafka_consumer_lag_gauge.labels(
-            model_id=self.model_id,
-            model_version=self.model_version,
-            partition=partition,
-            merlin_project=self.merlin_project,
-        ).set(total_lag)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
In the previous [PR](https://github.com/caraml-dev/merlin/pull/598), we introduce kafka lag metric calculated by periodically calling the kafka broker API. We observed that the lag value can be incorrect when no message exists in a partition. We will rely with the metrics that exposed by the kafka itself
# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
