### PR TITLE
fix: string validation in variable input schema

### DIFF
--- a/ui/src/pages/version/components/forms/validation/schema.js
+++ b/ui/src/pages/version/components/forms/validation/schema.js
@@ -67,13 +67,13 @@ const environmentVariableSchema = yup.object().shape({
   value: yup.string(),
 });
 
-const stringValueSchema = (name) => yup.mixed().test(
+const stringValueSchema = (name, key) => yup.mixed().test(
   `value input schema`,
   `${name} must be a \`string\` but the final value was $\{value}`,
   (value, { createError }) => {
     try {
-      if (typeof value == "object" && "jsonPath" in value) {
-        return yup.string().required(`${name} is required`).validateSync(value["jsonPath"])
+      if (typeof value == "object" && key in value) {
+        return yup.string().required(`${name} is required`).validateSync(value[key])
       }
       return yup.string().required(`${name} is required`).validateSync(value)
     } catch (e) {
@@ -107,7 +107,7 @@ const feastEntitiesSchema = yup.object().shape({
   name: yup.string().required("Entity Name is required"),
   valueType: yup.string().required("Entity Value Type is required"),
   fieldType: yup.string().required("Input Type is required"),
-  field: stringValueSchema("Input Value"),
+  field: stringValueSchema("Input Value", "jsonPath"),
 });
 
 const feastFeaturesSchema = yup.object().shape({
@@ -128,7 +128,7 @@ export const feastInputSchema = yup.object().shape({
 const variableInputSchema = yup.object().shape({
   name: yup.string().required("Name is required"),
   type: yup.string().required("Type is required"),
-  value: stringValueSchema("Value"),
+  value: stringValueSchema("Value", "jsonPath"),
 });
 
 const tablesInputSchema = yup.object().shape({

--- a/ui/src/pages/version/components/forms/validation/schema.js
+++ b/ui/src/pages/version/components/forms/validation/schema.js
@@ -70,11 +70,15 @@ const environmentVariableSchema = yup.object().shape({
 const stringValueSchema = (name) => yup.mixed().test(
   `value input schema`,
   `${name} must be a \`string\` but the final value was $\{value}`,
-  (value) => {
-    if (typeof value == "object" && "jsonPath" in value) {
-      return yup.string().required("Value is required").isValid(value["jsonPath"])
+  (value, { createError }) => {
+    try {
+      if (typeof value == "object" && "jsonPath" in value) {
+        return yup.string().required(`${name} is required`).validateSync(value["jsonPath"])
+      }
+      return yup.string().required(`${name} is required`).validateSync(value)
+    } catch (e) {
+      return createError({ message: e.message })
     }
-    return yup.string().required("Value is required").isValid(value)
   }
 )
 
@@ -103,7 +107,7 @@ const feastEntitiesSchema = yup.object().shape({
   name: yup.string().required("Entity Name is required"),
   valueType: yup.string().required("Entity Value Type is required"),
   fieldType: yup.string().required("Input Type is required"),
-  field: stringValueSchema("input field"),
+  field: stringValueSchema("Input Value"),
 });
 
 const feastFeaturesSchema = yup.object().shape({

--- a/ui/src/pages/version/components/forms/validation/schema.js
+++ b/ui/src/pages/version/components/forms/validation/schema.js
@@ -67,6 +67,17 @@ const environmentVariableSchema = yup.object().shape({
   value: yup.string(),
 });
 
+const variableValueInputSchema = (name) => yup.mixed().test(
+  `value input schema`,
+  `${name} must be a \`string\` but the final value was $\{value}`,
+  (value) => {
+    if (typeof value == "object" && "jsonPath" in value) {
+      return yup.string().required("Value is required").isValid(value["jsonPath"])
+    }
+    return yup.string().required("Value is required").isValid(value)
+  }
+)
+
 export const versionEndpointSchema = (maxAllowedReplica) => yup.object().shape({
   environment_name: yup.string().required("Environment is required"),
   resource_request: resourceRequestSchema(maxAllowedReplica),
@@ -92,7 +103,7 @@ const feastEntitiesSchema = yup.object().shape({
   name: yup.string().required("Entity Name is required"),
   valueType: yup.string().required("Entity Value Type is required"),
   fieldType: yup.string().required("Input Type is required"),
-  field: yup.string().required("Input Value is required"),
+  field: variableValueInputSchema("input field"),
 });
 
 const feastFeaturesSchema = yup.object().shape({
@@ -113,7 +124,7 @@ export const feastInputSchema = yup.object().shape({
 const variableInputSchema = yup.object().shape({
   name: yup.string().required("Name is required"),
   type: yup.string().required("Type is required"),
-  value: yup.string().required("Value is required"),
+  value: variableValueInputSchema("Value"),
 });
 
 const tablesInputSchema = yup.object().shape({

--- a/ui/src/pages/version/components/forms/validation/schema.js
+++ b/ui/src/pages/version/components/forms/validation/schema.js
@@ -67,7 +67,7 @@ const environmentVariableSchema = yup.object().shape({
   value: yup.string(),
 });
 
-const variableValueInputSchema = (name) => yup.mixed().test(
+const stringValueSchema = (name) => yup.mixed().test(
   `value input schema`,
   `${name} must be a \`string\` but the final value was $\{value}`,
   (value) => {
@@ -103,7 +103,7 @@ const feastEntitiesSchema = yup.object().shape({
   name: yup.string().required("Entity Name is required"),
   valueType: yup.string().required("Entity Value Type is required"),
   fieldType: yup.string().required("Input Type is required"),
-  field: variableValueInputSchema("input field"),
+  field: stringValueSchema("input field"),
 });
 
 const feastFeaturesSchema = yup.object().shape({
@@ -124,7 +124,7 @@ export const feastInputSchema = yup.object().shape({
 const variableInputSchema = yup.object().shape({
   name: yup.string().required("Name is required"),
   type: yup.string().required("Type is required"),
-  value: variableValueInputSchema("Value"),
+  value: stringValueSchema("Value"),
 });
 
 const tablesInputSchema = yup.object().shape({


### PR DESCRIPTION
# Background
When trying to input a `jsonPath` value type in standard transformer page (for variable input & feast table input), the value that is passed to the yup validation is type of object (e.g. `{ "jsonPath": "$.id" }`), instead of just the string value of jsonPath (`$.id`) inputted in the form. This prevent user to submit the form when their actual input is valid.  

<img width="660" alt="Screenshot 2024-08-29 at 13 18 40" src="https://github.com/user-attachments/assets/8ab9bbd3-c92f-46fa-b3aa-49b4c5ce938c">
<img width="530" alt="Screenshot 2024-08-29 at 13 40 48" src="https://github.com/user-attachments/assets/d09d13c8-15ca-405e-bcb8-3cc48333ad91">


# Modifications
Use a custom yup test function to validate `value`; if the value passed is type of object & has the field of `jsonPath`, it will compare the `jsonPath` value to the original schema; else can just compare the original value to the yup schema.

# Tests

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix variable input validation in transformer config ui page
```
