### PR TITLE
feat(ui): update templating of monitoring url

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,7 @@
     "dagre-d3-react": "^0.2.4",
     "js-yaml": "^4.1.0",
     "moment": "^2.30.1",
+    "mustache": "^4.2.0",
     "object-assign-deep": "^0.4.0",
     "proper-url-join": "^2.1.1",
     "react": "^18.3.1",

--- a/ui/src/pages/job/JobPage.js
+++ b/ui/src/pages/job/JobPage.js
@@ -100,6 +100,7 @@ const JobPage = () => {
             <EuiFlexItem>
               <JobDetailTabNavigation
                 project={project}
+                model={model}
                 job={job}
                 selectedTab={section}
               />

--- a/ui/src/pages/job/components/JobActions.js
+++ b/ui/src/pages/job/components/JobActions.js
@@ -16,7 +16,7 @@ function isActiveJob(status) {
   return ["pending", "running"].includes(status);
 }
 
-export const JobActions = ({ project, job }) => {
+export const JobActions = ({ project, model, job }) => {
   const [isStopPredictionJobModalVisible, toggleStopPredictionJobModal] =
     useState(false);
 
@@ -39,6 +39,7 @@ export const JobActions = ({ project, job }) => {
               href={createMonitoringUrl(
                 featureToggleConfig.monitoringDashboardJobBaseURL,
                 project,
+                model,
                 job,
               )}
               target="_blank"

--- a/ui/src/pages/job/components/JobDetailTabNavigation.js
+++ b/ui/src/pages/job/components/JobDetailTabNavigation.js
@@ -7,6 +7,7 @@ import { createMonitoringUrl } from "../utils/monitoringUrl";
 
 export const JobDetailTabNavigation = ({
   project,
+  model,
   job,
   actions,
   selectedTab,
@@ -47,6 +48,7 @@ export const JobDetailTabNavigation = ({
         href: createMonitoringUrl(
           featureToggleConfig.monitoringDashboardJobBaseURL,
           project,
+          model,
           job,
         ),
         target: "_blank",
@@ -54,7 +56,7 @@ export const JobDetailTabNavigation = ({
     }
 
     setTabs(tabs);
-  }, [project, job]);
+  }, [project, job, model]);
 
   return (
     <TabNavigation

--- a/ui/src/pages/job/components/JobRunPanel.js
+++ b/ui/src/pages/job/components/JobRunPanel.js
@@ -33,7 +33,7 @@ export const JobRunPanel = ({ project, model, version, job }) => {
     },
     {
       title: "Actions",
-      description: <JobActions job={job} project={project} />,
+      description: <JobActions job={job} model={model} project={project} />,
     },
   ];
 

--- a/ui/src/pages/job/components/JobsTable.js
+++ b/ui/src/pages/job/components/JobsTable.js
@@ -34,6 +34,7 @@ import { featureToggleConfig } from "../../../config";
 import { useMerlinApi } from "../../../hooks/useMerlinApi";
 import mocks from "../../../mocks";
 import StopPredictionJobModal from "../modals/StopPredictionJobModal";
+import { createMonitoringUrl } from "../utils/monitoringUrl";
 
 const moment = require("moment");
 
@@ -42,6 +43,7 @@ const defaultIconSize = "xs";
 
 const JobsTable = ({
   projectId,
+  modelId,
   jobs,
   isLoaded,
   error,
@@ -83,20 +85,11 @@ const JobsTable = ({
     [],
   );
 
-  function createMonitoringUrl(baseURL, project, job) {
-    const start_time_nano =
-      moment(job.created_at, "YYYY-MM-DDTHH:mm.SSZ").unix() * 1000;
-    const end_time_nano = start_time_nano + 7200000;
-    const query = {
-      from: start_time_nano,
-      to: end_time_nano,
-      "var-cluster": job.environment.cluster,
-      "var-project": project.name,
-      "var-job": job.name,
-    };
-    const queryParams = new URLSearchParams(query).toString();
-    return `${baseURL}?${queryParams}`;
-  }
+  const [{ data: model }] = useMerlinApi(
+    `/projects/${projectId}/models/${modelId}`,
+    { mock: mocks.model },
+    [],
+  );
 
   const [isStopPredictionJobModalVisible, toggleStopPredictionJobModal] =
     useState(false);
@@ -208,6 +201,7 @@ const JobsTable = ({
                 href={createMonitoringUrl(
                   featureToggleConfig.monitoringDashboardJobBaseURL,
                   project.data,
+                  model,
                   item,
                 )}
                 target="_blank"

--- a/ui/src/pages/job/utils/monitoringUrl.js
+++ b/ui/src/pages/job/utils/monitoringUrl.js
@@ -1,16 +1,27 @@
+import Mustache from "mustache";
+
 const moment = require("moment");
 
-export function createMonitoringUrl(baseURL, project, job) {
-  const start_time_nano =
+export function createMonitoringUrl(template, project, model, job) {
+  const created_at_unix =
     moment(job.created_at, "YYYY-MM-DDTHH:mm.SSZ").unix() * 1000;
-  const end_time_nano = start_time_nano + 7200000;
-  const query = {
-    from: start_time_nano,
-    to: end_time_nano,
-    "var-cluster": job.environment.cluster,
-    "var-project": project.name,
-    "var-job": job.name,
+  const updated_at_unix =
+    moment(job.updated_at, "YYYY-MM-DDTHH:mm.SSZ").unix() * 1000;
+  const updated_at_unix_with_extra = updated_at_unix + 600000; // extra 10 minutes
+
+  const data = {
+    created_at: created_at_unix.toString(),
+    updated_at: updated_at_unix.toString(),
+    updated_at_with_extra: updated_at_unix_with_extra.toString(),
+    cluster: job.environment.cluster,
+    project_id: project.id,
+    project_name: project.name,
+    model_id: model.id,
+    model_name: model.name,
+    model_version: job.version_id,
+    job_id: job.id,
+    job_name: job.name,
   };
-  const queryParams = new URLSearchParams(query).toString();
-  return `${baseURL}?${queryParams}`;
+
+  return Mustache.render(template, data);
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7772,6 +7772,11 @@ multicast-dns@^7.2.5:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
 
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
+
 mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
In this PR, we are moving the templating of monitoring url from classic string concat to [mustache template](https://github.com/janl/mustache.js). This change allows user to configure the monitoring url dynamically without being constrained by our pre-defined url format

# Modifications
- add new mustache dependency
- update `createMonitoringUrl` logic to use mustache template
- remove duplicated code of `createMonitoringUrl`

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
There will be a breaking change for the next released version. Users need to update REACT_APP_MONITORING_DASHBOARD_JOB_BASE_URL env var to use the latest format.
```
