### PR TITLE
chore: add managed by label to namespace

### DIFF
--- a/api/batch/resource_test.go
+++ b/api/batch/resource_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/stretchr/testify/assert"
 	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,11 +135,11 @@ var (
 )
 
 func TestCreateSparkApplicationResource(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	tests := []struct {

--- a/api/cluster/controller_test.go
+++ b/api/cluster/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	fakekserve "github.com/kserve/kserve/pkg/client/clientset/versioned/fake"
 	fakekservev1beta1 "github.com/kserve/kserve/pkg/client/clientset/versioned/typed/serving/v1beta1/fake"
@@ -759,7 +760,7 @@ func TestController_DeployInferenceService(t *testing.T) {
 }
 
 func TestController_DeployInferenceService_PodDisruptionBudgetsRemoval(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", "dev")
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", "dev")
 	assert.Nil(t, err)
 
 	minAvailablePercentage := 80

--- a/api/cluster/labeller/labeller.go
+++ b/api/cluster/labeller/labeller.go
@@ -1,0 +1,84 @@
+package labeller
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	LabelAppName          = "app"
+	LabelComponent        = "component"
+	LabelEnvironment      = "environment"
+	LabelOrchestratorName = "orchestrator"
+	LabelStreamName       = "stream"
+	LabelTeamName         = "team"
+	LabelManaged          = "managed"
+)
+
+var reservedKeys = map[string]bool{
+	LabelAppName:          true,
+	LabelComponent:        true,
+	LabelEnvironment:      true,
+	LabelOrchestratorName: true,
+	LabelStreamName:       true,
+	LabelTeamName:         true,
+}
+
+var (
+	prefix           string
+	nsPrefix         string
+	environment      string
+	validPrefixRegex = regexp.MustCompile("^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?(/)$")
+)
+
+// InitKubernetesLabeller builds a new KubernetesLabeller Singleton
+func InitKubernetesLabeller(p, ns, e string) error {
+	if err := isValidPrefix(p, "prefix"); err != nil {
+		return err
+	}
+	if err := isValidPrefix(ns, "namespace prefix"); err != nil {
+		return err
+	}
+
+	prefix = p
+	nsPrefix = ns
+	environment = e
+	return nil
+}
+
+// isValidPrefix checks if the given prefix is valid
+func isValidPrefix(prefix, name string) error {
+	if len(prefix) > 253 {
+		return fmt.Errorf("length of %s is greater than 253 characters", name)
+	}
+	if isValidPrefix := validPrefixRegex.MatchString(prefix); !isValidPrefix {
+		return fmt.Errorf("%s name violates kubernetes label's prefix constraint", name)
+	}
+	return nil
+}
+
+// GetLabelName prefixes the label with the config specified label and returns the formatted label prefix
+func GetLabelName(name string) string {
+	return fmt.Sprintf("%s%s", prefix, name)
+}
+
+// GetNamespaceLabel prefixes the label with the config specified namespace label and returns the formatted label prefix
+func GetNamespaceLabel(name string) string {
+	return fmt.Sprintf("%s%s", nsPrefix, name)
+}
+
+// GetPrefix returns the labeller prefix
+func GetPrefix() string {
+	return prefix
+}
+
+// GetEnvironment returns the environment
+func GetEnvironment() string {
+	return environment
+}
+
+// IsReservedKey checks if the key is a reserved key
+func IsReservedKey(key string) bool {
+	_, usingReservedKeys := reservedKeys[key]
+	return usingReservedKeys
+}

--- a/api/cluster/labeller/labeller_test.go
+++ b/api/cluster/labeller/labeller_test.go
@@ -1,0 +1,62 @@
+package labeller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitKubernetesLabeller(t *testing.T) {
+	defaultNsPrefix := "caraml.dev/"
+	err := InitKubernetesLabeller("gojek.com/", "caraml.dev/", "dev")
+	assert.NoError(t, err)
+
+	defer func() {
+		_ = InitKubernetesLabeller("", "", "")
+	}()
+
+	tests := []struct {
+		prefix  string
+		wantErr bool
+	}{
+		{
+			"gojek.com/",
+			false,
+		},
+		{
+			"model.caraml.dev/",
+			false,
+		},
+		{
+			"goto/gojek",
+			true,
+		},
+		{
+			"gojek",
+			true,
+		},
+		{
+			"gojek.com/caraml",
+			true,
+		},
+		{
+			"gojek//",
+			true,
+		},
+		{
+			"gojek.com//",
+			true,
+		},
+		{
+			"//gojek.com",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prefix, func(t *testing.T) {
+			if err := InitKubernetesLabeller(tt.prefix, defaultNsPrefix, "dev"); (err != nil) != tt.wantErr {
+				t.Errorf("InitKubernetesLabeller() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/cluster/namespace.go
+++ b/api/cluster/namespace.go
@@ -17,8 +17,10 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +61,9 @@ func (k *namespaceCreator) CreateNamespace(ctx context.Context, namespace string
 	return k.Namespaces().Create(ctx, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
+			Labels: map[string]string{
+				labeller.GetNamespaceLabel(labeller.LabelManaged): strconv.FormatBool(true),
+			},
 		},
 	}, metav1.CreateOptions{})
 }

--- a/api/cluster/pdb_test.go
+++ b/api/cluster/pdb_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/stretchr/testify/assert"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +15,7 @@ import (
 )
 
 func Test_NewPodDisruptionBudget(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", "dev")
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", "dev")
 	assert.Nil(t, err)
 
 	twenty := 20
@@ -190,7 +191,7 @@ func TestPodDisruptionBudget_BuildPDBSpec(t *testing.T) {
 }
 
 func Test_generatePDBSpecs(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", "dev")
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", "dev")
 	assert.Nil(t, err)
 
 	ten, twenty := 10, 20

--- a/api/cluster/resource/templater_gpu_test.go
+++ b/api/cluster/resource/templater_gpu_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveconstant "github.com/kserve/kserve/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -66,11 +67,11 @@ var (
 )
 
 func TestCreateInferenceServiceSpecWithGPU(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	project := mlp.Project{

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	kservev1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	kserveconstant "github.com/kserve/kserve/pkg/constants"
 	"github.com/stretchr/testify/assert"
@@ -206,11 +207,11 @@ var (
 )
 
 func TestCreateInferenceServiceSpec(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	project := mlp.Project{
@@ -1935,11 +1936,11 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 }
 
 func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	project := mlp.Project{
@@ -2897,11 +2898,11 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 }
 
 func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	project := mlp.Project{
@@ -3390,11 +3391,11 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 }
 
 func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	project := mlp.Project{

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	mlflowDelete "github.com/caraml-dev/mlp/api/pkg/client/mlflow"
 	"github.com/caraml-dev/mlp/api/pkg/instrumentation/sentry"
 	webhookManager "github.com/caraml-dev/mlp/api/pkg/webhooks"
@@ -41,7 +42,6 @@ import (
 	"github.com/caraml-dev/merlin/database"
 	"github.com/caraml-dev/merlin/log"
 	mlflow "github.com/caraml-dev/merlin/mlflow"
-	"github.com/caraml-dev/merlin/models"
 	"github.com/caraml-dev/merlin/pkg/gitlab"
 	"github.com/caraml-dev/merlin/pkg/observability/event"
 	"github.com/caraml-dev/merlin/queue"
@@ -264,7 +264,7 @@ func buildDependencies(ctx context.Context, cfg *config.Config, db *gorm.DB, dis
 	mlpAPIClient := initMLPAPIClient(ctx, cfg.MlpAPIConfig)
 	coreClient := initFeastCoreClient(cfg.StandardTransformerConfig.FeastCoreURL, cfg.StandardTransformerConfig.FeastCoreAuthAudience, cfg.StandardTransformerConfig.EnableAuth)
 
-	if err := models.InitKubernetesLabeller(cfg.DeploymentLabelPrefix, cfg.Environment); err != nil {
+	if err := labeller.InitKubernetesLabeller(cfg.DeploymentLabelPrefix, cfg.NamespaceLabelPrefix, cfg.Environment); err != nil {
 		log.Panicf("invalid deployment label prefix (%s): %s", cfg.DeploymentLabelPrefix, err)
 	}
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	NumOfQueueWorkers         int    `validate:"required" default:"2"`
 	SwaggerPath               string `validate:"required" default:"./swagger.yaml"`
 
+	NamespaceLabelPrefix  string `validate:"required" default:"caraml.dev/"`
 	DeploymentLabelPrefix string `validate:"required" default:"gojek.com/"`
 	PyfuncGRPCOptions     string `validate:"required" default:"{}"`
 

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -366,6 +366,7 @@ func TestLoad(t *testing.T) {
 				},
 				NumOfQueueWorkers:     2,
 				SwaggerPath:           "swaggerpath.com",
+				NamespaceLabelPrefix:  "caraml.dev/",
 				DeploymentLabelPrefix: "caraml.com/",
 				PyfuncGRPCOptions:     "{}",
 				DbConfig: DatabaseConfig{

--- a/api/models/metadata_test.go
+++ b/api/models/metadata_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"testing"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/caraml-dev/merlin/mlp"
 	"github.com/stretchr/testify/assert"
 )
@@ -13,11 +14,11 @@ const (
 )
 
 func TestToLabel(t *testing.T) {
-	err := InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	testCases := []struct {
@@ -131,60 +132,6 @@ func TestToLabel(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			gotLabels := tC.metadata.ToLabel()
 			assert.Equal(t, tC.expectedLabels, gotLabels)
-		})
-	}
-}
-
-func TestInitKubernetesLabeller(t *testing.T) {
-	err := InitKubernetesLabeller("gojek.com/", testEnvironmentName)
-	assert.NoError(t, err)
-
-	defer func() {
-		_ = InitKubernetesLabeller("", "")
-	}()
-
-	tests := []struct {
-		prefix  string
-		wantErr bool
-	}{
-		{
-			"gojek.com/",
-			false,
-		},
-		{
-			"model.caraml.dev/",
-			false,
-		},
-		{
-			"goto/gojek",
-			true,
-		},
-		{
-			"gojek",
-			true,
-		},
-		{
-			"gojek.com/caraml",
-			true,
-		},
-		{
-			"gojek//",
-			true,
-		},
-		{
-			"gojek.com//",
-			true,
-		},
-		{
-			"//gojek.com",
-			true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.prefix, func(t *testing.T) {
-			if err := InitKubernetesLabeller(tt.prefix, testEnvironmentName); (err != nil) != tt.wantErr {
-				t.Errorf("InitKubernetesLabeller() error = %v, wantErr %v", err, tt.wantErr)
-			}
 		})
 	}
 }

--- a/api/models/service_test.go
+++ b/api/models/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/caraml-dev/merlin/mlp"
 	"github.com/caraml-dev/merlin/pkg/protocol"
 	transformerpkg "github.com/caraml-dev/merlin/pkg/transformer"
@@ -49,11 +50,11 @@ func TestGetValidInferenceURL(t *testing.T) {
 }
 
 func Test_mergeProjectVersionLabels(t *testing.T) {
-	err := InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	type args struct {

--- a/api/pkg/imagebuilder/imagebuilder_test.go
+++ b/api/pkg/imagebuilder/imagebuilder_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	cfg "github.com/caraml-dev/merlin/config"
 	"github.com/caraml-dev/merlin/mlp"
 	"github.com/caraml-dev/merlin/models"
@@ -253,11 +254,11 @@ func (w *podWatchReactor) React(action ktesting.Action) (handled bool, ret watch
 }
 
 func TestBuildImage(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	hash := sha256.New()

--- a/api/pkg/imagebuilder/janitor.go
+++ b/api/pkg/imagebuilder/janitor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	batchv1 "k8s.io/api/batch/v1"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/caraml-dev/merlin/cluster"
 	"github.com/caraml-dev/merlin/log"
-	"github.com/caraml-dev/merlin/models"
 )
 
 var (
@@ -72,7 +72,7 @@ func (j *Janitor) CleanJobs() {
 }
 
 func (j *Janitor) getExpiredJobs(ctx context.Context) ([]batchv1.Job, error) {
-	jobs, err := j.cc.ListJobs(ctx, j.cfg.BuildNamespace, models.LabelOrchestratorName+"=merlin")
+	jobs, err := j.cc.ListJobs(ctx, j.cfg.BuildNamespace, labeller.LabelOrchestratorName+"=merlin")
 	if err != nil {
 		return nil, err
 	}

--- a/api/pkg/imagebuilder/janitor_test.go
+++ b/api/pkg/imagebuilder/janitor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	batchv1 "k8s.io/api/batch/v1"
@@ -14,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/caraml-dev/merlin/cluster/mocks"
-	"github.com/caraml-dev/merlin/models"
 )
 
 var (
@@ -121,7 +121,7 @@ func TestJanitor_CleanJobs(t *testing.T) {
 
 	totalDelete := 0
 
-	mc.On("ListJobs", context.Background(), namespace, models.LabelOrchestratorName+"=merlin").
+	mc.On("ListJobs", context.Background(), namespace, labeller.LabelOrchestratorName+"=merlin").
 		Return(&batchv1.JobList{Items: []batchv1.Job{completedJob1, completedJob2, activeJob1, failedJob1}}, nil)
 
 	mc.On("DeleteJob", context.Background(), namespace, completedJob1.Name, mock.Anything).
@@ -156,7 +156,7 @@ func TestJanitor_getExpiredJobs(t *testing.T) {
 				cfg: JanitorConfig{BuildNamespace: namespace, Retention: retention},
 			},
 			mockFn: func(mc *mocks.Controller) {
-				mc.On("ListJobs", context.Background(), namespace, models.LabelOrchestratorName+"=merlin").
+				mc.On("ListJobs", context.Background(), namespace, labeller.LabelOrchestratorName+"=merlin").
 					Return(&batchv1.JobList{}, nil)
 			},
 			want:    []batchv1.Job{},
@@ -168,7 +168,7 @@ func TestJanitor_getExpiredJobs(t *testing.T) {
 				cfg: JanitorConfig{BuildNamespace: namespace, Retention: retention},
 			},
 			mockFn: func(mc *mocks.Controller) {
-				mc.On("ListJobs", context.Background(), namespace, models.LabelOrchestratorName+"=merlin").
+				mc.On("ListJobs", context.Background(), namespace, labeller.LabelOrchestratorName+"=merlin").
 					Return(&batchv1.JobList{Items: []batchv1.Job{completedJob1}}, nil)
 			},
 			want:    []batchv1.Job{completedJob1},
@@ -180,7 +180,7 @@ func TestJanitor_getExpiredJobs(t *testing.T) {
 				cfg: JanitorConfig{BuildNamespace: namespace, Retention: retention},
 			},
 			mockFn: func(mc *mocks.Controller) {
-				mc.On("ListJobs", context.Background(), namespace, models.LabelOrchestratorName+"=merlin").
+				mc.On("ListJobs", context.Background(), namespace, labeller.LabelOrchestratorName+"=merlin").
 					Return(&batchv1.JobList{Items: []batchv1.Job{completedJob1, activeJob1}}, nil)
 			},
 			want:    []batchv1.Job{completedJob1},
@@ -192,7 +192,7 @@ func TestJanitor_getExpiredJobs(t *testing.T) {
 				cfg: JanitorConfig{BuildNamespace: namespace, Retention: retention},
 			},
 			mockFn: func(mc *mocks.Controller) {
-				mc.On("ListJobs", context.Background(), namespace, models.LabelOrchestratorName+"=merlin").
+				mc.On("ListJobs", context.Background(), namespace, labeller.LabelOrchestratorName+"=merlin").
 					Return(&batchv1.JobList{Items: []batchv1.Job{completedJob1, activeJob1, failedJob1}}, nil)
 			},
 			want:    []batchv1.Job{completedJob1},

--- a/api/service/model_endpoint_service_test.go
+++ b/api/service/model_endpoint_service_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/caraml-dev/merlin/cluster/labeller"
 	"github.com/caraml-dev/merlin/istio"
 	istioCliMock "github.com/caraml-dev/merlin/istio/mocks"
 	"github.com/caraml-dev/merlin/models"
@@ -458,11 +459,11 @@ func Test_modelEndpointsService_UndeployEndpoint(t *testing.T) {
 }
 
 func TestModelEndpointService_createVirtualService(t *testing.T) {
-	err := models.InitKubernetesLabeller("gojek.com/", testEnvironmentName)
+	err := labeller.InitKubernetesLabeller("gojek.com/", "caraml.dev/", testEnvironmentName)
 	assert.NoError(t, err)
 
 	defer func() {
-		_ = models.InitKubernetesLabeller("", "")
+		_ = labeller.InitKubernetesLabeller("", "", "")
 	}()
 
 	type fields struct {


### PR DESCRIPTION
# Description

When creating a namespace object in Kubernetes, add label “{prefix}/managed: true”. This will help when we want to modify resources created by CaraML services in a shared cluster, e.g. configuring log for the managed namespace only

By default the namespace prefix would `caraml.dev/`, and it can be configured in the config yaml


# Modifications
- As the creation of label for Kubernetes’ object in Merlin previously is bind to metadata struct, while namespace doesn’t have metada, in this changes the functionality of labelling (labeller) is moved to it’s own package
- Add one more prefix in `InitKubernetesLabeller` initiation
- Add the `{prefix}/managed: true` when creating namespace

# Tests

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes

```release-note

```
