### PR TITLE
Add extra arguments to merlin logger

### DIFF
--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -41,9 +41,11 @@ var (
 	namespace        = flag.String("namespace", "my-project", "The namespace to add as header to log events")
 
 	// These flags are not needed by our logger but provided by Kserve, hence we need to parse it to avoid error.
-	sourceUri = flag.String("source-uri", "", "The source URI to use when publishing cloudevents")
-	endpoint  = flag.String("endpoint", "", "The endpoint name to add as header to log events")
-	component = flag.String("component", "", "The component name (predictor, explainer, transformer) to add as header to log events")
+	sourceUri     = flag.String("source-uri", "", "The source URI to use when publishing cloudevents")
+	endpoint      = flag.String("endpoint", "", "The endpoint name to add as header to log events")
+	component     = flag.String("component", "", "The component name (predictor, explainer, transformer) to add as header to log events")
+	CaCertFile    = flag.String("logger-ca-cert-file", "service-ca.crt", "The logger CA certificate file")
+	TlsSkipVerify = flag.Bool("logger-tls-skip-verify", false, "Skip verification of TLS certificate")
 )
 
 const (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
- kserve v0.14.0 adds new params in the agent arguments https://github.com/kserve/kserve/commit/02293acd44bf0cadb0a0fb5b126a1ca2246b8020#diff-61358711e980ccf505246fd3915f97cbd3a380e9b66f6fa5aad46749968c5ca3R78, this causes the merlin-logger to fail when starting up as it cannot parse those extra arguments

# Modifications
<!-- Summarize the key code changes. -->
- This PR adds support for those 2 arguments

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
