### PR TITLE
fix(ui): add maxcompute support to job detail page

### DIFF
--- a/ui/src/pages/job/components/SinkConfig.js
+++ b/ui/src/pages/job/components/SinkConfig.js
@@ -86,8 +86,65 @@ const BQSinkConfig = ({ job }) => {
   );
 };
 
+const MCSinkConfig = ({ job }) => {
+  const items = [
+    { title: "Sink Type", description: "MaxCompute" },
+    {
+      title: "Table Name",
+      description: job.config.job_config.maxcomputeSink.table,
+    },
+    {
+      title: "Endpoint",
+      description: job.config.job_config.maxcomputeSource.endpoint
+    },
+    {
+      title: "Result Column Name",
+      description: job.config.job_config.maxcomputeSink.resultColumn,
+    },
+    {
+      title: "Save Mode",
+      description: job.config.job_config.maxcomputeSink.saveMode,
+    },
+    {
+      title: "Result Type",
+      description: getResultType(job.config.job_config.model.result),
+    },
+    {
+      title: "Options",
+      description: job.config.job_config.maxcomputeSink.options ? (
+        <EuiCodeBlock paddingSize="s">
+          {JSON.stringify(
+            job.config.job_config.maxcomputeSink.options,
+            undefined,
+            2
+          )}
+        </EuiCodeBlock>
+      ) : (
+        "-"
+      ),
+    },
+  ];
+
+  return (
+    <Fragment>
+      <ConfigSectionPanelTitle title="Sink Config" />
+
+      <EuiDescriptionList
+        compressed
+        columnWidths={[2, 4]}
+        type="responsiveColumn"
+        listItems={items}
+      />
+    </Fragment>
+  );
+};
+
 const SinkConfig = ({ job }) => {
-  return <BQSinkConfig job={job} />;
+  return (
+      job.config.job_config.bigquerySink ?
+          <BQSinkConfig job={job} /> :
+          <MCSinkConfig job={job} />
+  );
 };
 
 export default SinkConfig;

--- a/ui/src/pages/job/components/SourceConfig.js
+++ b/ui/src/pages/job/components/SourceConfig.js
@@ -66,8 +66,69 @@ const BQSourceConfig = ({ job }) => {
   );
 };
 
+const MCSourceConfig = ({ job }) => {
+  const items = [
+    { title: "Source Type", description: "MaxCompute" },
+    {
+      title: "Table Name",
+      description: job.config.job_config.maxcomputeSource.table,
+    },
+    {
+      title: "Endpoint",
+      description: job.config.job_config.maxcomputeSource.endpoint
+    },
+    {
+      title: "Features",
+      description: (
+        <div className="eui-yScrollWithShadows" style={{ maxHeight: 310 }}>
+          {job.config.job_config.maxcomputeSource.features &&
+            job.config.job_config.maxcomputeSource.features
+              .sort((a, b) => (a > b ? 1 : -1))
+              .map((feature) => (
+                <>
+                  {feature}
+                  <br />
+                </>
+              ))}
+        </div>
+      ),
+    },
+    {
+      title: "Options",
+      description: job.config.job_config.maxcomputeSource.options ? (
+        <EuiCodeBlock paddingSize="s">
+          {JSON.stringify(
+            job.config.job_config.maxcomputeSource.options,
+            undefined,
+            2
+          )}
+        </EuiCodeBlock>
+      ) : (
+        "-"
+      ),
+    },
+  ];
+
+  return (
+    <Fragment>
+      <ConfigSectionPanelTitle title="Source Config" />
+
+      <EuiDescriptionList
+        compressed
+        columnWidths={[2, 4]}
+        type="responsiveColumn"
+        listItems={items}
+      />
+    </Fragment>
+  );
+};
+
 const SourceConfig = ({ job }) => {
-  return <BQSourceConfig job={job} />;
+  return (
+      job.config.job_config.bigquerySource ?
+          <BQSourceConfig job={job} /> :
+          <MCSourceConfig job={job} />
+  );
 };
 
 export default SourceConfig;

--- a/ui/src/services/job/Job.js
+++ b/ui/src/services/job/Job.js
@@ -81,6 +81,37 @@ export class Job {
             allowFieldRelaxation: "false",
           },
         },
+        maxcomputeSource: {
+          table: "",
+          features: [],
+          endpoint: "",
+          options: {
+            // parentProject: "",
+            // maxParallelism: "0",
+            viewsEnabled: "false",
+            // viewMaterializationProject: "",
+            // viewMaterializationDataset: "",
+            readDataFormat: "AVRO",
+            optimizedEmptyProjection: "true",
+            // filter: ""
+          },
+        },
+        maxcomputeSink: {
+          table: "",
+          endpoint: "",
+          resultColumn: "",
+          saveMode: "ERRORIFEXISTS",
+          options: {
+            createDisposition: "CREATE_IF_NEEDED",
+            intermediateFormat: "parquet",
+            // partitionField: "",
+            // partitionExpirationMs: "0",
+            partitionType: "DAY",
+            // clusteredFields: "",
+            allowFieldAddition: "false",
+            allowFieldRelaxation: "false",
+          },
+        },
       },
     };
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
This PR will fix a bug on Batch Prediction Job Detail Page. Previously there was an error (`Something Went Wrong`) when opening this page.  That can happen because this page doesn't support MaxCompute Sink & Source.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/65218ea9-35a2-4872-b65a-ceadd654c374" />


# Modifications
- Add MaxCompute Sink & Source

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
