### PR TITLE
fix(ui): Fix secrets component in batch prediction job creation page

### DIFF
--- a/ui/src/pages/job/form/components/SecretsForm.js
+++ b/ui/src/pages/job/form/components/SecretsForm.js
@@ -91,7 +91,7 @@ export const SecretsForm = ({ variables, onChange }) => {
           options.push({
             value: secret.name,
             inputDisplay: secret.name,
-            textWrap: "truncate",
+            textwrap: "truncate",
           });
         });
       setOptions(options);

--- a/ui/src/pages/job/form/components/SecretsForm.js
+++ b/ui/src/pages/job/form/components/SecretsForm.js
@@ -91,7 +91,6 @@ export const SecretsForm = ({ variables, onChange }) => {
           options.push({
             value: secret.name,
             inputDisplay: secret.name,
-            textwrap: "truncate",
           });
         });
       setOptions(options);

--- a/ui/src/pages/version/components/forms/components/SecretsPanel.js
+++ b/ui/src/pages/version/components/forms/components/SecretsPanel.js
@@ -30,7 +30,6 @@ export const SecretsPanel = ({
           options.push({
             value: secret.name,
             inputDisplay: secret.name,
-            textwrap: "truncate"
           });
         });
       setOptions(options);

--- a/ui/src/services/job/Job.js
+++ b/ui/src/services/job/Job.js
@@ -39,6 +39,8 @@ export class Job {
 
       env_vars: [],
 
+      secrets: [],
+
       job_config: {
         model: {
           type: "",
@@ -86,6 +88,10 @@ export class Job {
   static from(json) {
     if (!json.config.env_vars) {
       json.config.env_vars = [];
+    }
+
+    if (!json.config.secrets) {
+      json.config.secrets = [];
     }
 
     return objectAssignDeep(new Job(), json);


### PR DESCRIPTION
# Description
This PR fixes a bug with the new UI changes introduced in PR #627, whereby attempting to redeploy a batch job in a terminal state (succeeded or failed) that does not have any user secrets configured (`nil`) will cause the UI to crash. This PR fixes this bug by setting the default value of the `secrets` field to be `[]` by default.

Another minor change in this PR is also made to remove the redundant `textwrap` option (this is not recognised and does nothing) that had been accidentally introduced in the same PR quoted above.

# Modifications
- `ui/src/pages/job/form/components/SecretsForm.js` - Removal of `textwrap` option
- `ui/src/pages/version/components/forms/components/SecretsPanel.js` - Removal of `textwrap` option
- `ui/src/services/job/Job.js` - Addition of steps to ensure the `secrets` field gets intialised as `[]` by default

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
