### PR TITLE
feat: add webhook to model version deployment & undeployment

### DIFF
--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 	"github.com/caraml-dev/mlp/api/pkg/artifact"
 	"github.com/caraml-dev/mlp/api/pkg/auth"
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
 	feast "github.com/feast-dev/feast/sdk/go"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/core"
 	"google.golang.org/grpc"
@@ -421,7 +422,7 @@ func initPredictionJobService(cfg *config.Config, controllers map[string]batch.C
 	return service.NewPredictionJobService(controllers, builder, predictionJobStorage, clock.RealClock{}, cfg.Environment, producer)
 }
 
-func initModelServiceDeployment(cfg *config.Config, builder imagebuilder.ImageBuilder, controllers map[string]cluster.Controller, db *gorm.DB, observabilityEvent event.EventProducer) *work.ModelServiceDeployment {
+func initModelServiceDeployment(cfg *config.Config, builder imagebuilder.ImageBuilder, controllers map[string]cluster.Controller, db *gorm.DB, observabilityEvent event.EventProducer, webhookManager webhooks.WebhookManager) *work.ModelServiceDeployment {
 	return &work.ModelServiceDeployment{
 		ClusterControllers:         controllers,
 		ImageBuilder:               builder,
@@ -430,6 +431,7 @@ func initModelServiceDeployment(cfg *config.Config, builder imagebuilder.ImageBu
 		LoggerDestinationURL:       cfg.LoggerDestinationURL,
 		MLObsLoggerDestinationURL:  cfg.MLObsLoggerDestinationURL,
 		ObservabilityEventProducer: observabilityEvent,
+		WebhookManager:             webhookManager,
 	}
 }
 
@@ -502,7 +504,7 @@ func initClusterControllers(cfg *config.Config) map[string]cluster.Controller {
 	return controllers
 }
 
-func initVersionEndpointService(cfg *config.Config, builder imagebuilder.ImageBuilder, controllers map[string]cluster.Controller, db *gorm.DB, feastCoreClient core.CoreServiceClient, producer queue.Producer) service.EndpointsService {
+func initVersionEndpointService(cfg *config.Config, builder imagebuilder.ImageBuilder, controllers map[string]cluster.Controller, db *gorm.DB, feastCoreClient core.CoreServiceClient, producer queue.Producer, webhookManager webhooks.WebhookManager) service.EndpointsService {
 	return service.NewEndpointService(service.EndpointServiceParams{
 		ClusterControllers:        controllers,
 		ImageBuilder:              builder,
@@ -514,6 +516,7 @@ func initVersionEndpointService(cfg *config.Config, builder imagebuilder.ImageBu
 		JobProducer:               producer,
 		FeastCoreClient:           feastCoreClient,
 		StandardTransformerConfig: cfg.StandardTransformerConfig,
+		WebhookManager:            webhookManager,
 	})
 }
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -24,6 +24,7 @@ import (
 	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 	"github.com/caraml-dev/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/caraml-dev/mlp/api/pkg/instrumentation/sentry"
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/mapstructure"
 	"github.com/ory/viper"
@@ -70,6 +71,7 @@ type Config struct {
 	PyFuncPublisherConfig     PyFuncPublisherConfig
 	InferenceServiceDefaults  InferenceServiceDefaults
 	ObservabilityPublisher    ObservabilityPublisher
+	WebhooksConfig            webhooks.Config
 }
 
 // UIConfig stores the configuration for the UI.

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -604,13 +604,13 @@ func TestLoad(t *testing.T) {
 					Config: map[webhooks.EventType][]webhooks.WebhookConfig{
 						"on-model-deployed": []webhooks.WebhookConfig{
 							{
-								Name:          "sync-webhook",
+								Name:          "sync-webhooks",
 								URL:           "http://127.0.0.1:8000/sync-webhook",
 								Method:        "POST",
 								FinalResponse: true,
 							},
 							{
-								Name:   "async-webhook",
+								Name:   "async-webhooks",
 								URL:    "http://127.0.0.1:8000/async-webhook",
 								Method: "POST",
 								Async:  true,

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -25,6 +25,7 @@ import (
 	mlpcluster "github.com/caraml-dev/mlp/api/pkg/cluster"
 	"github.com/caraml-dev/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/caraml-dev/mlp/api/pkg/instrumentation/sentry"
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -597,6 +598,25 @@ func TestLoad(t *testing.T) {
 						AdditionalConsumerConfig: map[string]string{},
 					},
 					DeploymentTimeout: 30 * time.Minute,
+				},
+				WebhooksConfig: webhooks.Config{
+					Enabled: true,
+					Config: map[webhooks.EventType][]webhooks.WebhookConfig{
+						"on-model-deployed": []webhooks.WebhookConfig{
+							{
+								Name:          "sync-webhook",
+								URL:           "http://127.0.0.1:8000/sync-webhook",
+								Method:        "POST",
+								FinalResponse: true,
+							},
+							{
+								Name:   "async-webhook",
+								URL:    "http://127.0.0.1:8000/async-webhook",
+								Method: "POST",
+								Async:  true,
+							},
+						},
+					},
 				},
 			},
 		},

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -602,7 +602,7 @@ func TestLoad(t *testing.T) {
 				WebhooksConfig: webhooks.Config{
 					Enabled: true,
 					Config: map[webhooks.EventType][]webhooks.WebhookConfig{
-						"on-model-deployed": []webhooks.WebhookConfig{
+						"on-model-deployed": {
 							{
 								Name:          "sync-webhooks",
 								URL:           "http://127.0.0.1:8000/sync-webhook",

--- a/api/config/testdata/base-configs-1.yaml
+++ b/api/config/testdata/base-configs-1.yaml
@@ -156,8 +156,8 @@ WebhooksConfig:
       - URL: http://127.0.0.1:8000/sync-webhook
         Method: POST
         FinalResponse: true
-        Name: sync-webhook
+        Name: sync-webhooks
       - URL: http://127.0.0.1:8000/async-webhook
         Method: POST
-        Name: async-webhook
+        Name: async-webhooks
         Async: true

--- a/api/config/testdata/base-configs-1.yaml
+++ b/api/config/testdata/base-configs-1.yaml
@@ -149,3 +149,15 @@ InferenceServiceDefaults:
   DefaultEnvVarsWithoutCPULimits:
     - Name: foo
       Value: bar
+WebhooksConfig:
+  Enabled: true
+  Config:
+    On-Model-Deployed:
+      - URL: http://127.0.0.1:8000/sync-webhook
+        Method: POST
+        FinalResponse: true
+        Name: sync-webhook
+      - URL: http://127.0.0.1:8000/async-webhook
+        Method: POST
+        Name: async-webhook
+        Async: true

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bboughton/gcp-helpers v0.1.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/caraml-dev/merlin-pyspark-app v0.0.3
-	github.com/caraml-dev/mlp v1.13.2-rc1
+	github.com/caraml-dev/mlp v1.13.2-rc2
 	github.com/caraml-dev/protopath v0.1.0
 	github.com/caraml-dev/universal-prediction-interface v1.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bboughton/gcp-helpers v0.1.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/caraml-dev/merlin-pyspark-app v0.0.3
-	github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96
+	github.com/caraml-dev/mlp v1.13.2-rc1
 	github.com/caraml-dev/protopath v0.1.0
 	github.com/caraml-dev/universal-prediction-interface v1.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/bboughton/gcp-helpers v0.1.0
 	github.com/buger/jsonparser v1.1.1
 	github.com/caraml-dev/merlin-pyspark-app v0.0.3
-	github.com/caraml-dev/mlp v1.12.2-0.20240517121307-b89dab536aab
+	github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96
 	github.com/caraml-dev/protopath v0.1.0
 	github.com/caraml-dev/universal-prediction-interface v1.0.0
 	github.com/cenkalti/backoff/v4 v4.2.1
@@ -64,7 +64,7 @@ require (
 	github.com/rs/cors v1.8.2
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spaolacci/murmur3 v1.1.0
-	github.com/stretchr/testify v1.8.4
+	github.com/stretchr/testify v1.9.0
 	github.com/xanzy/go-gitlab v0.32.0
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
@@ -213,7 +213,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.8.1 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/valyala/fastjson v1.6.3 // indirect
@@ -246,6 +246,7 @@ require (
 )
 
 require (
+	github.com/avast/retry-go/v4 v4.6.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231113174909-778a5567bc1e // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -137,6 +137,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
+github.com/avast/retry-go/v4 v4.6.0/go.mod h1:gvWlPhBVsvBbLkVGDg/KwvBv0bEkCOLRRSHKIr2PyOE=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.50.0 h1:HBtrLeO+QyDKnc3t1+5DR1RxodOHCGr8ZcrHudpv7jI=
 github.com/aws/aws-sdk-go v1.50.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
@@ -159,8 +161,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/caraml-dev/mlp v1.12.2-0.20240517121307-b89dab536aab h1:+XKM4kEBZz1gEbOHrphso6HxmMGSfss9TyMBIE0hm2M=
-github.com/caraml-dev/mlp v1.12.2-0.20240517121307-b89dab536aab/go.mod h1:Zdz4bALO9WOHXhOgsoLmCjMCJnDVEZEnQFg8rk+u2cE=
+github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96 h1:f8fj9KScheqAJGrOPrGnhbwylptbdk0YberSAeJaIDQ=
+github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96/go.mod h1:jKfnUEpCcARv/aJF6qH7vT7VMKICDVOq/pDFvj6V3vQ=
 github.com/caraml-dev/protopath v0.1.0 h1:hjJ/U9RGD6QZ0Ee9SIYbVmwPugps4S5EpL6R+5ZrBe0=
 github.com/caraml-dev/protopath v0.1.0/go.mod h1:hVA2HkTrMYv+Q57gtrzu9/P7EXlNtBUcTz43z6EE010=
 github.com/caraml-dev/universal-prediction-interface v1.0.0 h1:3Z6adv1XZnBVRzFIeCu3mPcPnJrdB5IByYfdD9K/atI=
@@ -998,8 +1000,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1010,8 +1013,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/api/go.sum
+++ b/api/go.sum
@@ -161,8 +161,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96 h1:f8fj9KScheqAJGrOPrGnhbwylptbdk0YberSAeJaIDQ=
-github.com/caraml-dev/mlp v1.13.2-0.20240812072859-9a95b964df96/go.mod h1:jKfnUEpCcARv/aJF6qH7vT7VMKICDVOq/pDFvj6V3vQ=
+github.com/caraml-dev/mlp v1.13.2-rc1 h1:mjAm0uEN8BMb7asq6Xw5cI6kbTh6/bcBBMC4xM3GXxs=
+github.com/caraml-dev/mlp v1.13.2-rc1/go.mod h1:jKfnUEpCcARv/aJF6qH7vT7VMKICDVOq/pDFvj6V3vQ=
 github.com/caraml-dev/protopath v0.1.0 h1:hjJ/U9RGD6QZ0Ee9SIYbVmwPugps4S5EpL6R+5ZrBe0=
 github.com/caraml-dev/protopath v0.1.0/go.mod h1:hVA2HkTrMYv+Q57gtrzu9/P7EXlNtBUcTz43z6EE010=
 github.com/caraml-dev/universal-prediction-interface v1.0.0 h1:3Z6adv1XZnBVRzFIeCu3mPcPnJrdB5IByYfdD9K/atI=

--- a/api/go.sum
+++ b/api/go.sum
@@ -161,8 +161,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
-github.com/caraml-dev/mlp v1.13.2-rc1 h1:mjAm0uEN8BMb7asq6Xw5cI6kbTh6/bcBBMC4xM3GXxs=
-github.com/caraml-dev/mlp v1.13.2-rc1/go.mod h1:jKfnUEpCcARv/aJF6qH7vT7VMKICDVOq/pDFvj6V3vQ=
+github.com/caraml-dev/mlp v1.13.2-rc2 h1:Zmyoy3OTPv2fU+42rxMwUt9erS9J6QA0nlZQy/xCPtk=
+github.com/caraml-dev/mlp v1.13.2-rc2/go.mod h1:jKfnUEpCcARv/aJF6qH7vT7VMKICDVOq/pDFvj6V3vQ=
 github.com/caraml-dev/protopath v0.1.0 h1:hjJ/U9RGD6QZ0Ee9SIYbVmwPugps4S5EpL6R+5ZrBe0=
 github.com/caraml-dev/protopath v0.1.0/go.mod h1:hVA2HkTrMYv+Q57gtrzu9/P7EXlNtBUcTz43z6EE010=
 github.com/caraml-dev/universal-prediction-interface v1.0.0 h1:3Z6adv1XZnBVRzFIeCu3mPcPnJrdB5IByYfdD9K/atI=

--- a/api/pkg/transformer/types/converter/converter_test.go
+++ b/api/pkg/transformer/types/converter/converter_test.go
@@ -1882,7 +1882,7 @@ func TestToFloat64List(t *testing.T) {
 		{
 			name: "from []float32",
 			args: args{
-				val: []float32{float32(3.14), float32(math.NaN())},
+				val: []float32{float32(3.14), float32(4.56), float32(math.NaN())},
 			},
 			want:    []float64{3.14, 4.56},
 			wantErr: false,

--- a/api/queue/work/model_service_deployment_test.go
+++ b/api/queue/work/model_service_deployment_test.go
@@ -191,7 +191,7 @@ func TestExecuteDeployment(t *testing.T) {
 			}(),
 		},
 		{
-			name:    "Success: with calling webhook",
+			name:    "Success: with calling webhooks",
 			model:   model,
 			version: version,
 			endpoint: &models.VersionEndpoint{

--- a/api/queue/work/model_service_deployment_test.go
+++ b/api/queue/work/model_service_deployment_test.go
@@ -14,7 +14,8 @@ import (
 	eventMock "github.com/caraml-dev/merlin/pkg/observability/event/mocks"
 	"github.com/caraml-dev/merlin/queue"
 	"github.com/caraml-dev/merlin/storage/mocks"
-	"github.com/caraml-dev/mlp/api/pkg/webhooks"
+	webhook "github.com/caraml-dev/merlin/webhooks"
+	webhookManager "github.com/caraml-dev/mlp/api/pkg/webhooks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"gorm.io/gorm"
@@ -73,7 +74,7 @@ func TestExecuteDeployment(t *testing.T) {
 		storage           func() *mocks.VersionEndpointStorage
 		controller        func() *clusterMock.Controller
 		imageBuilder      func() *imageBuilderMock.ImageBuilder
-		webhookManager    func() webhooks.WebhookManager
+		webhookManager    func() webhookManager.WebhookManager
 		eventProducer     *eventMock.EventProducer
 	}{
 		{
@@ -119,8 +120,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -169,8 +170,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -233,11 +234,12 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
-				webhookManager.On("IsEventConfigured", mock.Anything).Return(true)
-				webhookManager.On("InvokeWebhooks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-				return webhookManager
+			webhookManager: func() webhookManager.WebhookManager {
+				manager := webhookManager.NewMockWebhookManager(t)
+
+				manager.On("IsEventConfigured", mock.Anything).Return(true)
+				manager.On("InvokeWebhooks", mock.Anything, webhook.OnModelVersionDeployed, mock.IsType(&webhook.VersionEndpointRequest{}), mock.Anything, mock.Anything).Return(nil)
+				return manager
 			},
 		},
 		{
@@ -284,8 +286,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -356,8 +358,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -413,8 +415,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -462,8 +464,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -513,8 +515,8 @@ func TestExecuteDeployment(t *testing.T) {
 					Return("gojek/mymodel-1:latest", nil)
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -564,8 +566,8 @@ func TestExecuteDeployment(t *testing.T) {
 					Return("gojek/mymodel-1:latest", nil)
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -627,8 +629,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				webhookManager := webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				webhookManager := webhookManager.NewMockWebhookManager(t)
 				webhookManager.On("IsEventConfigured", mock.Anything).Return(false)
 				return webhookManager
 			},
@@ -670,8 +672,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder := &imageBuilderMock.ImageBuilder{}
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				return webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				return webhookManager.NewMockWebhookManager(t)
 			},
 		},
 		{
@@ -710,8 +712,8 @@ func TestExecuteDeployment(t *testing.T) {
 				mockImgBuilder.On("BuildImage", context.Background(), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("", errors.New("Failed to build image"))
 				return mockImgBuilder
 			},
-			webhookManager: func() webhooks.WebhookManager {
-				return webhooks.NewMockWebhookManager(t)
+			webhookManager: func() webhookManager.WebhookManager {
+				return webhookManager.NewMockWebhookManager(t)
 			},
 		},
 	}

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -147,7 +147,7 @@ func (k *endpointService) DeployEndpoint(ctx context.Context, environment *model
 
 		err := k.webhookManager.InvokeWebhooks(ctx, webhooks.OnModelVersionPredeployment, body, webhookManager.NoOpCallback, webhookManager.NoOpErrorHandler)
 		if err != nil {
-			log.Errorf("unable to invoke webhooks for event type: %s, model: %s, version: %s, error: %v", webhooks.OnModelVersionDeployed, model.Name, version.ID, err)
+			log.Errorf("unable to invoke webhooks for event type: %s, model: %s, version: %s, error: %v", webhooks.OnModelVersionPredeployment, model.Name, version.ID, err)
 			return nil, err
 		}
 	}
@@ -310,7 +310,7 @@ func (k *endpointService) UndeployEndpoint(ctx context.Context, environment *mod
 
 		err = k.webhookManager.InvokeWebhooks(ctx, webhooks.OnModelVersionUndeployed, body, webhookManager.NoOpCallback, webhookManager.NoOpErrorHandler)
 		if err != nil {
-			log.Warnf("unable to invoke webhooks for event type: %s, model: %s, version: %s, error: %v", webhooks.OnModelVersionDeployed, model.Name, version.ID, err)
+			log.Warnf("unable to invoke webhooks for event type: %s, model: %s, version: %s, error: %v", webhooks.OnModelVersionUndeployed, model.Name, version.ID, err)
 		}
 	}
 

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/core"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
 	"github.com/google/uuid"
@@ -47,6 +48,7 @@ import (
 	"github.com/caraml-dev/merlin/pkg/transformer/spec"
 	queueMock "github.com/caraml-dev/merlin/queue/mocks"
 	"github.com/caraml-dev/merlin/storage/mocks"
+	wh "github.com/caraml-dev/merlin/webhooks"
 )
 
 var (
@@ -56,10 +58,11 @@ var (
 
 func TestDeployEndpoint(t *testing.T) {
 	type args struct {
-		environment *models.Environment
-		model       *models.Model
-		version     *models.Version
-		endpoint    *models.VersionEndpoint
+		environment    *models.Environment
+		model          *models.Model
+		version        *models.Version
+		endpoint       *models.VersionEndpoint
+		isWebhookExist bool
 	}
 
 	env := &models.Environment{
@@ -79,13 +82,12 @@ func TestDeployEndpoint(t *testing.T) {
 	model := &models.Model{Name: "model", Project: project}
 	version := &models.Version{ID: 1}
 
-	// iSvcName := fmt.Sprintf("%s-%d-0", model.Name, version.ID)
-
 	tests := []struct {
 		name             string
 		args             args
 		expectedEndpoint *models.VersionEndpoint
-		wantDeployError  bool
+
+		wantDeployError bool
 	}{
 		{
 			name: "success: new endpoint default resource request",
@@ -94,6 +96,7 @@ func TestDeployEndpoint(t *testing.T) {
 				model,
 				version,
 				&models.VersionEndpoint{},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -120,6 +123,7 @@ func TestDeployEndpoint(t *testing.T) {
 						MemoryRequest: resource.MustParse("1Gi"),
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -144,6 +148,7 @@ func TestDeployEndpoint(t *testing.T) {
 				&models.Model{Name: "model", Project: project, Type: models.ModelTypePyTorch},
 				&models.Version{ID: 1},
 				&models.VersionEndpoint{},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -165,6 +170,7 @@ func TestDeployEndpoint(t *testing.T) {
 				&models.VersionEndpoint{
 					ResourceRequest: env.DefaultResourceRequest,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -186,6 +192,7 @@ func TestDeployEndpoint(t *testing.T) {
 				&models.VersionEndpoint{
 					ResourceRequest: env.DefaultResourceRequest,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -223,6 +230,7 @@ func TestDeployEndpoint(t *testing.T) {
 					},
 					Protocol: protocol.HttpJson,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -252,6 +260,7 @@ func TestDeployEndpoint(t *testing.T) {
 				model,
 				version,
 				&models.VersionEndpoint{},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{},
 			wantDeployError:  true,
@@ -269,6 +278,7 @@ func TestDeployEndpoint(t *testing.T) {
 						ResourceRequest: env.DefaultResourceRequest,
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -311,6 +321,7 @@ func TestDeployEndpoint(t *testing.T) {
 					},
 					Protocol: protocol.HttpJson,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -359,6 +370,7 @@ func TestDeployEndpoint(t *testing.T) {
 						},
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -403,6 +415,7 @@ func TestDeployEndpoint(t *testing.T) {
 						},
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -451,6 +464,7 @@ func TestDeployEndpoint(t *testing.T) {
 						},
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -504,6 +518,7 @@ func TestDeployEndpoint(t *testing.T) {
 					},
 					DeploymentMode: deployment.RawDeploymentMode,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				Namespace: project.Name,
@@ -561,6 +576,7 @@ func TestDeployEndpoint(t *testing.T) {
 						TargetValue: 100,
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				Namespace: project.Name,
@@ -621,6 +637,7 @@ func TestDeployEndpoint(t *testing.T) {
 						TargetValue: 100,
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				Namespace: project.Name,
@@ -725,6 +742,7 @@ func TestDeployEndpoint(t *testing.T) {
 						TargetValue: 10,
 					},
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				Namespace: project.Name,
@@ -771,6 +789,7 @@ func TestDeployEndpoint(t *testing.T) {
 					ResourceRequest: env.DefaultResourceRequest,
 					Protocol:        protocol.UpiV1,
 				},
+				false,
 			},
 			expectedEndpoint: &models.VersionEndpoint{
 				DeploymentMode:    deployment.ServerlessDeploymentMode,
@@ -780,6 +799,26 @@ func TestDeployEndpoint(t *testing.T) {
 				URL:               "",
 				Status:            models.EndpointPending,
 				Protocol:          protocol.UpiV1,
+			},
+			wantDeployError: false,
+		},
+		{
+			name: "success: new endpoint with existing webhook",
+			args: args{
+				env,
+				model,
+				version,
+				&models.VersionEndpoint{},
+				true,
+			},
+			expectedEndpoint: &models.VersionEndpoint{
+				DeploymentMode:    deployment.ServerlessDeploymentMode,
+				AutoscalingPolicy: autoscaling.DefaultServerlessAutoscalingPolicy,
+				ResourceRequest:   env.DefaultResourceRequest,
+				Namespace:         project.Name,
+				URL:               "",
+				Status:            models.EndpointPending,
+				Protocol:          protocol.HttpJson,
 			},
 			wantDeployError: false,
 		},
@@ -798,8 +837,15 @@ func TestDeployEndpoint(t *testing.T) {
 			imgBuilder := &imageBuilderMock.ImageBuilder{}
 			mockStorage := &mocks.VersionEndpointStorage{}
 			mockDeploymentStorage := &mocks.DeploymentStorage{}
+			mockWebhook := webhooks.NewMockWebhookManager(t)
+
 			mockStorage.On("Save", mock.Anything).Return(nil)
 			mockDeploymentStorage.On("Save", mock.Anything).Return(nil, nil)
+			mockWebhook.On("IsEventConfigured", wh.OnModelVersionPredeployment).Return(tt.args.isWebhookExist)
+			if tt.args.isWebhookExist {
+				mockWebhook.On("InvokeWebhooks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			}
+
 			mockCfg := &config.Config{
 				Environment: "dev",
 				FeatureToggleConfig: config.FeatureToggleConfig{
@@ -820,6 +866,7 @@ func TestDeployEndpoint(t *testing.T) {
 				MonitoringConfig:     mockCfg.FeatureToggleConfig.MonitoringConfig,
 				LoggerDestinationURL: loggerDestinationURL,
 				JobProducer:          mockQueueProducer,
+				WebhookManager:       mockWebhook,
 			})
 			actualEndpoint, err := endpointSvc.DeployEndpoint(context.Background(), tt.args.environment, tt.args.model, tt.args.version, tt.args.endpoint)
 			if tt.wantDeployError {
@@ -850,6 +897,10 @@ func TestDeployEndpoint(t *testing.T) {
 
 			if tt.args.endpoint.Transformer != nil {
 				assert.Equal(t, tt.args.endpoint.Transformer.Enabled, actualEndpoint.Transformer.Enabled)
+			}
+
+			if tt.args.isWebhookExist {
+				mockWebhook.AssertNumberOfCalls(t, "InvokeWebhooks", 1)
 			}
 		})
 	}
@@ -2333,4 +2384,170 @@ func assertElementMatchFeatureTableMetadata(t *testing.T, expectation []*spec.Fe
 		}
 	}
 	assert.True(t, len(expectation) == numOfMatchElements)
+}
+
+func TestUndeployEndpoint(t *testing.T) {
+	type webhooksArgs struct {
+		event             webhooks.EventType
+		isEventConfigured bool
+		err               error
+	}
+
+	type args struct {
+		endpoint *models.VersionEndpoint
+		webhooks *webhooksArgs
+	}
+
+	id := uuid.New()
+
+	env := &models.Environment{
+		Name:       "env1",
+		Cluster:    "cluster1",
+		IsDefault:  &isDefaultTrue,
+		Region:     "id",
+		GcpProject: "project",
+		DefaultResourceRequest: &models.ResourceRequest{
+			MinReplica:    0,
+			MaxReplica:    1,
+			CPURequest:    resource.MustParse("1"),
+			MemoryRequest: resource.MustParse("1Gi"),
+		},
+	}
+	project := mlp.Project{Name: "project"}
+	model := &models.Model{Name: "model", Project: project}
+	version := &models.Version{ID: 1}
+
+	tests := []struct {
+		name              string
+		args              args
+		expectedEndpoint  *models.VersionEndpoint
+		wantUndeployError bool
+	}{
+		{
+			name: "success: without webhook",
+			args: args{
+				&models.VersionEndpoint{
+					ID:        id,
+					Namespace: project.Name,
+					Status:    models.EndpointRunning,
+				},
+				&webhooksArgs{
+					event:             wh.OnModelVersionUndeployed,
+					isEventConfigured: false,
+					err:               nil,
+				},
+			},
+			expectedEndpoint: &models.VersionEndpoint{
+				ID:        id,
+				Namespace: project.Name,
+				Status:    models.EndpointTerminated,
+			},
+			wantUndeployError: false,
+		},
+		{
+			name: "success: with webhook",
+			args: args{
+				&models.VersionEndpoint{
+					ID:        id,
+					Namespace: project.Name,
+					Status:    models.EndpointRunning,
+				},
+				&webhooksArgs{
+					event:             wh.OnModelVersionUndeployed,
+					isEventConfigured: true,
+				},
+			},
+			expectedEndpoint: &models.VersionEndpoint{
+				ID:        id,
+				Namespace: project.Name,
+				Status:    models.EndpointTerminated,
+			},
+		},
+		{
+			name: "fail: to undeploy",
+			args: args{
+				&models.VersionEndpoint{
+					ID:        id,
+					Namespace: project.Name,
+					Status:    models.EndpointRunning,
+				},
+				&webhooksArgs{
+					event:             wh.OnModelVersionUndeployed,
+					isEventConfigured: false,
+				},
+			},
+			expectedEndpoint: &models.VersionEndpoint{
+				ID:        id,
+				Namespace: project.Name,
+				Status:    models.EndpointTerminated,
+			},
+			wantUndeployError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envController := &clusterMock.Controller{}
+			mockQueueProducer := &queueMock.Producer{}
+			imgBuilder := &imageBuilderMock.ImageBuilder{}
+			mockStorage := &mocks.VersionEndpointStorage{}
+			mockDeploymentStorage := &mocks.DeploymentStorage{}
+			mockWebhook := webhooks.NewMockWebhookManager(t)
+
+			envController.On("Delete", mock.Anything, mock.Anything).Return(nil, nil)
+			mockStorage.On("Save", mock.Anything).Return(nil)
+			if tt.wantUndeployError {
+				mockDeploymentStorage.On("Undeploy", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("Failed to undeploy"))
+			} else {
+				mockDeploymentStorage.On("Undeploy", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				mockWebhook.On("IsEventConfigured", mock.Anything).Return(tt.args.webhooks.isEventConfigured)
+			}
+			if tt.args.webhooks.isEventConfigured {
+				mockWebhook.On("InvokeWebhooks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			}
+
+			mockCfg := &config.Config{
+				Environment: "dev",
+				FeatureToggleConfig: config.FeatureToggleConfig{
+					MonitoringConfig: config.MonitoringConfig{
+						MonitoringEnabled: false,
+					},
+				},
+			}
+
+			controllers := map[string]cluster.Controller{env.Name: envController}
+
+			endpointSvc := NewEndpointService(EndpointServiceParams{
+				ClusterControllers:   controllers,
+				ImageBuilder:         imgBuilder,
+				Storage:              mockStorage,
+				DeploymentStorage:    mockDeploymentStorage,
+				Environment:          mockCfg.Environment,
+				MonitoringConfig:     mockCfg.FeatureToggleConfig.MonitoringConfig,
+				LoggerDestinationURL: loggerDestinationURL,
+				JobProducer:          mockQueueProducer,
+				WebhookManager:       mockWebhook,
+			})
+
+			actualEndpoint, err := endpointSvc.UndeployEndpoint(context.Background(), env, model, version, tt.args.endpoint)
+
+			envController.AssertNumberOfCalls(t, "Delete", 1)
+			mockStorage.AssertNumberOfCalls(t, "Save", 1)
+			mockDeploymentStorage.AssertNumberOfCalls(t, "Undeploy", 1)
+
+			if tt.args.webhooks.isEventConfigured {
+				mockWebhook.AssertNumberOfCalls(t, "InvokeWebhooks", 1)
+			}
+
+			if tt.wantUndeployError {
+				assert.Error(t, err)
+				return
+			}
+
+			mockWebhook.AssertNumberOfCalls(t, "IsEventConfigured", 1)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedEndpoint, actualEndpoint)
+		})
+	}
 }

--- a/api/service/version_endpoint_service_test.go
+++ b/api/service/version_endpoint_service_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/caraml-dev/mlp/api/pkg/webhooks"
+	webhookManager "github.com/caraml-dev/mlp/api/pkg/webhooks"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/core"
 	"github.com/feast-dev/feast/sdk/go/protos/feast/types"
 	"github.com/google/uuid"
@@ -48,7 +48,7 @@ import (
 	"github.com/caraml-dev/merlin/pkg/transformer/spec"
 	queueMock "github.com/caraml-dev/merlin/queue/mocks"
 	"github.com/caraml-dev/merlin/storage/mocks"
-	wh "github.com/caraml-dev/merlin/webhooks"
+	webhooks "github.com/caraml-dev/merlin/webhooks"
 )
 
 var (
@@ -803,7 +803,7 @@ func TestDeployEndpoint(t *testing.T) {
 			wantDeployError: false,
 		},
 		{
-			name: "success: new endpoint with existing webhook",
+			name: "success: new endpoint with existing webhookManager",
 			args: args{
 				env,
 				model,
@@ -837,11 +837,11 @@ func TestDeployEndpoint(t *testing.T) {
 			imgBuilder := &imageBuilderMock.ImageBuilder{}
 			mockStorage := &mocks.VersionEndpointStorage{}
 			mockDeploymentStorage := &mocks.DeploymentStorage{}
-			mockWebhook := webhooks.NewMockWebhookManager(t)
+			mockWebhook := webhookManager.NewMockWebhookManager(t)
 
 			mockStorage.On("Save", mock.Anything).Return(nil)
 			mockDeploymentStorage.On("Save", mock.Anything).Return(nil, nil)
-			mockWebhook.On("IsEventConfigured", wh.OnModelVersionPredeployment).Return(tt.args.isWebhookExist)
+			mockWebhook.On("IsEventConfigured", webhooks.OnModelVersionPredeployment).Return(tt.args.isWebhookExist)
 			if tt.args.isWebhookExist {
 				mockWebhook.On("InvokeWebhooks", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			}
@@ -2388,7 +2388,7 @@ func assertElementMatchFeatureTableMetadata(t *testing.T, expectation []*spec.Fe
 
 func TestUndeployEndpoint(t *testing.T) {
 	type webhooksArgs struct {
-		event             webhooks.EventType
+		event             webhookManager.EventType
 		isEventConfigured bool
 		err               error
 	}
@@ -2424,7 +2424,7 @@ func TestUndeployEndpoint(t *testing.T) {
 		wantUndeployError bool
 	}{
 		{
-			name: "success: without webhook",
+			name: "success: without webhookManager",
 			args: args{
 				&models.VersionEndpoint{
 					ID:        id,
@@ -2432,7 +2432,7 @@ func TestUndeployEndpoint(t *testing.T) {
 					Status:    models.EndpointRunning,
 				},
 				&webhooksArgs{
-					event:             wh.OnModelVersionUndeployed,
+					event:             webhooks.OnModelVersionUndeployed,
 					isEventConfigured: false,
 					err:               nil,
 				},
@@ -2445,7 +2445,7 @@ func TestUndeployEndpoint(t *testing.T) {
 			wantUndeployError: false,
 		},
 		{
-			name: "success: with webhook",
+			name: "success: with webhookManager",
 			args: args{
 				&models.VersionEndpoint{
 					ID:        id,
@@ -2453,7 +2453,7 @@ func TestUndeployEndpoint(t *testing.T) {
 					Status:    models.EndpointRunning,
 				},
 				&webhooksArgs{
-					event:             wh.OnModelVersionUndeployed,
+					event:             webhooks.OnModelVersionUndeployed,
 					isEventConfigured: true,
 				},
 			},
@@ -2472,7 +2472,7 @@ func TestUndeployEndpoint(t *testing.T) {
 					Status:    models.EndpointRunning,
 				},
 				&webhooksArgs{
-					event:             wh.OnModelVersionUndeployed,
+					event:             webhooks.OnModelVersionUndeployed,
 					isEventConfigured: false,
 				},
 			},
@@ -2492,7 +2492,7 @@ func TestUndeployEndpoint(t *testing.T) {
 			imgBuilder := &imageBuilderMock.ImageBuilder{}
 			mockStorage := &mocks.VersionEndpointStorage{}
 			mockDeploymentStorage := &mocks.DeploymentStorage{}
-			mockWebhook := webhooks.NewMockWebhookManager(t)
+			mockWebhook := webhookManager.NewMockWebhookManager(t)
 
 			envController.On("Delete", mock.Anything, mock.Anything).Return(nil, nil)
 			mockStorage.On("Save", mock.Anything).Return(nil)

--- a/api/webhooks/webhook.go
+++ b/api/webhooks/webhook.go
@@ -1,0 +1,36 @@
+package webhooks
+
+import (
+	"github.com/caraml-dev/mlp/api/pkg/webhooks"
+
+	"github.com/caraml-dev/merlin/models"
+)
+
+var (
+	OnModelVersionPredeployment = webhooks.EventType("on-model-version-predeployment")
+	OnModelVersionDeployed      = webhooks.EventType("on-model-version-deployed")
+	OnModelVersionUndeployed    = webhooks.EventType("on-model-version-undeployed")
+)
+
+var WebhookEvents = []webhooks.EventType{
+	OnModelVersionPredeployment,
+	OnModelVersionDeployed,
+	OnModelVersionUndeployed,
+}
+
+type Request struct {
+	EventType webhooks.EventType `json:"event_type"`
+
+	Data interface{} `json:"data"`
+}
+
+type VersionEndpointData struct {
+	VersionEndpoint *models.VersionEndpoint `json:"version_endpoint"`
+}
+
+func BuildRequest(eventType webhooks.EventType, d interface{}) *Request {
+	return &Request{
+		EventType: eventType,
+		Data:      d,
+	}
+}

--- a/api/webhooks/webhooks.go
+++ b/api/webhooks/webhooks.go
@@ -18,19 +18,7 @@ var WebhookEvents = []webhooks.EventType{
 	OnModelVersionUndeployed,
 }
 
-type Request struct {
-	EventType webhooks.EventType `json:"event_type"`
-
-	Data interface{} `json:"data"`
-}
-
-type VersionEndpointData struct {
+type VersionEndpointRequest struct {
+	EventType       webhooks.EventType      `json:"event_type"`
 	VersionEndpoint *models.VersionEndpoint `json:"version_endpoint"`
-}
-
-func BuildRequest(eventType webhooks.EventType, d interface{}) *Request {
-	return &Request{
-		EventType: eventType,
-		Data:      d,
-	}
 }


### PR DESCRIPTION
# Description
When deploying or undeploying model endpoint, other entity might want to get a trigger to automate their process or for Merlin other process. This PR add webhooks call (based on the [webhook from MLP](https://github.com/caraml-dev/mlp/blob/main/api/pkg/webhooks/README.md)), so on model version deployment/undeployment it will call the configured webhooks. 


# Modifications
**Main Changes:** 

Added webhooks call on
- Model version pre-deployment: will ignore the success response (for this version) and will stop/fail the deployment version if any `async` webhook fail
- Model version post-deployment: will ignore error, only log the error if any occur during the call
- Model version post-undeployment: will ignore error, only log the error if any occur during the call

Request payload to webhook: 
- Request:
  - `event_type`: name of event which triggers the webhook
  - `versionEndpoint`: object version endpoint

**Side effect changes**:
- With MLP update in go.mod, the assert function is also updated. Previously, the `assert.InEpsilon` can pass when item in actual slice is in expected slice, even though the expected slice might have more items; now the `testify/assert` will check the two slices length first ([ref](https://github.com/stretchr/testify/pull/1483/files)) -> Added some changes to fix the unit test in `TestToFloat64List`

# Tests

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add configurable webhook call in endpoint deployment and undeployment
```
