### PR TITLE
draft: Cicd/sdk versioning improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ Temporary Items
 bin/
 
 .vscode/
+
+# SED command backups / residue
+*-e

--- a/python/Makefile
+++ b/python/Makefile
@@ -5,14 +5,10 @@ observation-publisher:
 	@echo "Building image for observation publisher..."
 	@docker build -t ${OBSERVATION_PUBLISHER_IMAGE_TAG} -f observation-publisher/Dockerfile --progress plain .
 
-SDK_VER = $(subst v,,$(SDK_VERSION))
+VER = $(subst v,,$(VERSION))
 
-.PHONY: upgrade-sdk-version
-upgrade-sdk-version:
-	python -m pip install --upgrade pip
-	pip install setuptools setuptools_scm twine wheel
-	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./batch-predictor/requirements.txt
-	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./pyfunc-server/requirements.txt
-	cd sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"$(SDK_VER)\"|g" ./merlin/version.py
-	cd sdk && python setup.py sdist bdist_wheel
-	pip install sdk/dist/merlin_sdk-$(SDK_VER)-py3-none-any.whl
+# to update merlin-sdk version in packages that depend on it
+.PHONY: update-sdk-version
+update-sdk-version:
+	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(VER)|g" ./batch-predictor/requirements.txt
+	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(VER)|g" ./pyfunc-server/requirements.txt

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,3 +4,16 @@ OBSERVATION_PUBLISHER_IMAGE_TAG ?= observation-publisher:dev
 observation-publisher:
 	@echo "Building image for observation publisher..."
 	@docker build -t ${OBSERVATION_PUBLISHER_IMAGE_TAG} -f observation-publisher/Dockerfile --progress plain .
+
+SDK_VER = $(subst v,,$(SDK_VERSION))
+
+.PHONY: upgrade-sdk-version
+upgrade-sdk-version:
+	python -m pip install --upgrade pip
+	pip install setuptools setuptools_scm twine wheel
+	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./batch-predictor/requirements.txt
+	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./pyfunc-server/requirements.txt
+	cd sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"$(SDK_VER)\"|g" ./merlin/version.py
+	cd sdk && pip install setuptools wheel twine
+	cd sdk && python setup.py sdist bdist_wheel
+	pip install sdk/dist/merlin_sdk-$(SDK_VER)-py3-none-any.whl

--- a/python/Makefile
+++ b/python/Makefile
@@ -14,6 +14,5 @@ upgrade-sdk-version:
 	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./batch-predictor/requirements.txt
 	sed -i -e "s|merlin-sdk.*|merlin-sdk==$(SDK_VER)|g" ./pyfunc-server/requirements.txt
 	cd sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"$(SDK_VER)\"|g" ./merlin/version.py
-	cd sdk && pip install setuptools wheel twine
 	cd sdk && python setup.py sdist bdist_wheel
 	pip install sdk/dist/merlin_sdk-$(SDK_VER)-py3-none-any.whl

--- a/python/batch-predictor/Makefile
+++ b/python/batch-predictor/Makefile
@@ -8,17 +8,9 @@ PROTOC_PATH ?= protoc  # Default to 'protoc' if PROTOC_PATH is not set
 
 .PHONY: setup
 setup:
+	$(MAKE) install_sdk
 	@pip install pipenv
 	@pipenv install --skip-lock -e .[test]
-
-SDK_VER = $(subst v,,$(SDK_VERSION))
-
-.PHONY: build-install-sdk
-build-install-sdk:
-	cd ../sdk && pip install setuptools setuptools_scm twine wheel
-	cd ../sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"$(SDK_VER)\"|g" ./merlin/version.py
-	cd ../sdk && python setup.py sdist bdist_wheel
-	pip install ../sdk/dist/merlin_sdk-$(SDK_VER)-py3-none-any.whl
 
 .PHONY: type_check
 type_check:
@@ -46,3 +38,21 @@ proto:
 	fi
 	go install github.com/mitchellh/protoc-gen-go-json@${PROTOC_GEN_GO_JSON_VERSION}
 	@$(PROTOC_PATH) -I=. --python_out=merlinpyspark --mypy_out=merlinpyspark --go_out=pkg/ --go-json_out=pkg/ --go_opt=paths=source_relative spec/*.proto
+
+
+.PHONY: depp build_install_sdk
+
+SDK_VER := $(shell grep '^merlin-sdk' requirements.txt | awk -F '[=<>]+' '{print $$2}')
+# check if installation of merlin-sdk  from pypi is succesful, if not build from local (latest / unreleased version)
+install_sdk:
+	@if pip install merlin-sdk==${SDK_VER}; then \
+		echo "Installation successful!"; \
+	else \
+		$(MAKE) build_install_sdk; \
+	fi
+
+build_install_sdk:
+	cd ../sdk && pip install setuptools setuptools_scm twine wheel
+	cd ../sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"${SDK_VER}\"|g" ./merlin/version.py
+	cd ../sdk && python setup.py sdist bdist_wheel
+	pip install ../sdk/dist/merlin_sdk-${SDK_VER}-py3-none-any.whl

--- a/python/batch-predictor/Makefile
+++ b/python/batch-predictor/Makefile
@@ -4,9 +4,21 @@ PROTOC_GEN_GO_JSON_VERSION="v1.1.0"
 PROTOC_GEN_GO_VERSION="v1.26"
 PROTOC_PATH ?= protoc  # Default to 'protoc' if PROTOC_PATH is not set
 
+# @pip install pipenv==2023.7.23
+
 .PHONY: setup
 setup:
+	@pip install pipenv
 	@pipenv install --skip-lock -e .[test]
+
+SDK_VER = $(subst v,,$(SDK_VERSION))
+
+.PHONY: build-install-sdk
+build-install-sdk:
+	cd ../sdk && pip install setuptools setuptools_scm twine wheel
+	cd ../sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"$(SDK_VER)\"|g" ./merlin/version.py
+	cd ../sdk && python setup.py sdist bdist_wheel
+	pip install ../sdk/dist/merlin_sdk-$(SDK_VER)-py3-none-any.whl
 
 .PHONY: type_check
 type_check:

--- a/python/batch-predictor/Pipfile
+++ b/python/batch-predictor/Pipfile
@@ -7,4 +7,4 @@ verify_ssl = true
 merlin-batch-predictor = {editable = true,extras = ["test"],path = "."}
 
 [packages]
-merlin-batch-predictor = {editable = true, extras = ["test"], path = "."}
+merlin-batch-predictor = {extras = ["test"], file = ".", editable = true}

--- a/python/batch-predictor/requirements.txt
+++ b/python/batch-predictor/requirements.txt
@@ -1,6 +1,6 @@
 cloudpickle==2.0.0
 findspark==2.0.1
-merlin-sdk==0.46.0
+merlin-sdk==0.47.1rc1
 mlflow==1.26.1
 pyarrow>=0.14.1,<=17.0.0
 pyspark==3.1.3

--- a/python/pyfunc-server/Makefile
+++ b/python/pyfunc-server/Makefile
@@ -1,10 +1,8 @@
-
-.PHONY: dev_install
-dev_install:
-	pipenv install --skip-lock -e .[test] --verbose
-
 .PHONY: setup
-setup: dev_install
+setup:
+	$(MAKE) install_sdk
+	pip install pipenv
+	pipenv install --skip-lock -e .[test]
 
 .PHONY: test
 test: type_check
@@ -17,3 +15,20 @@ type_check:
 .PHONY: benchmark
 benchmark:
 	cd benchmark && ./benchmark.sh
+
+.PHONY: depp build_install_sdk
+
+SDK_VER := $(shell grep '^merlin-sdk' requirements.txt | awk -F '[=<>]+' '{print $$2}')
+# check if installation of merlin-sdk  from pypi is succesful, if not build from local (latest / unreleased version)
+install_sdk:
+	@if pip install merlin-sdk==${SDK_VER}; then \
+		echo "Installation successful!"; \
+	else \
+		$(MAKE) build_install_sdk; \
+	fi
+
+build_install_sdk:
+	cd ../sdk && pip install setuptools setuptools_scm twine wheel
+	cd ../sdk && sed -i -e "s|VERSION = \".*\"|VERSION = \"${SDK_VER}\"|g" ./merlin/version.py
+	cd ../sdk && python setup.py sdist bdist_wheel
+	pip install ../sdk/dist/merlin_sdk-${SDK_VER}-py3-none-any.whl

--- a/python/pyfunc-server/Pipfile
+++ b/python/pyfunc-server/Pipfile
@@ -5,3 +5,6 @@ verify_ssl = true
 
 [packages]
 pyfuncserver = {editable = true, extras = ["test"], path = "."}
+merlin-pyfunc-server = {extras = ["test"], file = ".", editable = true}
+
+[dev-packages]

--- a/python/pyfunc-server/requirements.txt
+++ b/python/pyfunc-server/requirements.txt
@@ -4,7 +4,7 @@ cloudpickle==2.0.0
 confluent-kafka==2.3.0
 grpcio-health-checking
 grpcio-reflection
-merlin-sdk==0.45.1
+merlin-sdk==0.47.1rc1
 numpy>=1.8.2
 orjson>=2.6.8
 prometheus-client

--- a/python/sdk/merlin/version.py
+++ b/python/sdk/merlin/version.py
@@ -12,4 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To be overriden with tag version by Github Actions pipeline
 VERSION = "0.0.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
- Background: we want to use latest merlin-sdk on batch-predictor and pyfunc-server. Previously we cannot do that because these packages relies on merlin-sdk versions that have been uploaded to PyPI. The idea is making the development and pipeline smoother by enabling these packages to install merlin-sdk from local source if the version is not yet available on pypi.

# Modifications
- Added `make update-sdk-version VERSION=1.2.3` at `python/` directory to update all merlin-sdk version to all dependent packages.
- Added conditional handling on `make setup` command in `batch-predictor` and `pyfunc-server` package. When installing `merlin-sdk`, if not found on pypi then build merlin-sdk locally and then install.

# Tests
- Test github actions pipelines if it's working correctly.

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

