### PR TITLE
fix(batch-predictor): Bump up pyarrow version limit

### DIFF
--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -2,6 +2,6 @@ cloudpickle==2.0.0
 findspark==2.0.1
 merlin-sdk==0.44.0
 mlflow==1.26.1
-pyarrow>=0.14.1,<11.0.0
+pyarrow>=0.14.1,<=17.0.0
 pyspark==3.0.1
 setuptools<75


### PR DESCRIPTION
# Description
It seems like there's a [memory leak](https://github.com/apache/arrow/issues/37989) in older `pyarrow` versions and this fix has only been [addressed recently](https://github.com/apache/arrow/commits/apache-arrow-16.0.0?after=6a28035c2b49b432dc63f5ee7524d76b4ed2d762+174) in `pyarrow==16.0.0`. Since we have `pyarrow` pinned to `<11.0.0` within the batch predictor, this PR loosens this restriction and simply sets it to allow the latest released version `pyarrow<=17.0.0` instead.

# Modifications
- `python/batch-predictor/requirements.txt` - Loosening of `pyarrow` version pinned

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
