### PR TITLE
fix(cicd): Replace deprecated golangci config

### DIFF
--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -1,9 +1,6 @@
 run:
   timeout: 10m
   modules-download-mode: readonly
-  skip-dirs:
-  - client
-  - '.*/mocks/.*'
 
 linters:
 # See https://golangci-lint.run/usage/linters/
@@ -17,3 +14,6 @@ issues:
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-dirs:
+    - client
+    - '.*/mocks/.*'


### PR DESCRIPTION
# Description
This PR simply removes a deprecated config field in the golangci config file and replaces it with its replacement. See this CICD run for an example of a failed run: https://github.com/caraml-dev/merlin/actions/runs/13383384346/job/37376991624#step:4:35. Previously using the old config would only emit warnings but now they have become explicit errors. See this PR from golangci for more details https://github.com/golangci/golangci-lint/pull/4509.

# Modifications
- `api/.golangci.yml` - Replace deprecated configs

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
