### PR TITLE
chore: retrieve google sa in batch job only if it's specified

### DIFF
--- a/api/batch/controller.go
+++ b/api/batch/controller.go
@@ -324,11 +324,13 @@ func (c *controller) onUpdate(old, new interface{}) {
 func (c *controller) getMLPSecrets(ctx context.Context, predictionJob *models.PredictionJob, namespace string) (map[string]string, error) {
 	secretMap := make(map[string]string)
 	// Retrieve Google Service Account secret from MLP
-	googleServiceAccountSecret, err := c.mlpAPIClient.GetSecretByName(ctx, predictionJob.Config.ServiceAccountName, int32(predictionJob.ProjectID))
-	if err != nil {
-		return nil, fmt.Errorf("service account %s is not found within %s project: %w", predictionJob.Config.ServiceAccountName, namespace, err)
+	if predictionJob.Config.ServiceAccountName != "" {
+		googleServiceAccountSecret, err := c.mlpAPIClient.GetSecretByName(ctx, predictionJob.Config.ServiceAccountName, int32(predictionJob.ProjectID))
+		if err != nil {
+			return nil, fmt.Errorf("service account %s is not found within %s project: %w", predictionJob.Config.ServiceAccountName, namespace, err)
+		}
+		secretMap[serviceAccountFileName] = googleServiceAccountSecret.Data
 	}
-	secretMap[serviceAccountFileName] = googleServiceAccountSecret.Data
 
 	// Retrieve user-configured secrets from MLP
 	for _, secret := range predictionJob.Config.Secrets {


### PR DESCRIPTION
# Description
Previously, the batch-job in Merlin was using BQ table and when client tries to submit a batch-job, Merlin assumed that a Google Service Account will be provided in the job configuration. But as we have added option for using MaxCompute and it doesn't need a Google SA, I'm adding a check where it will only try to retrieve the service account if it's provided

# Modifications
<!-- Summarize the key code changes. -->

# Tests

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
remove google sa dependency in batch job
```
