### PR TITLE
chore(sdk): Update pyfunc server and batch predictor default version

### DIFF
--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1005,9 +1005,9 @@ class ModelVersion:
                 "log_pyfunc_model is only for PyFunc, PyFuncV2 and PyFuncV3 model"
             )
 
-        merlin_requirements = ["merlin-pyfunc-server<0.42.0"]
+        merlin_requirements = ["merlin-pyfunc-server<0.46.0"]
         if self._model.type == ModelType.PYFUNC_V2:
-            merlin_requirements = ["merlin-batch-predictor<0.42.0"]
+            merlin_requirements = ["merlin-batch-predictor<0.46.0"]
 
         # add/replace python version in conda to match that used to create model version
         conda_env = process_conda_env(


### PR DESCRIPTION
# Description
This PR is the **third part** (3 out of 3) of a series of PRs to update the version of Mlflow used by Merlin (to `1.26.1`*). These changes are:

1. Update the version of Mlflow used in the Merlin SDK and publish it to PyPI
2. Update 
   - the Merlin pyfunc server and batch predictor to use the updated Merlin SDK version released in step 1 and publish them to PyPI
   - the Merlin API server to ensure that requests sent to Mlflow reflect the update API endpoint contracts
   - the Mlflow image so that it's built using version `1.26.1`
3. Update the default pyfunc server and batch predictor version in the Merlin SDK and publish its new version to PyPI

Since the pyfunc server and batch predictor versions have already been updated in the PR #617, we need to ensure that the SDK is able to use these newly released versions by default.

# Modifications
- `python/sdk/merlin/model.py` - Update the version bounds of the default pyfunc server and batch predictor version in the SDK

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
