### PR TITLE
feat(api): allow enable mlobs from API directly

### DIFF
--- a/api/api/validator.go
+++ b/api/api/validator.go
@@ -179,13 +179,11 @@ func modelObservabilityValidation(endpoint *models.VersionEndpoint, model *model
 		if !endpoint.IsModelMonitoringEnabled() {
 			return nil
 		}
+
 		if !slices.Contains(supportedObservabilityModelTypes, model.Type) {
 			return fmt.Errorf("%s: %w", model.Type, ErrUnsupportedObservabilityModelType)
 		}
 
-		if !model.ObservabilitySupported {
-			return fmt.Errorf("model observability is not supported for this model")
-		}
 		return nil
 	})
 }

--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -154,6 +154,7 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 		}
 
 		newEndpoint.EnvironmentName = env.Name
+		newEndpoint.SetModelObservabilityEnabledWithEnableModelObservabilityIfNil()
 	}
 
 	validationRules := []requestValidator{
@@ -209,6 +210,8 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 	if !ok {
 		return BadRequest("Unable to parse body as version endpoint resource")
 	}
+
+	newEndpoint.SetModelObservabilityEnabledWithEnableModelObservabilityIfNil()
 
 	env, err := c.AppContext.EnvironmentService.GetEnvironment(newEndpoint.EnvironmentName)
 	if err != nil {

--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -154,7 +154,7 @@ func (c *EndpointsController) CreateEndpoint(r *http.Request, vars map[string]st
 		}
 
 		newEndpoint.EnvironmentName = env.Name
-		newEndpoint.SetModelObservabilityEnabledWithEnableModelObservabilityIfNil()
+		newEndpoint.SetModeObservabilityIfNil()
 	}
 
 	validationRules := []requestValidator{
@@ -211,7 +211,7 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 		return BadRequest("Unable to parse body as version endpoint resource")
 	}
 
-	newEndpoint.SetModelObservabilityEnabledWithEnableModelObservabilityIfNil()
+	newEndpoint.SetModeObservabilityIfNil()
 
 	env, err := c.AppContext.EnvironmentService.GetEnvironment(newEndpoint.EnvironmentName)
 	if err != nil {

--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -1068,7 +1068,9 @@ func TestCreateEndpoint(t *testing.T) {
 						Value: "1",
 					},
 				}),
-				EnableModelObservability: true,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 			modelService: func() *mocks.ModelsService {
 				svc := &mocks.ModelsService{}
@@ -1198,105 +1200,6 @@ func TestCreateEndpoint(t *testing.T) {
 					}),
 					CreatedUpdated: models.CreatedUpdated{},
 				},
-			},
-		},
-		{
-			desc: "Fail when try to enable model observability but the model is not supported yet",
-			vars: map[string]string{
-				"model_id":   "1",
-				"version_id": "1",
-			},
-			requestBody: &models.VersionEndpoint{
-				ID:              uuid,
-				VersionID:       models.ID(1),
-				VersionModelID:  models.ID(1),
-				ServiceName:     "sample",
-				Namespace:       "sample",
-				EnvironmentName: "dev",
-				Message:         "",
-				ResourceRequest: &models.ResourceRequest{
-					MinReplica:    1,
-					MaxReplica:    4,
-					CPURequest:    resource.MustParse("1"),
-					MemoryRequest: resource.MustParse("1Gi"),
-				},
-				EnvVars: models.EnvVars([]models.EnvVar{
-					{
-						Name:  "WORKER",
-						Value: "1",
-					},
-				}),
-				EnableModelObservability: true,
-			},
-			modelService: func() *mocks.ModelsService {
-				svc := &mocks.ModelsService{}
-				svc.On("FindByID", mock.Anything, models.ID(1)).Return(&models.Model{
-					ID:                     models.ID(1),
-					Name:                   "model-1",
-					ProjectID:              models.ID(1),
-					Project:                mlp.Project{},
-					ExperimentID:           1,
-					Type:                   "pyfunc",
-					MlflowURL:              "",
-					Endpoints:              nil,
-					ObservabilitySupported: false,
-				}, nil)
-				return svc
-			},
-			versionService: func() *mocks.VersionsService {
-				svc := &mocks.VersionsService{}
-				svc.On("FindByID", mock.Anything, models.ID(1), models.ID(1), mock.Anything).Return(&models.Version{
-					ID:      models.ID(1),
-					ModelID: models.ID(1),
-					Model: &models.Model{
-						ID:           models.ID(1),
-						Name:         "model-1",
-						ProjectID:    models.ID(1),
-						Project:      mlp.Project{},
-						ExperimentID: 1,
-						Type:         "pyfunc",
-						MlflowURL:    "",
-						Endpoints:    nil,
-					},
-				}, nil)
-				return svc
-			},
-			envService: func() *mocks.EnvironmentService {
-				svc := &mocks.EnvironmentService{}
-				svc.On("GetDefaultEnvironment").Return(&models.Environment{
-					ID:         models.ID(1),
-					Name:       "dev",
-					Cluster:    "dev",
-					IsDefault:  &trueBoolean,
-					Region:     "id",
-					GcpProject: "dev-proj",
-					MaxCPU:     "1",
-					MaxMemory:  "1Gi",
-				}, nil)
-				svc.On("GetEnvironment", "dev").Return(&models.Environment{
-					ID:         models.ID(1),
-					Name:       "dev",
-					Cluster:    "dev",
-					IsDefault:  &trueBoolean,
-					Region:     "id",
-					GcpProject: "dev-proj",
-					MaxCPU:     "1",
-					MaxMemory:  "1Gi",
-				}, nil)
-				return svc
-			},
-			endpointService: func() *mocks.EndpointsService {
-				svc := &mocks.EndpointsService{}
-				svc.On("CountEndpoints", context.Background(), mock.Anything, mock.Anything).Return(0, nil)
-				return svc
-			},
-			monitoringConfig: config.MonitoringConfig{},
-			feastCoreMock: func() *feastmocks.CoreServiceClient {
-				return &feastmocks.CoreServiceClient{}
-			},
-			expected: &Response{
-				code: http.StatusBadRequest,
-				data: Error{Message: "Request validation failed: model observability is not supported for this model"},
 			},
 		},
 		{
@@ -4004,7 +3907,9 @@ func TestUpdateEndpoint(t *testing.T) {
 						Value: "1",
 					},
 				}),
-				EnableModelObservability: true,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 			modelService: func() *mocks.ModelsService {
 				svc := &mocks.ModelsService{}
@@ -4083,7 +3988,9 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					EnableModelObservability: false,
+					ModelObservability: &models.ModelObservability{
+						Enabled: false,
+					},
 				}, nil)
 				svc.On("DeployEndpoint", context.Background(), mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&models.VersionEndpoint{
 					ID:                   uuid,
@@ -4114,8 +4021,10 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					CreatedUpdated:           models.CreatedUpdated{},
-					EnableModelObservability: true,
+					CreatedUpdated: models.CreatedUpdated{},
+					ModelObservability: &models.ModelObservability{
+						Enabled: true,
+					},
 				}, nil)
 				return svc
 			},
@@ -4150,8 +4059,10 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					CreatedUpdated:           models.CreatedUpdated{},
-					EnableModelObservability: true,
+					CreatedUpdated: models.CreatedUpdated{},
+					ModelObservability: &models.ModelObservability{
+						Enabled: true,
+					},
 				},
 			},
 		},
@@ -4696,7 +4607,9 @@ func TestUpdateEndpoint(t *testing.T) {
 						Value: "1",
 					},
 				}),
-				EnableModelObservability: true,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 			modelService: func() *mocks.ModelsService {
 				svc := &mocks.ModelsService{}
@@ -4775,7 +4688,9 @@ func TestUpdateEndpoint(t *testing.T) {
 							Value: "1",
 						},
 					}),
-					EnableModelObservability: false,
+					ModelObservability: &models.ModelObservability{
+						Enabled: false,
+					},
 				}, nil)
 				return svc
 			},

--- a/api/models/model_endpoint.go
+++ b/api/models/model_endpoint.go
@@ -38,6 +38,10 @@ type ModelEndpoint struct {
 }
 
 func (me *ModelEndpoint) GetVersionEndpoint() *VersionEndpoint {
+	if me == nil {
+		return nil
+	}
+
 	if me.Rule == nil || len(me.Rule.Destination) == 0 {
 		return nil
 	}

--- a/api/models/model_observability.go
+++ b/api/models/model_observability.go
@@ -16,6 +16,14 @@ type ModelObservability struct {
 	PredictionLogIngestionResourceRequest *WorkerResourceRequest `json:"prediction_log_ingestion_resource_request"`
 }
 
+func (mo *ModelObservability) IsEnabled() bool {
+	if mo == nil {
+		return false
+	}
+
+	return mo.Enabled
+}
+
 // GroundTruthSource represents the source configuration for ground truth data.
 type GroundTruthSource struct {
 	TableURN             string `json:"table_urn"`

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -181,6 +181,21 @@ func (ve *VersionEndpoint) ParsedURL() (*url.URL, error) {
 	return parsedURL, nil
 }
 
+// [TODO]: deprecate this after deprecating VersionEndpoint.EnableModelObservability
+func (ve *VersionEndpoint) SetModelObservabilityEnabledWithEnableModelObservabilityIfNil() {
+	if ve == nil {
+		return
+	}
+
+	if ve.ModelObservability != nil {
+		return
+	}
+
+	ve.ModelObservability = &ModelObservability{
+		Enabled: ve.EnableModelObservability,
+	}
+}
+
 type EndpointMonitoringURLParams struct {
 	Cluster      string
 	Project      string

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -134,6 +134,10 @@ func (ve *VersionEndpoint) IsServing() bool {
 }
 
 func (ve *VersionEndpoint) IsModelMonitoringEnabled() bool {
+	if ve == nil {
+		return false
+	}
+
 	return ve.ModelObservability.IsEnabled()
 }
 

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -134,10 +134,7 @@ func (ve *VersionEndpoint) IsServing() bool {
 }
 
 func (ve *VersionEndpoint) IsModelMonitoringEnabled() bool {
-	if ve.ModelObservability == nil {
-		return ve.EnableModelObservability
-	}
-	return ve.ModelObservability.Enabled
+	return ve.ModelObservability.IsEnabled()
 }
 
 func (ve *VersionEndpoint) Hostname() string {

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -137,7 +137,6 @@ func (ve *VersionEndpoint) IsModelMonitoringEnabled() bool {
 	if ve == nil {
 		return false
 	}
-
 	return ve.ModelObservability.IsEnabled()
 }
 
@@ -194,11 +193,9 @@ func (ve *VersionEndpoint) SetModeObservabilityIfNil() {
 	if ve == nil {
 		return
 	}
-
 	if ve.ModelObservability != nil {
 		return
 	}
-
 	ve.ModelObservability = &ModelObservability{
 		Enabled: ve.EnableModelObservability,
 	}

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -186,7 +186,11 @@ func (ve *VersionEndpoint) ParsedURL() (*url.URL, error) {
 }
 
 // [TODO]: deprecate this after deprecating VersionEndpoint.EnableModelObservability
-func (ve *VersionEndpoint) SetModelObservabilityEnabledWithEnableModelObservabilityIfNil() {
+// perviously we only have VersionEndpoint.EnableModelObservability and now we want to deprecate it
+// and only read/write to VersionEndpoint.ModelObservability instead. to allow backward compatibility if the user
+// only set VersionEndpoint.EnableModelObservability but not VersionEndpoint.ModelObservability we will use the
+// VersionEndpoint.EnableModelObservability value as VersionEndpoint.ModelObservability.EnableModelObservability
+func (ve *VersionEndpoint) SetModeObservabilityIfNil() {
 	if ve == nil {
 		return
 	}

--- a/api/models/version_endpoint_test.go
+++ b/api/models/version_endpoint_test.go
@@ -244,38 +244,20 @@ func TestVersionEndpoint_IsModelMonitoringEnabled(t *testing.T) {
 		want            bool
 	}{
 		{
-			name: "model observability is nil but enable model observability is true",
-			versionEndpoint: &VersionEndpoint{
-				ModelObservability:       nil,
-				EnableModelObservability: true,
-			},
-			want: true,
-		},
-		{
-			name: "model observability is nil and enable model observability is false",
-			versionEndpoint: &VersionEndpoint{
-				ModelObservability:       nil,
-				EnableModelObservability: false,
-			},
-			want: false,
-		},
-		{
-			name: "model observability is not nil and enabled is true",
+			name: "model observability enabled is true",
 			versionEndpoint: &VersionEndpoint{
 				ModelObservability: &ModelObservability{
 					Enabled: true,
 				},
-				EnableModelObservability: true,
 			},
 			want: true,
 		},
 		{
-			name: "model observability is not nil and enabled is false",
+			name: "model observability enabled is false",
 			versionEndpoint: &VersionEndpoint{
 				ModelObservability: &ModelObservability{
 					Enabled: false,
 				},
-				EnableModelObservability: false,
 			},
 			want: false,
 		},

--- a/api/pkg/observability/event/event.go
+++ b/api/pkg/observability/event/event.go
@@ -34,12 +34,6 @@ func NewEventProducer(jobProducer queue.Producer, observabilityPublisherStorage 
 }
 
 func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndpoint, model *models.Model) error {
-	versionEndpoint := modelEndpoint.GetVersionEndpoint()
-
-	if !versionEndpoint.ModelObservability.IsEnabled() {
-		return nil
-	}
-
 	ctx := context.Background()
 	publisher, err := e.observabilityPublisherStorage.GetByModelID(ctx, model.ID)
 	if err != nil {
@@ -70,6 +64,7 @@ func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndp
 		return e.enqueueJob(version, model, publisher, models.UndeployPublisher, nil)
 	}
 
+	versionEndpoint := modelEndpoint.GetVersionEndpoint()
 	version, err := e.findVersionWithModelSchema(ctx, versionEndpoint.VersionID, model.ID)
 	if err != nil {
 		return err

--- a/api/pkg/observability/event/event.go
+++ b/api/pkg/observability/event/event.go
@@ -34,6 +34,11 @@ func NewEventProducer(jobProducer queue.Producer, observabilityPublisherStorage 
 }
 
 func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndpoint, model *models.Model) error {
+	versionEndpoint := modelEndpoint.GetVersionEndpoint()
+	if versionEndpoint == nil || !versionEndpoint.IsModelMonitoringEnabled() {
+		return nil
+	}
+
 	ctx := context.Background()
 	publisher, err := e.observabilityPublisherStorage.GetByModelID(ctx, model.ID)
 	if err != nil {
@@ -64,7 +69,6 @@ func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndp
 		return e.enqueueJob(version, model, publisher, models.UndeployPublisher, nil)
 	}
 
-	versionEndpoint := modelEndpoint.GetVersionEndpoint()
 	version, err := e.findVersionWithModelSchema(ctx, versionEndpoint.VersionID, model.ID)
 	if err != nil {
 		return err

--- a/api/pkg/observability/event/event.go
+++ b/api/pkg/observability/event/event.go
@@ -34,11 +34,6 @@ func NewEventProducer(jobProducer queue.Producer, observabilityPublisherStorage 
 }
 
 func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndpoint, model *models.Model) error {
-	versionEndpoint := modelEndpoint.GetVersionEndpoint()
-	if versionEndpoint == nil || !versionEndpoint.IsModelMonitoringEnabled() {
-		return nil
-	}
-
 	ctx := context.Background()
 	publisher, err := e.observabilityPublisherStorage.GetByModelID(ctx, model.ID)
 	if err != nil {
@@ -67,6 +62,11 @@ func (e *eventProducer) ModelEndpointChangeEvent(modelEndpoint *models.ModelEndp
 		}
 
 		return e.enqueueJob(version, model, publisher, models.UndeployPublisher, nil)
+	}
+
+	versionEndpoint := modelEndpoint.GetVersionEndpoint()
+	if !versionEndpoint.IsModelMonitoringEnabled() {
+		return nil
 	}
 
 	version, err := e.findVersionWithModelSchema(ctx, versionEndpoint.VersionID, model.ID)

--- a/api/pkg/observability/event/event_test.go
+++ b/api/pkg/observability/event/event_test.go
@@ -76,43 +76,6 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 		expectedError                 error
 	}{
 		{
-			name: "do nothing if model doesn't support model observability",
-			jobProducer: func() *queueMock.Producer {
-				producer := &queueMock.Producer{}
-				return producer
-			}(),
-			observabilityPublisherStorage: func() *storageMock.ObservabilityPublisherStorage {
-				mockStorage := &storageMock.ObservabilityPublisherStorage{}
-				return mockStorage
-			}(),
-			versionStorage: func() *storageMock.VersionStorage {
-				mockStorage := &storageMock.VersionStorage{}
-				return mockStorage
-			}(),
-			model: &models.Model{
-				ID:                     models.ID(2),
-				ObservabilitySupported: false,
-			},
-			modelEndpoint: &models.ModelEndpoint{
-				ID:      models.ID(1),
-				ModelID: model.ID,
-				Model:   model,
-				Status:  models.EndpointServing,
-				Rule: &models.ModelEndpointRule{
-					Destination: []*models.ModelEndpointRuleDestination{
-						{
-							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(2),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: true,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "no deployment; version endpoint model observability is disabled and never been deployed before",
 			jobProducer: func() *queueMock.Producer {
 				producer := &queueMock.Producer{}
@@ -137,10 +100,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(2),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: false,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(2),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: false,
+								},
 							},
 						},
 					},
@@ -222,10 +187,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(2),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: true,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(2),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: true,
+								},
 							},
 						},
 					},
@@ -263,10 +230,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(3),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: true,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(3),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: true,
+								},
 							},
 						},
 					},
@@ -359,10 +328,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(3),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: true,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(3),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: true,
+								},
 							},
 						},
 					},
@@ -401,10 +372,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(4),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: true,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(4),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: true,
+								},
 							},
 						},
 					},
@@ -571,10 +544,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(2),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: false,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(2),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: false,
+								},
 							},
 						},
 					},
@@ -612,10 +587,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(3),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: false,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(3),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: false,
+								},
 							},
 						},
 					},
@@ -655,10 +632,12 @@ func Test_eventProducer_ModelEndpointChangeEvent(t *testing.T) {
 					Destination: []*models.ModelEndpointRuleDestination{
 						{
 							VersionEndpoint: &models.VersionEndpoint{
-								ID:                       uuid.UUID{},
-								VersionID:                models.ID(2),
-								Status:                   models.EndpointServing,
-								EnableModelObservability: false,
+								ID:        uuid.UUID{},
+								VersionID: models.ID(2),
+								Status:    models.EndpointServing,
+								ModelObservability: &models.ModelObservability{
+									Enabled: false,
+								},
 							},
 						},
 					},
@@ -741,16 +720,6 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 		expectedError                 error
 	}{
 		{
-			name:                          "do nothing if model not supported observability",
-			jobProducer:                   &queueMock.Producer{},
-			observabilityPublisherStorage: &storageMock.ObservabilityPublisherStorage{},
-			versionStorage:                &storageMock.VersionStorage{},
-			model: &models.Model{
-				ID:                     models.ID(1),
-				ObservabilitySupported: false,
-			},
-		},
-		{
 			name: "no deployment; version endpoint model observability is disabled and never been deployed before",
 			jobProducer: func() *queueMock.Producer {
 				producer := &queueMock.Producer{}
@@ -764,10 +733,12 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			versionStorage: &storageMock.VersionStorage{},
 			model:          model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(2),
-				Status:                   models.EndpointServing,
-				EnableModelObservability: false,
+				ID:        uuid.UUID{},
+				VersionID: models.ID(2),
+				Status:    models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: false,
+				},
 			},
 		},
 		{
@@ -837,11 +808,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(2),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: true,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(2),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 		},
 		{
@@ -867,11 +840,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(3),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: true,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(3),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 			expectedError: fmt.Errorf("versionID: 3 in modelID: 1 doesn't have model schema"),
 		},
@@ -952,11 +927,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(3),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: true,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(3),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: true,
+				},
 			},
 		},
 		{
@@ -1034,11 +1011,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(2),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: false,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(2),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: false,
+				},
 			},
 		},
 		{
@@ -1064,11 +1043,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(3),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: false,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(3),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: false,
+				},
 			},
 		},
 		{
@@ -1096,11 +1077,13 @@ func Test_eventProducer_VersionEndpointChangeEvent(t *testing.T) {
 			}(),
 			model: model,
 			versionEndpoint: &models.VersionEndpoint{
-				ID:                       uuid.UUID{},
-				VersionID:                models.ID(2),
-				VersionModelID:           model.ID,
-				Status:                   models.EndpointServing,
-				EnableModelObservability: false,
+				ID:             uuid.UUID{},
+				VersionID:      models.ID(2),
+				VersionModelID: model.ID,
+				Status:         models.EndpointServing,
+				ModelObservability: &models.ModelObservability{
+					Enabled: false,
+				},
 			},
 			expectedError: fmt.Errorf("connection error"),
 		},

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -86,7 +86,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 
 	// Need to reassign destionationURL because it is ignored when marshalled and unmarshalled
 	if endpoint.Logger != nil {
-		if model.ObservabilitySupported {
+		if endpoint.ModelObservability.IsEnabled() {
 			endpoint.Logger.DestinationURL = depl.MLObsLoggerDestinationURL
 		} else {
 			endpoint.Logger.DestinationURL = depl.LoggerDestinationURL
@@ -204,7 +204,7 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		log.Errorf("unable to update endpoint status for model: %s, version: %s, reason: %v", model.Name, version.ID, err)
 	}
 
-	if model.ObservabilitySupported {
+	if endpoint.ModelObservability.IsEnabled() {
 		if err := depl.ObservabilityEventProducer.VersionEndpointChangeEvent(endpoint, model); err != nil {
 			log.Errorf("error publishing event for observability deployment for model: %s, version: %s with error: %w", model.Name, version.ID, err)
 		}

--- a/api/queue/work/model_service_deployment.go
+++ b/api/queue/work/model_service_deployment.go
@@ -204,10 +204,8 @@ func (depl *ModelServiceDeployment) Deploy(job *queue.Job) error {
 		log.Errorf("unable to update endpoint status for model: %s, version: %s, reason: %v", model.Name, version.ID, err)
 	}
 
-	if endpoint.ModelObservability.IsEnabled() {
-		if err := depl.ObservabilityEventProducer.VersionEndpointChangeEvent(endpoint, model); err != nil {
-			log.Errorf("error publishing event for observability deployment for model: %s, version: %s with error: %w", model.Name, version.ID, err)
-		}
+	if err := depl.ObservabilityEventProducer.VersionEndpointChangeEvent(endpoint, model); err != nil {
+		log.Errorf("error publishing event for observability deployment for model: %s, version: %s with error: %w", model.Name, version.ID, err)
 	}
 
 	// trigger webhook call

--- a/api/queue/work/model_service_deployment_test.go
+++ b/api/queue/work/model_service_deployment_test.go
@@ -125,6 +125,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Default - Model Observability Supported",
@@ -240,6 +245,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success eventhough error when produce event",
@@ -363,6 +373,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Latest deployment entry in storage not in pending state",
@@ -420,6 +435,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Pytorch Model",
@@ -469,6 +489,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: empty pyfunc model",
@@ -520,6 +545,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: pytorch model with transformer",
@@ -571,6 +601,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Default With GPU",
@@ -634,6 +669,11 @@ func TestExecuteDeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:      "Failed: deployment failed",
@@ -675,6 +715,11 @@ func TestExecuteDeployment(t *testing.T) {
 			webhook: func() *webhookMock.Client {
 				return webhookMock.NewClient(t)
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:      "Failed: image builder failed",
@@ -715,6 +760,11 @@ func TestExecuteDeployment(t *testing.T) {
 			webhook: func() *webhookMock.Client {
 				return webhookMock.NewClient(t)
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 	}
 	for _, tt := range tests {
@@ -843,6 +893,7 @@ func TestExecuteRedeployment(t *testing.T) {
 		controller             func() *clusterMock.Controller
 		imageBuilder           func() *imageBuilderMock.ImageBuilder
 		webhook                func() *webhookMock.Client
+		eventProducer          *eventMock.EventProducer
 	}{
 		{
 			name:    "Success: Redeploy running endpoint",
@@ -920,6 +971,11 @@ func TestExecuteRedeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Redeploy serving endpoint",
@@ -997,6 +1053,11 @@ func TestExecuteRedeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:    "Success: Redeploy failed endpoint",
@@ -1074,6 +1135,11 @@ func TestExecuteRedeployment(t *testing.T) {
 				w.On("TriggerWebhooks", mock.Anything, webhook.OnVersionEndpointDeployed, mock.Anything).Return(nil)
 				return w
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 		{
 			name:      "Failed to redeploy running endpoint",
@@ -1139,6 +1205,11 @@ func TestExecuteRedeployment(t *testing.T) {
 			webhook: func() *webhookMock.Client {
 				return webhookMock.NewClient(t)
 			},
+			eventProducer: func() *eventMock.EventProducer {
+				eProducer := &eventMock.EventProducer{}
+				eProducer.On("VersionEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+				return eProducer
+			}(),
 		},
 	}
 	for _, tt := range tests {
@@ -1161,12 +1232,13 @@ func TestExecuteRedeployment(t *testing.T) {
 				},
 			}
 			svc := &ModelServiceDeployment{
-				ClusterControllers:   controllers,
-				ImageBuilder:         imgBuilder,
-				Storage:              mockStorage,
-				DeploymentStorage:    mockDeploymentStorage,
-				LoggerDestinationURL: loggerDestinationURL,
-				Webhook:              mockWebhook,
+				ClusterControllers:         controllers,
+				ImageBuilder:               imgBuilder,
+				Storage:                    mockStorage,
+				DeploymentStorage:          mockDeploymentStorage,
+				LoggerDestinationURL:       loggerDestinationURL,
+				Webhook:                    mockWebhook,
+				ObservabilityEventProducer: tt.eventProducer,
 			}
 
 			err := svc.Deploy(job)

--- a/api/service/model_endpoint_service.go
+++ b/api/service/model_endpoint_service.go
@@ -144,7 +144,6 @@ func (s *modelEndpointsService) DeployEndpoint(ctx context.Context, model *model
 	}
 
 	// publish model endpoint change event to trigger consumer deployment
-
 	if err := s.observabilityEventProducer.ModelEndpointChangeEvent(endpoint, model); err != nil {
 		return nil, err
 	}

--- a/api/service/model_endpoint_service.go
+++ b/api/service/model_endpoint_service.go
@@ -144,10 +144,9 @@ func (s *modelEndpointsService) DeployEndpoint(ctx context.Context, model *model
 	}
 
 	// publish model endpoint change event to trigger consumer deployment
-	if model.ObservabilitySupported {
-		if err := s.observabilityEventProducer.ModelEndpointChangeEvent(endpoint, model); err != nil {
-			return nil, err
-		}
+
+	if err := s.observabilityEventProducer.ModelEndpointChangeEvent(endpoint, model); err != nil {
+		return nil, err
 	}
 
 	return endpoint, nil
@@ -195,10 +194,8 @@ func (s *modelEndpointsService) UpdateEndpoint(ctx context.Context, model *model
 	}
 
 	// publish model endpoint change event to trigger consumer deployment
-	if model.ObservabilitySupported {
-		if err := s.observabilityEventProducer.ModelEndpointChangeEvent(newEndpoint, model); err != nil {
-			return nil, err
-		}
+	if err := s.observabilityEventProducer.ModelEndpointChangeEvent(newEndpoint, model); err != nil {
+		return nil, err
 	}
 
 	return newEndpoint, nil
@@ -226,10 +223,8 @@ func (s *modelEndpointsService) UndeployEndpoint(ctx context.Context, model *mod
 	}
 
 	// publish model endpoint change event to trigger consumer undeployment
-	if model.ObservabilitySupported {
-		if err := s.observabilityEventProducer.ModelEndpointChangeEvent(nil, model); err != nil {
-			return nil, err
-		}
+	if err := s.observabilityEventProducer.ModelEndpointChangeEvent(nil, model); err != nil {
+		return nil, err
 	}
 
 	return endpoint, nil

--- a/api/service/model_endpoint_service_test.go
+++ b/api/service/model_endpoint_service_test.go
@@ -282,6 +282,11 @@ func Test_modelEndpointsService_UpdateEndpoint(t *testing.T) {
 				modelEndpointStorage:   &storageMock.ModelEndpointStorage{},
 				versionEndpointStorage: &storageMock.VersionEndpointStorage{},
 				environment:            testEnvironmentName,
+				observabilityEventProducer: func() event.EventProducer {
+					eProducer := &eventMock.EventProducer{}
+					eProducer.On("ModelEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+					return eProducer
+				}(),
 			},
 			mockFunc: func(s *modelEndpointsService) {
 				vs, _ := s.createVirtualService(model1, updatedModelEndpointReq)
@@ -311,6 +316,11 @@ func Test_modelEndpointsService_UpdateEndpoint(t *testing.T) {
 				modelEndpointStorage:   &storageMock.ModelEndpointStorage{},
 				versionEndpointStorage: &storageMock.VersionEndpointStorage{},
 				environment:            "staging",
+				observabilityEventProducer: func() event.EventProducer {
+					eProducer := &eventMock.EventProducer{}
+					eProducer.On("ModelEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+					return eProducer
+				}(),
 			},
 			mockFunc: func(s *modelEndpointsService) {
 				vs, _ := s.createVirtualService(model1, updatedUpiV1ModelEndpointReq)
@@ -340,6 +350,11 @@ func Test_modelEndpointsService_UpdateEndpoint(t *testing.T) {
 				modelEndpointStorage:   &storageMock.ModelEndpointStorage{},
 				versionEndpointStorage: &storageMock.VersionEndpointStorage{},
 				environment:            testEnvironmentName,
+				observabilityEventProducer: func() event.EventProducer {
+					eProducer := &eventMock.EventProducer{}
+					eProducer.On("ModelEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+					return eProducer
+				}(),
 			},
 			func(s *modelEndpointsService) {
 				vs, _ := s.createVirtualService(model1, modelEndpointRequestWrongEnvironment)
@@ -410,6 +425,11 @@ func Test_modelEndpointsService_UndeployEndpoint(t *testing.T) {
 				modelEndpointStorage:   &storageMock.ModelEndpointStorage{},
 				versionEndpointStorage: &storageMock.VersionEndpointStorage{},
 				environment:            testEnvironmentName,
+				observabilityEventProducer: func() event.EventProducer {
+					eProducer := &eventMock.EventProducer{}
+					eProducer.On("ModelEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+					return eProducer
+				}(),
 			},
 			mockFunc: func(s *modelEndpointsService) {
 				mockIstio := s.istioClients[env.Name].(*istioCliMock.Client)

--- a/api/service/model_endpoint_service_test.go
+++ b/api/service/model_endpoint_service_test.go
@@ -104,6 +104,11 @@ func Test_modelEndpointsService_DeployEndpoint(t *testing.T) {
 				modelEndpointStorage:   &storageMock.ModelEndpointStorage{},
 				versionEndpointStorage: &storageMock.VersionEndpointStorage{},
 				environment:            "staging",
+				eventProducer: func() event.EventProducer {
+					eProducer := &eventMock.EventProducer{}
+					eProducer.On("ModelEndpointChangeEvent", mock.Anything, mock.Anything).Return(nil)
+					return eProducer
+				}(),
 			},
 			mockFunc: func(s *modelEndpointsService) {
 				vs, _ := s.createVirtualService(upiV1Model, upiV1ModelEndpointRequest1)

--- a/api/service/version_endpoint_service.go
+++ b/api/service/version_endpoint_service.go
@@ -262,10 +262,10 @@ func (k *endpointService) override(left *models.VersionEndpoint, right *models.V
 		left.Protocol = protocol.HttpJson
 	}
 
-	left.EnableModelObservability = right.EnableModelObservability && model.ObservabilitySupported
+	left.EnableModelObservability = right.EnableModelObservability
 	if right.ModelObservability != nil {
 		left.ModelObservability = right.ModelObservability
-		left.ModelObservability.Enabled = right.ModelObservability.Enabled && model.ObservabilitySupported
+		left.ModelObservability.Enabled = right.ModelObservability.Enabled
 	}
 	// for older sdk
 	if left.EnableModelObservability && right.ModelObservability == nil {


### PR DESCRIPTION
# Description
- deprecate `Model.ObservabilitySupported`
- use `VersionEndpoint.ModelObservability.Enabled` as SSOT for MLObs configuration

# Modifications
- remove the use of `Model.ObservabilitySupported`
- use `VersionEndpoint.EnableModelObservability` value as `VersionEndpoint.ModelObservability.Enabled` if `VersionEndpoint.ModelObservability` is not set
- remove unit test with `Model.ObservabilitySupported` logic
- adjust unit test mock call

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes