### PR TITLE
feat: add extra config option for kafka

### DIFF
--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -33,14 +33,14 @@ import (
 )
 
 var (
-	logUrl                = flag.String("log-url", "localhost:8002", "The URL to send request/response logs to")
-	additionalKafkaConfig = flag.String("kafka-config-extra", "", "Additional Kafka configuration. This should be path to a file containing the configuration")
-	port                  = flag.String("port", "9081", "Logger port")
-	componentPort         = flag.String("component-port", "8080", "Component port")
-	workers               = flag.Int("workers", 5, "Number of workers")
-	logMode               = flag.String("log-mode", string(merlinlogger.LogModeAll), "Whether to log 'request', 'response' or 'all'")
-	inferenceService      = flag.String("inference-service", "my-model-1", "The InferenceService name to add as header to log events")
-	namespace             = flag.String("namespace", "my-project", "The namespace to add as header to log events")
+	logUrl           = flag.String("log-url", "localhost:8002", "The URL to send request/response logs to")
+	kafkaConfigPath  = flag.String("kafka-config-path", "", "Additional Kafka configuration. This should be path to a file containing the configuration")
+	port             = flag.String("port", "9081", "Logger port")
+	componentPort    = flag.String("component-port", "8080", "Component port")
+	workers          = flag.Int("workers", 5, "Number of workers")
+	logMode          = flag.String("log-mode", string(merlinlogger.LogModeAll), "Whether to log 'request', 'response' or 'all'")
+	inferenceService = flag.String("inference-service", "my-model-1", "The InferenceService name to add as header to log events")
+	namespace        = flag.String("namespace", "my-project", "The namespace to add as header to log events")
 
 	// These flags are not needed by our logger but provided by Kserve, hence we need to parse it to avoid error.
 	sourceUri     = flag.String("source-uri", "", "The source URI to use when publishing cloudevents")
@@ -346,8 +346,8 @@ func getLogSink(
 			"compression.type":  merlinlogger.CompressionType,
 		}
 
-		if additionalKafkaConfig != nil && *additionalKafkaConfig != "" {
-			err := addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+		if kafkaConfigPath != nil && *kafkaConfigPath != "" {
+			err := addKafkaConfig(kafkaCfg, *kafkaConfigPath)
 			if err != nil {
 				return nil, err
 			}
@@ -378,8 +378,8 @@ func getLogSink(
 			"compression.type":  merlinlogger.CompressionType,
 		}
 
-		if additionalKafkaConfig != nil && *additionalKafkaConfig != "" {
-			err := addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+		if kafkaConfigPath != nil && *kafkaConfigPath != "" {
+			err := addKafkaConfig(kafkaCfg, *kafkaConfigPath)
 			if err != nil {
 				return nil, err
 			}

--- a/api/cmd/inference-logger/main.go
+++ b/api/cmd/inference-logger/main.go
@@ -347,7 +347,10 @@ func getLogSink(
 		}
 
 		if additionalKafkaConfig != nil && *additionalKafkaConfig != "" {
-			addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+			err := addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Create Kafka Producer
@@ -376,7 +379,10 @@ func getLogSink(
 		}
 
 		if additionalKafkaConfig != nil && *additionalKafkaConfig != "" {
-			addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+			err := addKafkaConfig(kafkaCfg, *additionalKafkaConfig)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Create Kafka Producer
@@ -400,10 +406,10 @@ func getLogSink(
 	}
 }
 
-func addKafkaConfig(cfg *kafka.ConfigMap, kafkaConfig string) (*kafka.ConfigMap, error) {
+func addKafkaConfig(cfg *kafka.ConfigMap, kafkaConfig string) error {
 	file, err := os.Open(kafkaConfig)
 	if err != nil {
-		return &kafka.ConfigMap{}, fmt.Errorf("failed to open kafka config file: %w", err)
+		return fmt.Errorf("failed to open kafka config file: %w", err)
 	}
 	defer file.Close()
 
@@ -423,8 +429,8 @@ func addKafkaConfig(cfg *kafka.ConfigMap, kafkaConfig string) (*kafka.ConfigMap,
 	}
 
 	if err := scanner.Err(); err != nil {
-		return &kafka.ConfigMap{}, fmt.Errorf("failed to open kafka config file: %w", err)
+		return fmt.Errorf("failed to open kafka config file: %w", err)
 	}
 
-	return cfg, nil
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
We have a usecase where we need to connect to Kafka V3 and we need to configure the SSL properties. Adding an option so that user can provide an extra option during kafka producer initialization as a kafka `.properties` files. This option is expected to be a path to the config file. So we have to mount it before hand in the deployment. Either as a secret or configmap

# Modifications
Add options to CLI inference-logging API

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [ ] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
