### PR TITLE
fix(image-builder): Add kaniko api server env vars config to pred job image builder

### DIFF
--- a/api/cmd/api/setup.go
+++ b/api/cmd/api/setup.go
@@ -161,6 +161,7 @@ func initImageBuilder(cfg *config.Config) (webserviceBuilder imagebuilder.ImageB
 		KanikoDockerCredentialSecretName: cfg.ImageBuilderConfig.KanikoDockerCredentialSecretName,
 		KanikoServiceAccount:             cfg.ImageBuilderConfig.KanikoServiceAccount,
 		KanikoAdditionalArgs:             cfg.ImageBuilderConfig.KanikoAdditionalArgs,
+		KanikoAPIServerEnvVars:           cfg.ImageBuilderConfig.KanikoAPIServerEnvVars,
 		DefaultResources:                 cfg.ImageBuilderConfig.DefaultResources,
 		Tolerations:                      cfg.ImageBuilderConfig.Tolerations,
 		NodeSelectors:                    cfg.ImageBuilderConfig.NodeSelectors,


### PR DESCRIPTION
# Description
Previously in https://github.com/caraml-dev/merlin/pull/621/files, a change has been made to allow the API server to propagate environment variables within its environment to the build environment of all Kaniko jobs that it spins up. However, this [only happens](https://github.com/caraml-dev/merlin/pull/621/files#diff-7b392e9c2e9e1954a33f66c70cfa8aed8a4b468f20be6bbc6b3a44d8a1054ae7R141) for all Merlin web service image building jobs (and not batch prediction image building jobs) because the config `KanikoAPIServerEnvVars` is not passed as a field of the batch prediction image building job config.

This PR addresses this bug by simply adding the `KanikoAPIServerEnvVars` field as one of the new fields to create when the batch prediction image building job config gets initiliased.

# Modifications
- `api/cmd/api/setup.go` - Add `KanikoAPIServerEnvVars` to batching prediction image building job config

# Tests
None

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
