### PR TITLE
feat(api): Decouple Arize and BigQuery sink config

### DIFF
--- a/api/config/observability.go
+++ b/api/config/observability.go
@@ -26,8 +26,19 @@ type KafkaConsumer struct {
 
 // ArizeSink
 type ArizeSink struct {
-	APIKey   string
-	SpaceKey string
+	APIKey              string
+	SpaceKey            string
+	EnabledModelSerials []string
+}
+
+func (az ArizeSink) IsEnabled(modelSerial string) bool {
+	for _, ems := range az.EnabledModelSerials {
+		if ems == modelSerial {
+			return true
+		}
+	}
+
+	return false
 }
 
 // BigQuerySink

--- a/api/config/observability.go
+++ b/api/config/observability.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ObservabilityPublisher
 type ObservabilityPublisher struct {
@@ -28,11 +31,11 @@ type KafkaConsumer struct {
 type ArizeSink struct {
 	APIKey              string
 	SpaceKey            string
-	EnabledModelSerials []string
+	EnabledModelSerials string
 }
 
 func (az ArizeSink) IsEnabled(modelSerial string) bool {
-	for _, ems := range az.EnabledModelSerials {
+	for _, ems := range strings.Split(az.EnabledModelSerials, ",") {
 		if ems == modelSerial {
 			return true
 		}

--- a/api/models/observability_publisher.go
+++ b/api/models/observability_publisher.go
@@ -43,6 +43,10 @@ type WorkerData struct {
 	ResourceRequest *WorkerResourceRequest
 }
 
+func (wd *WorkerData) GetModelSerial() string {
+	return fmt.Sprintf("%s_%s_%s", wd.Project, wd.ModelName, wd.ModelVersion)
+}
+
 func NewWorkerData(modelVersion *Version, model *Model, observabilityPublisher *ObservabilityPublisher, resourceRequest *WorkerResourceRequest) *WorkerData {
 	return &WorkerData{
 		ModelName:       model.Name,


### PR DESCRIPTION
# Description
Use `BigQuery` sink as the sink default and add `EnabledModelSerials` config to `ArizeSink` to determine which model needs `ArizeSink` for the `ObservationSinks` config. The value for the `EnabledModelSerials` is following this pattern `{Project}_{Model Name}_{Model Version}`, separated with comma.

# Modifications
Only add `ArizeSink` in the consumer config if the model serial is in the `EnabledModelSerials`

# Tests
1. Hit redeploy API locally while connected to staging env without `OBSERVABILITYPUBLISHER_ARIZESINK_ENABLEDMODELSERIALS` env, the `config.yaml` file generated for the consumer looks like this
```
observation_sinks:
- type: BIGQUERY
  config:
    project: p-gojek-data-science
    dataset: data_science_platform_playground
    ttl_days: 14
```
2. Hit redeploy API locally while connected to staging env with `"OBSERVABILITYPUBLISHER_ARIZESINK_ENABLEDMODELSERIALS": "tari-staging_pyfunc-play_3"` , the `config.yaml` file generated for the consumer looks like this
```
observation_sinks:
- type: BIGQUERY
  config:
    project: p-gojek-data-science
    dataset: data_science_platform_playground
    ttl_days: 14
- type: ARIZE
  config:
    api_key: YzJjNmY5OGZhMGNmYTkxOTc0YQ==
    space_key: ODVkMmMwMg==
```

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

```release-note
NONE
```
