### PR TITLE
fix(ui): revert changes in Job constructor

### DIFF
--- a/ui/src/pages/job/components/JobRunPanel.js
+++ b/ui/src/pages/job/components/JobRunPanel.js
@@ -29,7 +29,7 @@ export const JobRunPanel = ({ project, model, version, job }) => {
     },
     {
       title: "Updated At",
-      description: <DateFromNow date={job.created_at} size="s" />,
+      description: <DateFromNow date={job.updated_at} size="s" />,
     },
     {
       title: "Actions",

--- a/ui/src/services/job/Job.js
+++ b/ui/src/services/job/Job.js
@@ -81,37 +81,6 @@ export class Job {
             allowFieldRelaxation: "false",
           },
         },
-        maxcomputeSource: {
-          table: "",
-          features: [],
-          endpoint: "",
-          options: {
-            // parentProject: "",
-            // maxParallelism: "0",
-            viewsEnabled: "false",
-            // viewMaterializationProject: "",
-            // viewMaterializationDataset: "",
-            readDataFormat: "AVRO",
-            optimizedEmptyProjection: "true",
-            // filter: ""
-          },
-        },
-        maxcomputeSink: {
-          table: "",
-          endpoint: "",
-          resultColumn: "",
-          saveMode: "ERRORIFEXISTS",
-          options: {
-            createDisposition: "CREATE_IF_NEEDED",
-            intermediateFormat: "parquet",
-            // partitionField: "",
-            // partitionExpirationMs: "0",
-            partitionType: "DAY",
-            // clusteredFields: "",
-            allowFieldAddition: "false",
-            allowFieldRelaxation: "false",
-          },
-        },
       },
     };
   }


### PR DESCRIPTION
# Description
This PR reverts changes related to `Job` constructor in this PR https://github.com/caraml-dev/merlin/pull/644. We should not change the `Job` constructor unless we want to support `Job` creation using MaxCompute. This PR also contains a bug fix related to wrong field name in `JobRunPanel`

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
