### PR TITLE
fix(cicd): Fix invalid pip installation commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         working-directory: ./python/sdk
-        run: pip install setuptools>=64,<75 setuptools_scm>=8 twine wheel
+        run: pip install "setuptools>=64,<75" "setuptools_scm>=8" "twine" "wheel"
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.pypi_username }}
@@ -53,7 +53,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         working-directory: ./python/pyfunc-server
-        run: pip install setuptools>=64,<75 setuptools_scm>=8 twine wheel
+        run: pip install "setuptools>=64,<75" "setuptools_scm>=8" "twine" "wheel"
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.pypi_username }}
@@ -78,7 +78,7 @@ jobs:
           cache: pip
       - name: Install dependencies
         working-directory: ./python/batch-predictor
-        run: pip install setuptools>=64,<75 setuptools_scm>=8 twine wheel
+        run: pip install "setuptools>=64,<75" "setuptools_scm>=8" "twine" "wheel"
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.pypi_username }}


### PR DESCRIPTION
# Description
In PR #608, the version of `setuptools` was pinned to `<75`. However, this wasn't done correctly for the pip installation command, causing the CICD pipeline to [fail](https://github.com/caraml-dev/merlin/actions/runs/10988775479/job/30506834078#step:4:13) when publishing new versions of the Merlin SDK, batch predictor and pyfunc server to PyPI. This PR simply corrects that invalid command.

# Modifications
- `.github/workflows/release.yml` - Fix incorrect pip installation command

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
