### PR TITLE
chore: add new label to reserved key list

### DIFF
--- a/api/cluster/labeller/labeller.go
+++ b/api/cluster/labeller/labeller.go
@@ -22,6 +22,7 @@ var reservedKeys = map[string]bool{
 	LabelOrchestratorName: true,
 	LabelStreamName:       true,
 	LabelTeamName:         true,
+	LabelManaged:          true,
 }
 
 var (


### PR DESCRIPTION
# Description
Previously I added a new kubernetes label in #604, this should've been added to reserved key list

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes

```release-note

```
