### PR TITLE
feat: Using secret to attach identity to pod for observability publisher

### DIFF
--- a/api/config/observability.go
+++ b/api/config/observability.go
@@ -4,16 +4,16 @@ import "time"
 
 // ObservabilityPublisher
 type ObservabilityPublisher struct {
-	ArizeSink          ArizeSink
-	BigQuerySink       BigQuerySink
-	KafkaConsumer      KafkaConsumer
-	ImageName          string
-	DefaultResources   ResourceRequestsLimits
-	EnvironmentName    string
-	Replicas           int32
-	TargetNamespace    string
-	ServiceAccountName string
-	DeploymentTimeout  time.Duration `default:"30m"`
+	ArizeSink                ArizeSink
+	BigQuerySink             BigQuerySink
+	KafkaConsumer            KafkaConsumer
+	ImageName                string
+	DefaultResources         ResourceRequestsLimits
+	EnvironmentName          string
+	Replicas                 int32
+	TargetNamespace          string
+	DeploymentTimeout        time.Duration `default:"30m"`
+	ServiceAccountSecretName string
 }
 
 // KafkaConsumer

--- a/api/pkg/observability/deployment/deployment_test.go
+++ b/api/pkg/observability/deployment/deployment_test.go
@@ -48,8 +48,8 @@ const (
 	ready        deploymentStatus = "ready"
 	timeoutError deploymentStatus = "timeout_error"
 
-	namespace          = "caraml-observability"
-	serviceAccountName = "caraml-observability-sa-secret"
+	namespace                = "caraml-observability"
+	serviceAccountSecretName = "caraml-observability-sa-secret"
 )
 
 func createDeploymentSpec(data *models.WorkerData, resourceRequest corev1.ResourceList, resourceLimit corev1.ResourceList, imageName string, serviceAccountSecretName string) *appsv1.Deployment {
@@ -234,7 +234,7 @@ func Test_deployer_Deploy(t *testing.T) {
 		EnvironmentName:          "dev",
 		Replicas:                 2,
 		TargetNamespace:          namespace,
-		ServiceAccountSecretName: serviceAccountName,
+		ServiceAccountSecretName: serviceAccountSecretName,
 		DeploymentTimeout:        5 * time.Second,
 	}
 	requestResource := corev1.ResourceList{
@@ -828,7 +828,7 @@ func Test_deployer_GetDeployedManifest(t *testing.T) {
 		},
 		TopicSource: "caraml-project-1-model-1-1-prediction-log",
 	}
-	depl := createDeploymentSpec(workerData, requestResource, limitResource, "image:v0.1", serviceAccountName)
+	depl := createDeploymentSpec(workerData, requestResource, limitResource, "image:v0.1", serviceAccountSecretName)
 	testCases := []struct {
 		name             string
 		data             *models.WorkerData

--- a/api/pkg/observability/deployment/identity.go
+++ b/api/pkg/observability/deployment/identity.go
@@ -1,0 +1,52 @@
+package deployment
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func enrichIdentityToPod(podSpec corev1.PodSpec, secretName string, containerNames []string) corev1.PodSpec {
+	secretVolume := createVolumeFromSecret(secretName)
+	updatedPodSpec := podSpec.DeepCopy()
+
+	containerExist := false
+	for idx, containerSpec := range updatedPodSpec.Containers {
+		updatedContainerSpec := containerSpec
+		for _, targetName := range containerNames {
+			if targetName != updatedContainerSpec.Name {
+				continue
+			}
+			containerExist = true
+			mountPath := fmt.Sprintf("/iam/%s", secretName)
+			volumeMount := corev1.VolumeMount{
+				Name:      secretVolume.Name,
+				MountPath: mountPath,
+				ReadOnly:  true,
+			}
+			updatedContainerSpec.VolumeMounts = append(updatedContainerSpec.VolumeMounts, volumeMount)
+			gcpCredentialEnvVar := corev1.EnvVar{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: fmt.Sprintf("%s/service-account.json", mountPath),
+			}
+			updatedContainerSpec.Env = append(updatedContainerSpec.Env, gcpCredentialEnvVar)
+		}
+		updatedPodSpec.Containers[idx] = updatedContainerSpec
+	}
+
+	if containerExist {
+		updatedPodSpec.Volumes = append(updatedPodSpec.Volumes, secretVolume)
+	}
+	return *updatedPodSpec
+}
+
+func createVolumeFromSecret(secretName string) corev1.Volume {
+	return corev1.Volume{
+		Name: "iam-secret",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	}
+}

--- a/api/pkg/observability/deployment/identity_test.go
+++ b/api/pkg/observability/deployment/identity_test.go
@@ -1,0 +1,425 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Test_gcp_enrichIdentityToPod(t *testing.T) {
+	singleContainerPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "worker",
+				Image: "python:3.10",
+				Command: []string{
+					"python",
+					"-m",
+					"publisher",
+					"+environment=config",
+				},
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "prom-metric",
+						ContainerPort: 8000,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+			},
+		},
+	}
+
+	multipleContainerPodSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "worker",
+				Image: "python:3.10",
+				Command: []string{
+					"python",
+					"-m",
+					"publisher",
+					"+environment=config",
+				},
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "env-secret-volume",
+						MountPath: "/env",
+						ReadOnly:  true,
+					},
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "prom-metric",
+						ContainerPort: 8000,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "WORKERS",
+						Value: "1",
+					},
+				},
+			},
+			{
+				Name:  "sidecar",
+				Image: "python:3.10",
+				Command: []string{
+					"./run.sh",
+				},
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "env-secret-volume",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "secret-1",
+					},
+				},
+			},
+		},
+	}
+	type args struct {
+		podSpec        corev1.PodSpec
+		secretName     string
+		containerNames []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want corev1.PodSpec
+	}{
+		{
+			name: "update identity for one container",
+			args: args{
+				podSpec:        singleContainerPodSpec,
+				secretName:     "service-account",
+				containerNames: []string{"worker"},
+			},
+			want: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "worker",
+						Image: "python:3.10",
+						Command: []string{
+							"python",
+							"-m",
+							"publisher",
+							"+environment=config",
+						},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "prom-metric",
+								ContainerPort: 8000,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "iam-secret",
+								MountPath: "/iam/service-account",
+								ReadOnly:  true,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+								Value: "/iam/service-account/service-account.json",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "iam-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "service-account",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update identity for one container, but no matching container name",
+			args: args{
+				podSpec:        singleContainerPodSpec,
+				secretName:     "service-account",
+				containerNames: []string{"not-exist"},
+			},
+			want: singleContainerPodSpec,
+		},
+		{
+			name: "update identity for multiple containers",
+			args: args{
+				podSpec:        multipleContainerPodSpec,
+				secretName:     "service-account",
+				containerNames: []string{"worker", "sidecar"},
+			},
+			want: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "worker",
+						Image: "python:3.10",
+						Command: []string{
+							"python",
+							"-m",
+							"publisher",
+							"+environment=config",
+						},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "env-secret-volume",
+								MountPath: "/env",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "iam-secret",
+								MountPath: "/iam/service-account",
+								ReadOnly:  true,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "WORKERS",
+								Value: "1",
+							},
+							{
+								Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+								Value: "/iam/service-account/service-account.json",
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "prom-metric",
+								ContainerPort: 8000,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+					},
+					{
+						Name:  "sidecar",
+						Image: "python:3.10",
+						Command: []string{
+							"./run.sh",
+						},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "iam-secret",
+								MountPath: "/iam/service-account",
+								ReadOnly:  true,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+								Value: "/iam/service-account/service-account.json",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "env-secret-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "secret-1",
+							},
+						},
+					},
+					{
+						Name: "iam-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "service-account",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update identity for multiple containers, only match one container",
+			args: args{
+				podSpec:        multipleContainerPodSpec,
+				secretName:     "service-account",
+				containerNames: []string{"worker"},
+			},
+			want: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "worker",
+						Image: "python:3.10",
+						Command: []string{
+							"python",
+							"-m",
+							"publisher",
+							"+environment=config",
+						},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "env-secret-volume",
+								MountPath: "/env",
+								ReadOnly:  true,
+							},
+							{
+								Name:      "iam-secret",
+								MountPath: "/iam/service-account",
+								ReadOnly:  true,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "WORKERS",
+								Value: "1",
+							},
+							{
+								Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+								Value: "/iam/service-account/service-account.json",
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "prom-metric",
+								ContainerPort: 8000,
+								Protocol:      corev1.ProtocolTCP,
+							},
+						},
+					},
+					{
+						Name:  "sidecar",
+						Image: "python:3.10",
+						Command: []string{
+							"./run.sh",
+						},
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "env-secret-volume",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "secret-1",
+							},
+						},
+					},
+					{
+						Name: "iam-secret",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "service-account",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update identity for multiple containers, but none matching container name",
+			args: args{
+				podSpec:        multipleContainerPodSpec,
+				secretName:     "service-account",
+				containerNames: []string{"worker-1", "sidecar-1"},
+			},
+			want: multipleContainerPodSpec,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enrichIdentityToPod(tt.args.podSpec, tt.args.secretName, tt.args.containerNames)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
Since we are trying to move away from cloud-specific feature, hence as first step in observability publisher is to use secret for propagate identity instead of using existing workload identity way

# Modifications
Add `GOOGLE_APPLICATION_CREDENTIALS` for propagate google identity to pod
# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
