### PR TITLE
fix(api): Add configmaps as a resource to the spark driver role rules

### DIFF
--- a/api/batch/manifest.go
+++ b/api/batch/manifest.go
@@ -70,6 +70,18 @@ var (
 				"*",
 			},
 		},
+		{
+			// Allow driver to manage configmaps
+			APIGroups: []string{
+				"", // indicates the core API group
+			},
+			Resources: []string{
+				"configmaps",
+			},
+			Verbs: []string{
+				"*",
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
# Description
Currently, the Spark driver service account that is created for every batch prediction job does not have permissions to create ConfigMaps that its Spark executor(s) require(s). This is a problem in clusters with RBAC enabled and this PR simply adds the missing rule on ConfigMap resources for the Spark driver service account.

# Modifications
- `api/batch/manifest.go` - Addition of configmaps as an additional rule

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
