### PR TITLE
fix(cicd): Add google cloud sdk installation

### DIFF
--- a/.github/workflows/merlin.yml
+++ b/.github/workflows/merlin.yml
@@ -48,6 +48,8 @@ jobs:
       PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
# Description
It seems like the latest version of the Ubuntu image used in our GitHub runners [no longer contain](https://github.com/actions/runner-images/issues/10636) the Google Cloud CLI/SDK preinstalled (this has been removed amongst other CLI tools 'due to maintenance reasons') and this change now breaks one of our CICD workflows where we're expecting it to be installed. 

This PR simply adds another step in the affected CICD workflow to install the CLI/SDK explicitly (see https://github.com/stackrox/stackrox/pull/12968/files for an example).

Compare the Ubuntu images used to run the same CICD workflow here:
Attempt 1 (version 20240922.1.0) [SUCCESS]:
https://github.com/caraml-dev/merlin/actions/runs/11232637125/job/31224653961#step:1:9

Attempt 2 (version 20241006.1.0) [FAILURE]:
https://github.com/caraml-dev/merlin/actions/runs/11232637125/job/31335777735#step:1:9

# Modifications
- Addition of a new step in the batch predictor unit test CICD workflow

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
