### PR TITLE
fix: add option to specify executeProject

### DIFF
--- a/python/batch-predictor/merlinpyspark/config.py
+++ b/python/batch-predictor/merlinpyspark/config.py
@@ -124,7 +124,8 @@ class MaxComputeSourceConfig(SourceConfig):
 
     def __init__(self, mc_src_proto: MaxComputeSource):
         self._proto = mc_src_proto
-        self._project, self._schema, self._table = self._proto.table.split(".")
+        self._project, self._schema, _ = self._proto.table.split(".")
+        self._table = self._proto.table
         
     def source_type(self) -> str:
         return self.TYPE
@@ -237,7 +238,8 @@ class MaxComputeSinkConfig(SinkConfig):
 
     def __init__(self, mc_sink_proto: MaxComputeSink):
         self._proto = mc_sink_proto
-        self._project, self._schema, self._table = self._proto.table.split(".")
+        self._project, self._schema, _ = self._proto.table.split(".")
+        self._table = self._proto.table
     
     def sink_type(self) -> str:
         return self.TYPE

--- a/python/batch-predictor/merlinpyspark/config.py
+++ b/python/batch-predictor/merlinpyspark/config.py
@@ -238,8 +238,9 @@ class MaxComputeSinkConfig(SinkConfig):
 
     def __init__(self, mc_sink_proto: MaxComputeSink):
         self._proto = mc_sink_proto
-        self._project, self._schema, _ = self._proto.table.split(".")
-        self._table = self._proto.table
+        # NOTE: the table for the sink is not in the format of `project.schema.table`
+        # because the INSERT statement in MaxCompute only supports `table`
+        self._project, self._schema, self._table = self._proto.table.split(".")
     
     def sink_type(self) -> str:
         return self.TYPE

--- a/python/batch-predictor/merlinpyspark/config.py
+++ b/python/batch-predictor/merlinpyspark/config.py
@@ -140,6 +140,11 @@ class MaxComputeSourceConfig(SourceConfig):
     
     def project(self) -> str:
         return self._project
+
+    def execute_project(self) -> str:
+        if self.options() is not None and "execute_project" in self.options():
+            return self.options()["execute_project"]
+        return ""
     
     def schema(self) -> str:
         return self._schema
@@ -246,6 +251,11 @@ class MaxComputeSinkConfig(SinkConfig):
     def options(self) -> MutableMapping[str, str]:
         return self._proto.options
     
+    def execute_project(self) -> str:
+        if self.options() is not None and "execute_project" in self.options():
+            return self.options()["execute_project"]
+        return ""
+
     def save_mode(self) -> str:
         return SaveMode.Name(self._proto.save_mode).lower()
     

--- a/python/batch-predictor/merlinpyspark/sink.py
+++ b/python/batch-predictor/merlinpyspark/sink.py
@@ -74,7 +74,6 @@ class MaxComputeSink(Sink):
 
     def get_jdbc_url(self):
         url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&alwaysFallback=true&enableOdpsLogger=true"
-        # NOTE: Intentionally omit this to see if this is the problem
         if self._config.execute_project() is not None:
             url += f"&executeProject={self._config.execute_project()}"
         return url

--- a/python/batch-predictor/merlinpyspark/sink.py
+++ b/python/batch-predictor/merlinpyspark/sink.py
@@ -73,7 +73,10 @@ class MaxComputeSink(Sink):
         self._spark = spark_session
 
     def get_jdbc_url(self):
-        return f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false"
+        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&alwaysFallback=true&enableOdpsLogger=true"
+        if self._config.execute_project() is not None:
+            url += f"&executeProject={self._config.execute_project()}"
+        return url
 
     def get_query_timeout(self):
         return self._config.options().get("queryTimeout", "300")

--- a/python/batch-predictor/merlinpyspark/sink.py
+++ b/python/batch-predictor/merlinpyspark/sink.py
@@ -73,10 +73,10 @@ class MaxComputeSink(Sink):
         self._spark = spark_session
 
     def get_jdbc_url(self):
-        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false"
+        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&alwaysFallback=true&enableOdpsLogger=true"
         # NOTE: Intentionally omit this to see if this is the problem
-        # if self._config.execute_project() is not None:
-        #     url += f"&executeProject={self._config.execute_project()}"
+        if self._config.execute_project() is not None:
+            url += f"&executeProject={self._config.execute_project()}"
         return url
 
     def get_query_timeout(self):

--- a/python/batch-predictor/merlinpyspark/sink.py
+++ b/python/batch-predictor/merlinpyspark/sink.py
@@ -73,9 +73,10 @@ class MaxComputeSink(Sink):
         self._spark = spark_session
 
     def get_jdbc_url(self):
-        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&alwaysFallback=true&enableOdpsLogger=true"
-        if self._config.execute_project() is not None:
-            url += f"&executeProject={self._config.execute_project()}"
+        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false"
+        # NOTE: Intentionally omit this to see if this is the problem
+        # if self._config.execute_project() is not None:
+        #     url += f"&executeProject={self._config.execute_project()}"
         return url
 
     def get_query_timeout(self):

--- a/python/batch-predictor/merlinpyspark/source.py
+++ b/python/batch-predictor/merlinpyspark/source.py
@@ -154,7 +154,10 @@ class MaxComputeSource(Source):
         return self._config.features()
 
     def get_jdbc_url(self):
-        return f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&autoSelectLimit={self.auto_select_limit}&alwaysFallback=true&enableOdpsLogger=true"
+        url = f"jdbc:odps:{self._config.endpoint()}?project={self._config.project()}&accessId={self.get_access_id()}&accessKey={self.get_access_key()}&interactiveMode={self.get_interactive_mode()}&odpsNamespaceSchema=true&schema={self._config.schema()}&enableLimit=false&autoSelectLimit={self.auto_select_limit}&alwaysFallback=true&enableOdpsLogger=true"
+        if self._config.execute_project() is not None:
+            url += f"&executeProject={self._config.execute_project()}"
+        return url
 
     def get_query_timeout(self):
         return self._config.options().get("queryTimeout", "300")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
# Description
<!-- Briefly describe the motivation for the change. Please include illustrations where appropriate. -->
* Allow users to specify executeProject in options of MaxComputeSource
* For example:
```
mc_source = MaxComputeSource(
    table="some_other_project.data_science_platform_playground.batch_prediction_test_3",
    features=["sepal_length", "sepal_width", "petal_length", "petal_width"],
    endpoint="https://service.ap-southeast-5.maxcompute.aliyun.com/api",
    options={"execute_project": "project_a"}
)
```
This will `project_a` to execute the maxcompute job, even if the table being accessed is in `some_other_project`
cc @mbruner 

# Modifications
<!-- Summarize the key code changes. -->

# Tests
<!-- Besides the existing / updated automated tests, what specific scenarios should be tested? Consider the backward compatibility of the changes, whether corner cases are covered, etc. Please describe the tests and check the ones that have been completed. Eg:
- [x] Deploying new and existing standard models
- [ ] Deploying PyFunc models
-->

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [ ] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
<!--
Does this PR introduce a user-facing change?
If no, just write "NONE" in the release-note block below.
If yes, a release note is required. Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, include the string "action required".

For more information about release notes, see kubernetes' guide here: http://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
