### PR TITLE
feat(api): Add alert path prefix as configuration field

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -320,7 +320,7 @@ func buildDependencies(ctx context.Context, cfg *config.Config, db *gorm.DB, dis
 	modelEndpointAlertService := service.NewModelEndpointAlertService(
 		storage.NewAlertStorage(db), gitlabClient, wardenClient,
 		gitlabConfig.DashboardRepository, gitlabConfig.DashboardBranch,
-		gitlabConfig.AlertRepository, gitlabConfig.AlertBranch,
+		gitlabConfig.AlertRepository, gitlabConfig.AlertBranch, gitlabConfig.AlertPathPrefix,
 		cfg.FeatureToggleConfig.MonitoringConfig.MonitoringBaseURL)
 
 	mlflowConfig := cfg.MlflowConfig

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -288,6 +288,7 @@ type GitlabConfig struct {
 	DashboardBranch     string `default:"master"`
 	AlertRepository     string
 	AlertBranch         string `default:"master"`
+	AlertPathPrefix     string
 }
 
 type WardenConfig struct {

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -490,8 +490,9 @@ func TestLoad(t *testing.T) {
 							BaseURL:             "https://test.io/",
 							DashboardRepository: "dashboards/merlin",
 							DashboardBranch:     "master",
-							AlertRepository:     "alerts/merlin",
+							AlertRepository:     "alerts_repository/merlin",
 							AlertBranch:         "master",
+							AlertPathPrefix:     "alerts/merlin",
 						},
 						WardenConfig: WardenConfig{
 							APIHost: "https://test.io/",

--- a/api/config/testdata/base-configs-1.yaml
+++ b/api/config/testdata/base-configs-1.yaml
@@ -115,8 +115,9 @@ FeatureToggleConfig:
       BaseURL: https://test.io/
       DashboardRepository: dashboards/merlin
       DashboardBranch: master
-      AlertRepository: alerts/merlin
+      AlertRepository: alerts_repository/merlin
       AlertBranch: master
+      AlertPathPrefix: alerts/merlin
     WardenConfig:
       APIHost: https://test.io/
   ModelDeletionConfig:

--- a/api/service/model_endpoint_alert_service.go
+++ b/api/service/model_endpoint_alert_service.go
@@ -44,6 +44,7 @@ type modelEndpointAlertService struct {
 	dashboardBranch     string
 	alertRepository     string
 	alertBranch         string
+	alertPathPrefix     string
 
 	dashboardBaseURL string
 }
@@ -53,7 +54,7 @@ func NewModelEndpointAlertService(
 	alertStorage storage.AlertStorage,
 	gitlabClient gitlab.Client, wardenClient warden.Client,
 	dashboardRepository, dashboardBranch,
-	alertRepository, alertBranch, dashboardBaseURL string) ModelEndpointAlertService {
+	alertRepository, alertBranch, alertPathPrefix, dashboardBaseURL string) ModelEndpointAlertService {
 	return &modelEndpointAlertService{
 		alertStorage: alertStorage,
 		gitlabClient: gitlabClient,
@@ -63,6 +64,7 @@ func NewModelEndpointAlertService(
 		dashboardBranch:     dashboardBranch,
 		alertRepository:     alertRepository,
 		alertBranch:         alertBranch,
+		alertPathPrefix:     alertPathPrefix,
 
 		dashboardBaseURL: dashboardBaseURL,
 	}
@@ -91,7 +93,7 @@ func (s *modelEndpointAlertService) CreateModelEndpointAlert(user string, alert 
 	if err != nil {
 		return nil, err
 	}
-	alertFilename := fmt.Sprintf("alerts/merlin/%s/%s_%s.yaml", alert.Model.Project.Name, alert.Model.Name, alert.EnvironmentName)
+	alertFilename := fmt.Sprintf("%s/%s/%s_%s.yaml", s.alertPathPrefix, alert.Model.Project.Name, alert.Model.Name, alert.EnvironmentName)
 
 	createAlertOpt := gitlab.CreateFileOptions{
 		Repository:    s.alertRepository,
@@ -125,7 +127,7 @@ func (s *modelEndpointAlertService) UpdateModelEndpointAlert(user string, alert 
 	if err != nil {
 		return nil, err
 	}
-	alertFilename := fmt.Sprintf("alerts/merlin/%s/%s_%s.yaml", alert.Model.Project.Name, alert.Model.Name, alert.EnvironmentName)
+	alertFilename := fmt.Sprintf("%s/%s/%s_%s.yaml", s.alertPathPrefix, alert.Model.Project.Name, alert.Model.Name, alert.EnvironmentName)
 
 	updateAlertOpt := gitlab.UpdateFileOptions{
 		Repository:    s.alertRepository,


### PR DESCRIPTION
# Description
This PR simply introduces a new configuration field for the Merlin API server to make the alert path prefix (currently hardcoded as `alerts/merlin`) into a configurable field. This allows for more customisable paths to be used when setting up alerts using the current GitOps approach.

# Modifications
- `api/config/config.go` - Added a new configuration field `AlertPathPrefix`
- `api/service/model_endpoint_alert_service.go` - Made changes to the current way an alert file path is generated

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [x] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
