### PR TITLE
disallow undeploy and redeploy of version endpoint in pending deployment 

### DIFF
--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -205,10 +205,6 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 		return InternalServerError(fmt.Sprintf("Error getting endpoint: %v", err))
 	}
 
-	if endpoint.IsPending() {
-		return BadRequest(fmt.Sprintf("Version Endpoint %s is still pending and cannot be redeployed", endpointID))
-	}
-
 	newEndpoint, ok := body.(*models.VersionEndpoint)
 	if !ok {
 		return BadRequest("Unable to parse body as version endpoint resource")

--- a/api/api/version_endpoints_api.go
+++ b/api/api/version_endpoints_api.go
@@ -205,6 +205,10 @@ func (c *EndpointsController) UpdateEndpoint(r *http.Request, vars map[string]st
 		return InternalServerError(fmt.Sprintf("Error getting endpoint: %v", err))
 	}
 
+	if endpoint.IsPending() {
+		return BadRequest(fmt.Sprintf("Version Endpoint %s is still pending and cannot be redeployed", endpointID))
+	}
+
 	newEndpoint, ok := body.(*models.VersionEndpoint)
 	if !ok {
 		return BadRequest("Unable to parse body as version endpoint resource")
@@ -311,6 +315,10 @@ func (c *EndpointsController) DeleteEndpoint(r *http.Request, vars map[string]st
 
 	if endpoint.IsServing() {
 		return BadRequest(fmt.Sprintf("Version Endpoints %s is still serving traffic. Please route the traffic to another model version first", rawEndpointID))
+	}
+
+	if endpoint.IsPending() {
+		return BadRequest(fmt.Sprintf("Version Endpoint %s is still pending and cannot be undeployed", rawEndpointID))
 	}
 
 	_, err = c.EndpointsService.UndeployEndpoint(ctx, env, model, version, endpoint)

--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -3899,8 +3899,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4075,8 +4075,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4303,8 +4303,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4416,8 +4416,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4539,8 +4539,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4652,8 +4652,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4767,8 +4767,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4872,8 +4872,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4985,8 +4985,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5162,8 +5162,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5337,8 +5337,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5482,8 +5482,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5660,8 +5660,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5775,8 +5775,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5890,8 +5890,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6004,8 +6004,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6203,8 +6203,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6490,8 +6490,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6581,8 +6581,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6703,8 +6703,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6825,8 +6825,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:            "",
-					ResourceRequest:    nil,
+					Message:         "",
+					ResourceRequest: nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",

--- a/api/api/version_endpoints_api_test.go
+++ b/api/api/version_endpoints_api_test.go
@@ -3899,8 +3899,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4075,8 +4075,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4303,8 +4303,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4416,8 +4416,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4539,8 +4539,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4652,8 +4652,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4767,8 +4767,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4872,8 +4872,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -4985,8 +4985,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5162,8 +5162,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5337,8 +5337,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5482,8 +5482,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5660,8 +5660,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5775,8 +5775,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -5890,8 +5890,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6004,8 +6004,8 @@ func TestUpdateEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6203,8 +6203,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6490,8 +6490,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6581,8 +6581,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",
@@ -6626,6 +6626,128 @@ func TestDeleteEndpoint(t *testing.T) {
 			expected: &Response{
 				code: http.StatusBadRequest,
 				data: Error{Message: fmt.Sprintf("Version Endpoints %s is still serving traffic. Please route the traffic to another model version first", uuid)},
+			},
+		},
+		{
+			desc: "Should return 400 if endpoint is currently pending",
+			vars: map[string]string{
+				"model_id":    "1",
+				"version_id":  "1",
+				"endpoint_id": uuid.String(),
+			},
+			modelService: func() *mocks.ModelsService {
+				svc := &mocks.ModelsService{}
+				svc.On("FindByID", context.Background(), models.ID(1)).Return(&models.Model{
+					ID:           models.ID(1),
+					Name:         "model-1",
+					ProjectID:    models.ID(1),
+					Project:      mlp.Project{},
+					ExperimentID: 1,
+					Type:         "pyfunc",
+					MlflowURL:    "",
+					Endpoints:    nil,
+				}, nil)
+				return svc
+			},
+			versionService: func() *mocks.VersionsService {
+				svc := &mocks.VersionsService{}
+				svc.On("FindByID", context.Background(), models.ID(1), models.ID(1), mock.Anything).Return(&models.Version{
+					ID:      models.ID(1),
+					ModelID: models.ID(1),
+					Model: &models.Model{
+						ID:           models.ID(1),
+						Name:         "model-1",
+						ProjectID:    models.ID(1),
+						Project:      mlp.Project{},
+						ExperimentID: 1,
+						Type:         "pyfunc",
+						MlflowURL:    "",
+						Endpoints:    nil,
+					},
+				}, nil)
+				return svc
+			},
+			envService: func() *mocks.EnvironmentService {
+				svc := &mocks.EnvironmentService{}
+				svc.On("GetEnvironment", "dev").Return(&models.Environment{
+					ID:         models.ID(1),
+					Name:       "dev",
+					Cluster:    "dev",
+					IsDefault:  &trueBoolean,
+					Region:     "id",
+					GcpProject: "dev-proj",
+					MaxCPU:     "1",
+					MaxMemory:  "1Gi",
+				}, nil)
+				return svc
+			},
+			endpointService: func() *mocks.EndpointsService {
+				svc := &mocks.EndpointsService{}
+				svc.On("FindByID", context.Background(), uuid).Return(&models.VersionEndpoint{
+					ID:                   uuid,
+					VersionID:            models.ID(1),
+					VersionModelID:       models.ID(1),
+					Status:               models.EndpointPending,
+					ServiceName:          "sample",
+					InferenceServiceName: "sample",
+					Namespace:            "sample",
+					URL:                  "http://endpoint.svc",
+					MonitoringURL:        "http://monitoring.com",
+					Environment: &models.Environment{
+						ID:         models.ID(1),
+						Name:       "dev",
+						Cluster:    "dev",
+						IsDefault:  &trueBoolean,
+						Region:     "id",
+						GcpProject: "dev-proj",
+						MaxCPU:     "1",
+						MaxMemory:  "1Gi",
+					}, EnvironmentName: "dev",
+					Message:            "",
+					ResourceRequest:    nil,
+					EnvVars: models.EnvVars([]models.EnvVar{
+						{
+							Name:  "WORKER",
+							Value: "1",
+						},
+					}),
+				}, nil)
+				svc.On("UndeployEndpoint", context.Background(), mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&models.VersionEndpoint{
+					ID:                   uuid,
+					VersionID:            models.ID(1),
+					VersionModelID:       models.ID(1),
+					Status:               models.EndpointTerminated,
+					URL:                  "http://endpoint.svc",
+					ServiceName:          "sample",
+					InferenceServiceName: "sample",
+					Namespace:            "sample",
+					MonitoringURL:        "http://monitoring.com",
+					Environment: &models.Environment{
+						ID:         models.ID(1),
+						Name:       "dev",
+						Cluster:    "dev",
+						IsDefault:  &trueBoolean,
+						Region:     "id",
+						GcpProject: "dev-proj",
+						MaxCPU:     "1",
+						MaxMemory:  "1Gi",
+					},
+					EnvironmentName: "dev",
+					Message:         "",
+					ResourceRequest: nil,
+					EnvVars: models.EnvVars([]models.EnvVar{
+						{
+							Name:  "WORKER",
+							Value: "1",
+						},
+					}),
+					CreatedUpdated: models.CreatedUpdated{},
+				}, nil)
+				return svc
+			},
+			expected: &Response{
+				code: http.StatusBadRequest,
+				data: Error{Message: fmt.Sprintf("Version Endpoint %s is still pending and cannot be undeployed", uuid)},
 			},
 		},
 		{
@@ -6703,8 +6825,8 @@ func TestDeleteEndpoint(t *testing.T) {
 						MaxCPU:     "1",
 						MaxMemory:  "1Gi",
 					}, EnvironmentName: "dev",
-					Message:         "",
-					ResourceRequest: nil,
+					Message:            "",
+					ResourceRequest:    nil,
 					EnvVars: models.EnvVars([]models.EnvVar{
 						{
 							Name:  "WORKER",

--- a/api/models/version_endpoint.go
+++ b/api/models/version_endpoint.go
@@ -133,6 +133,10 @@ func (ve *VersionEndpoint) IsServing() bool {
 	return ve.Status == EndpointServing
 }
 
+func (ve *VersionEndpoint) IsPending() bool {
+	return ve.Status == EndpointPending
+}
+
 func (ve *VersionEndpoint) IsModelMonitoringEnabled() bool {
 	if ve.ModelObservability == nil {
 		return ve.EnableModelObservability


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!


-->
# Description
Right now, the model version endpoints in pending state is not allowed to be redeployed/undeployed from UI. But the same is possible via sdk
The change disallow the undeploy and redeploy of version endpoint in pending deployment state


# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

Tested by using an endpoint in pending and the undeploy and redeploy were blocked as expected

➜  ✗ curl localhost:8080/v1/models/411/versions/2/endpoint/4308d895-541d-40e7-b0f8-4e0d7c3ac669 -X PUT   
{"error":"Version Endpoint 4308d895-541d-40e7-b0f8-4e0d7c3ac669 is still pending and cannot be redeployed"}
➜  ✗ curl localhost:8080/v1/models/411/versions/2/endpoint/4308d895-541d-40e7-b0f8-4e0d7c3ac669 -X DELETE
{"error":"Version Endpoint 4308d895-541d-40e7-b0f8-4e0d7c3ac669 is still pending and cannot be undeployed"}
➜ 
