### PR TITLE
feat: Exposing Liveness config

### DIFF
--- a/api/cluster/resource/templater.go
+++ b/api/cluster/resource/templater.go
@@ -237,7 +237,16 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 		}
 	}
 
-	livenessProbeConfig := getLivenessProbeConfig(modelService.PredictorProtocol(), envVars, fmt.Sprintf("/v1/models/%s", modelService.Name))
+	// Get user-configured probe settings
+	var userLivenessConfig *models.ProbeConfig
+	var userReadinessConfig *models.ProbeConfig
+	if modelService.ResourceRequest != nil {
+		userLivenessConfig = modelService.ResourceRequest.LivenessProbe
+		userReadinessConfig = modelService.ResourceRequest.ReadinessProbe
+	}
+
+	livenessProbeConfig := getLivenessProbeConfig(modelService.PredictorProtocol(), envVars, fmt.Sprintf("/v1/models/%s", modelService.Name), userLivenessConfig)
+	readinessProbeConfig := getReadinessProbeConfig(modelService.PredictorProtocol(), fmt.Sprintf("/v1/models/%s", modelService.Name), userReadinessConfig)
 
 	containerPorts := createContainerPorts(modelService.PredictorProtocol(), modelService.DeploymentMode)
 	storageUri := utils.CreateModelLocation(modelService.ArtifactURI)
@@ -249,11 +258,12 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 				PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 					StorageURI: &storageUri,
 					Container: corev1.Container{
-						Name:          kserveconstant.InferenceServiceContainerName,
-						Resources:     resources,
-						LivenessProbe: livenessProbeConfig,
-						Ports:         containerPorts,
-						Env:           envVars,
+						Name:           kserveconstant.InferenceServiceContainerName,
+						Resources:      resources,
+						LivenessProbe:  livenessProbeConfig,
+						ReadinessProbe: readinessProbeConfig,
+						Ports:          containerPorts,
+						Env:            envVars,
 					},
 				},
 			},
@@ -264,11 +274,12 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 				PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 					StorageURI: &storageUri,
 					Container: corev1.Container{
-						Name:          kserveconstant.InferenceServiceContainerName,
-						Resources:     resources,
-						LivenessProbe: livenessProbeConfig,
-						Ports:         containerPorts,
-						Env:           envVars,
+						Name:           kserveconstant.InferenceServiceContainerName,
+						Resources:      resources,
+						LivenessProbe:  livenessProbeConfig,
+						ReadinessProbe: readinessProbeConfig,
+						Ports:          containerPorts,
+						Env:            envVars,
 					},
 				},
 			},
@@ -279,11 +290,12 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 				PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 					StorageURI: &storageUri,
 					Container: corev1.Container{
-						Name:          kserveconstant.InferenceServiceContainerName,
-						Resources:     resources,
-						LivenessProbe: livenessProbeConfig,
-						Ports:         containerPorts,
-						Env:           envVars,
+						Name:           kserveconstant.InferenceServiceContainerName,
+						Resources:      resources,
+						LivenessProbe:  livenessProbeConfig,
+						ReadinessProbe: readinessProbeConfig,
+						Ports:          containerPorts,
+						Env:            envVars,
 					},
 				},
 			},
@@ -294,11 +306,12 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 				PredictorExtensionSpec: kservev1beta1.PredictorExtensionSpec{
 					StorageURI: &storageUri,
 					Container: corev1.Container{
-						Name:          kserveconstant.InferenceServiceContainerName,
-						Resources:     resources,
-						LivenessProbe: livenessProbeConfig,
-						Ports:         containerPorts,
-						Env:           envVars,
+						Name:           kserveconstant.InferenceServiceContainerName,
+						Resources:      resources,
+						LivenessProbe:  livenessProbeConfig,
+						ReadinessProbe: readinessProbeConfig,
+						Ports:          containerPorts,
+						Env:            envVars,
 					},
 				},
 			},
@@ -335,12 +348,13 @@ func (t *InferenceServiceTemplater) createPredictorSpec(modelService *models.Ser
 			PodSpec: kservev1beta1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name:          kserveconstant.InferenceServiceContainerName,
-						Image:         modelService.Options.PyFuncImageName,
-						Env:           envVars,
-						Resources:     resources,
-						LivenessProbe: livenessProbeConfig,
-						Ports:         containerPorts,
+						Name:           kserveconstant.InferenceServiceContainerName,
+						Image:          modelService.Options.PyFuncImageName,
+						Env:            envVars,
+						Resources:      resources,
+						LivenessProbe:  livenessProbeConfig,
+						ReadinessProbe: readinessProbeConfig,
+						Ports:          containerPorts,
 					},
 				},
 			},
@@ -411,7 +425,16 @@ func (t *InferenceServiceTemplater) createTransformerSpec(
 		}
 	}
 
-	livenessProbeConfig := getLivenessProbeConfig(modelService.Protocol, envVars, "/")
+	// Get user-configured probe settings for transformer
+	var userLivenessConfig *models.ProbeConfig
+	var userReadinessConfig *models.ProbeConfig
+	if transformer.ResourceRequest != nil {
+		userLivenessConfig = transformer.ResourceRequest.LivenessProbe
+		userReadinessConfig = transformer.ResourceRequest.ReadinessProbe
+	}
+
+	livenessProbeConfig := getLivenessProbeConfig(modelService.Protocol, envVars, "/", userLivenessConfig)
+	readinessProbeConfig := getReadinessProbeConfig(modelService.Protocol, "/", userReadinessConfig)
 
 	containerPorts := createContainerPorts(modelService.Protocol, modelService.DeploymentMode)
 	transformerSpec := &kservev1beta1.TransformerSpec{
@@ -428,10 +451,11 @@ func (t *InferenceServiceTemplater) createTransformerSpec(
 						},
 						Limits: limits,
 					},
-					Command:       transformerCommand,
-					Args:          transformerArgs,
-					LivenessProbe: livenessProbeConfig,
-					Ports:         containerPorts,
+					Command:        transformerCommand,
+					Args:           transformerArgs,
+					LivenessProbe:  livenessProbeConfig,
+					ReadinessProbe: readinessProbeConfig,
+					Ports:          containerPorts,
 				},
 			},
 		},
@@ -515,8 +539,8 @@ func (t *InferenceServiceTemplater) enrichStandardTransformerEnvVars(modelServic
 	return envVars
 }
 
-func createHTTPGetLivenessProbe(httpPath string, port int) *corev1.Probe {
-	return &corev1.Probe{
+func createHTTPGetLivenessProbe(httpPath string, port int, userConfig *models.ProbeConfig) *corev1.Probe {
+	probe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Path:   httpPath,
@@ -532,10 +556,12 @@ func createHTTPGetLivenessProbe(httpPath string, port int) *corev1.Probe {
 		SuccessThreshold:    liveProbeSuccessThreshold,
 		FailureThreshold:    liveProbeFailureThreshold,
 	}
+	applyUserProbeConfig(probe, userConfig, port)
+	return probe
 }
 
-func createGRPCLivenessProbe(port int) *corev1.Probe {
-	return &corev1.Probe{
+func createGRPCLivenessProbe(port int, userConfig *models.ProbeConfig) *corev1.Probe {
+	probe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{grpcHealthProbeCommand, fmt.Sprintf("-addr=:%d", port)},
@@ -547,24 +573,118 @@ func createGRPCLivenessProbe(port int) *corev1.Probe {
 		SuccessThreshold:    liveProbeSuccessThreshold,
 		FailureThreshold:    liveProbeFailureThreshold,
 	}
+	applyUserProbeConfig(probe, userConfig, port)
+	return probe
 }
 
-func getLivenessProbeConfig(protocol prt.Protocol, envVars []corev1.EnvVar, httpPath string) *corev1.Probe {
+func getLivenessProbeConfig(protocol prt.Protocol, envVars []corev1.EnvVar, httpPath string, userConfig *models.ProbeConfig) *corev1.Probe {
 	// liveness probe config. if env var to disable != true or not set, it will default to enabled
 	var livenessProbeConfig *corev1.Probe = nil
 	envVarsMap := getEnvVarMap(envVars)
 	if !strings.EqualFold(envVarsMap[envOldDisableLivenessProbe].Value, "true") &&
 		!strings.EqualFold(envVarsMap[envDisableLivenessProbe].Value, "true") {
-		livenessProbeConfig = createLivenessProbeSpec(protocol, httpPath)
+		livenessProbeConfig = createLivenessProbeSpec(protocol, httpPath, userConfig)
 	}
 	return livenessProbeConfig
 }
 
-func createLivenessProbeSpec(protocol prt.Protocol, httpPath string) *corev1.Probe {
+func createLivenessProbeSpec(protocol prt.Protocol, httpPath string, userConfig *models.ProbeConfig) *corev1.Probe {
 	if protocol == prt.UpiV1 {
-		return createGRPCLivenessProbe(defaultGRPCPort)
+		return createGRPCLivenessProbe(defaultGRPCPort, userConfig)
 	}
-	return createHTTPGetLivenessProbe(httpPath, defaultHTTPPort)
+	return createHTTPGetLivenessProbe(httpPath, defaultHTTPPort, userConfig)
+}
+
+// getReadinessProbeConfig creates a readiness probe configuration based on user settings
+func getReadinessProbeConfig(protocol prt.Protocol, httpPath string, userConfig *models.ProbeConfig) *corev1.Probe {
+	if userConfig == nil {
+		return nil
+	}
+	return createReadinessProbeSpec(protocol, httpPath, userConfig)
+}
+
+func createReadinessProbeSpec(protocol prt.Protocol, httpPath string, userConfig *models.ProbeConfig) *corev1.Probe {
+	if protocol == prt.UpiV1 {
+		return createGRPCReadinessProbe(defaultGRPCPort, userConfig)
+	}
+	return createHTTPGetReadinessProbe(httpPath, defaultHTTPPort, userConfig)
+}
+
+func createHTTPGetReadinessProbe(httpPath string, port int, userConfig *models.ProbeConfig) *corev1.Probe {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   httpPath,
+				Scheme: "HTTP",
+				Port: intstr.IntOrString{
+					IntVal: int32(port),
+				},
+			},
+		},
+		InitialDelaySeconds: liveProbeInitialDelaySec,
+		TimeoutSeconds:      liveProbeTimeoutSec,
+		PeriodSeconds:       liveProbePeriodSec,
+		SuccessThreshold:    liveProbeSuccessThreshold,
+		FailureThreshold:    liveProbeFailureThreshold,
+	}
+	applyUserProbeConfig(probe, userConfig, port)
+	return probe
+}
+
+func createGRPCReadinessProbe(port int, userConfig *models.ProbeConfig) *corev1.Probe {
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: []string{grpcHealthProbeCommand, fmt.Sprintf("-addr=:%d", port)},
+			},
+		},
+		InitialDelaySeconds: liveProbeInitialDelaySec,
+		TimeoutSeconds:      liveProbeTimeoutSec,
+		PeriodSeconds:       liveProbePeriodSec,
+		SuccessThreshold:    liveProbeSuccessThreshold,
+		FailureThreshold:    liveProbeFailureThreshold,
+	}
+	applyUserProbeConfig(probe, userConfig, port)
+	return probe
+}
+
+// applyUserProbeConfig applies user-provided probe configuration to the probe
+func applyUserProbeConfig(probe *corev1.Probe, userConfig *models.ProbeConfig, _ int) {
+	if userConfig == nil {
+		return
+	}
+	if userConfig.InitialDelaySeconds > 0 {
+		probe.InitialDelaySeconds = userConfig.InitialDelaySeconds
+	}
+	if userConfig.TimeoutSeconds > 0 {
+		probe.TimeoutSeconds = userConfig.TimeoutSeconds
+	}
+	if userConfig.PeriodSeconds > 0 {
+		probe.PeriodSeconds = userConfig.PeriodSeconds
+	}
+	if userConfig.SuccessThreshold > 0 {
+		probe.SuccessThreshold = userConfig.SuccessThreshold
+	}
+	if userConfig.FailureThreshold > 0 {
+		probe.FailureThreshold = userConfig.FailureThreshold
+	}
+	// Apply port if specified in user config
+	if userConfig.Port > 0 {
+		if probe.ProbeHandler.HTTPGet != nil {
+			probe.ProbeHandler.HTTPGet.Port = intstr.FromInt32(userConfig.Port)
+		} else if probe.ProbeHandler.Exec != nil {
+			probe.ProbeHandler.Exec.Command = []string{grpcHealthProbeCommand, fmt.Sprintf("-addr=:%d", userConfig.Port)}
+		}
+	}
+	// Apply path and scheme for HTTP probes
+	if probe.ProbeHandler.HTTPGet != nil {
+		if userConfig.Path != "" {
+			probe.ProbeHandler.HTTPGet.Path = userConfig.Path
+		}
+		if userConfig.Scheme != "" {
+			probe.ProbeHandler.HTTPGet.Scheme = corev1.URIScheme(userConfig.Scheme)
+		}
+	}
 }
 
 func createPredictorHost(modelService *models.Service) string {

--- a/api/cluster/resource/templater_gpu_test.go
+++ b/api/cluster/resource/templater_gpu_test.go
@@ -119,8 +119,8 @@ func TestCreateInferenceServiceSpecWithGPU(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
 
 	tests := []struct {
 		name               string

--- a/api/cluster/resource/templater_test.go
+++ b/api/cluster/resource/templater_test.go
@@ -287,8 +287,8 @@ func TestCreateInferenceServiceSpec(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
 
 	tests := []struct {
 		name               string
@@ -2075,12 +2075,12 @@ func TestCreateInferenceServiceSpecWithTransformer(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
-	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
+	probeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
-	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/", nil)
+	transformerProbeConfigUPI := createLivenessProbeSpec(protocol.UpiV1, "/", nil)
 	tests := []struct {
 		name            string
 		modelSvc        *models.Service
@@ -3016,10 +3016,10 @@ func TestCreateInferenceServiceSpecWithLogger(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/", nil)
 
 	tests := []struct {
 		name            string
@@ -3503,10 +3503,10 @@ func TestCreateInferenceServiceSpecWithTopologySpreadConstraints(t *testing.T) {
 	storageUri := fmt.Sprintf("%s/model", modelSvc.ArtifactURI)
 
 	// Liveness probe config for the model containers
-	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name))
+	probeConfig := createLivenessProbeSpec(protocol.HttpJson, fmt.Sprintf("/v1/models/%s", modelSvc.Name), nil)
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/", nil)
 
 	tests := []struct {
 		name            string
@@ -4419,7 +4419,7 @@ func TestCreateTransformerSpec(t *testing.T) {
 	customCPULimit := resource.MustParse("8")
 
 	// Liveness probe config for the transformers
-	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/")
+	transformerProbeConfig := createLivenessProbeSpec(protocol.HttpJson, "/", nil)
 
 	modelSvc := &models.Service{
 		Name:         "model-1",

--- a/api/models/resource_request.go
+++ b/api/models/resource_request.go
@@ -37,6 +37,30 @@ type ResourceRequest struct {
 	GPUName string `json:"gpu_name,omitempty"`
 	// GPU Quantity requests
 	GPURequest resource.Quantity `json:"gpu_request,omitempty"`
+	// Liveness probe configuration
+	LivenessProbe *ProbeConfig `json:"liveness_probe,omitempty"`
+	// Readiness probe configuration
+	ReadinessProbe *ProbeConfig `json:"readiness_probe,omitempty"`
+}
+
+// ProbeConfig represents the configuration for Kubernetes liveness/readiness probes
+type ProbeConfig struct {
+	// Path for HTTP probe (for HTTP-based probes)
+	Path string `json:"path,omitempty"`
+	// Port for the probe
+	Port int32 `json:"port,omitempty"`
+	// Scheme for HTTP probe (HTTP or HTTPS)
+	Scheme string `json:"scheme,omitempty"`
+	// Initial delay before starting the probe (seconds)
+	InitialDelaySeconds int32 `json:"initial_delay_seconds,omitempty"`
+	// Timeout for the probe (seconds)
+	TimeoutSeconds int32 `json:"timeout_seconds,omitempty"`
+	// Period between probe checks (seconds)
+	PeriodSeconds int32 `json:"period_seconds,omitempty"`
+	// Number of successes required to be considered healthy
+	SuccessThreshold int32 `json:"success_threshold,omitempty"`
+	// Number of failures before considered unhealthy
+	FailureThreshold int32 `json:"failure_threshold,omitempty"`
 }
 
 func (r ResourceRequest) Value() (driver.Value, error) {

--- a/python/pyfunc-server/docker/local.Dockerfile
+++ b/python/pyfunc-server/docker/local.Dockerfile
@@ -7,6 +7,7 @@ COPY ${MODEL_DEPENDENCIES_URL} conda.yaml
 
 ARG MERLIN_DEP_CONSTRAINT
 RUN process_conda_env.sh conda.yaml "merlin-pyfunc-server" "${MERLIN_DEP_CONSTRAINT}"
+RUN process_conda_env.sh conda.yaml "merlin-sdk" "${MERLIN_DEP_CONSTRAINT}"
 RUN conda env create --name merlin-model --file conda.yaml
 
 # Download and dry-run user model artifacts and code

--- a/python/sdk/client_README.md
+++ b/python/sdk/client_README.md
@@ -186,6 +186,7 @@ Class | Method | HTTP request | Description
  - [PredictionJobResourceRequest](client/docs/PredictionJobResourceRequest.md)
  - [PredictionLogIngestionResourceRequest](client/docs/PredictionLogIngestionResourceRequest.md)
  - [PredictionLoggerConfig](client/docs/PredictionLoggerConfig.md)
+ - [ProbeConfig](client/docs/ProbeConfig.md)
  - [Project](client/docs/Project.md)
  - [Protocol](client/docs/Protocol.md)
  - [RankingOutput](client/docs/RankingOutput.md)

--- a/python/sdk/merlin/__init__.py
+++ b/python/sdk/merlin/__init__.py
@@ -24,6 +24,7 @@ import merlin.autoscaling
 import merlin.deployment_mode
 import merlin.fluent
 import merlin.resource_request
+import merlin.probe_config
 from merlin.version import VERSION as __version__
 
 # Merlin URL
@@ -80,6 +81,7 @@ list_model_endpoints = merlin.fluent.list_model_endpoints
 
 # Definitions
 ResourceRequest = merlin.resource_request.ResourceRequest
+ProbeConfig = merlin.probe_config.ProbeConfig
 DeploymentMode = merlin.deployment_mode.DeploymentMode
 AutoscalingPolicy = merlin.autoscaling.AutoscalingPolicy
 MetricsType = merlin.autoscaling.MetricsType
@@ -116,6 +118,7 @@ __all__ = [
     "set_traffic",
     "serve_traffic",
     "ResourceRequest",
+    "ProbeConfig",
     "DeploymentMode",
     "AutoscalingPolicy",
     "MetricsType",

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1276,25 +1276,7 @@ class ModelVersion:
 
         if resource_request is not None:
             resource_request.validate()
-
-            # Convert probe configs to client models if present
-            liveness_probe_client = None
-            readiness_probe_client = None
-            if resource_request.liveness_probe is not None:
-                liveness_probe_client = resource_request.liveness_probe.to_client_probe_config()
-            if resource_request.readiness_probe is not None:
-                readiness_probe_client = resource_request.readiness_probe.to_client_probe_config()
-
-            target_resource_request = client.ResourceRequest(
-                min_replica=resource_request.min_replica,
-                max_replica=resource_request.max_replica,
-                cpu_request=resource_request.cpu_request,
-                cpu_limit=resource_request.cpu_limit,
-                memory_request=resource_request.memory_request,
-                liveness_probe=liveness_probe_client,
-                readiness_probe=readiness_probe_client,
-            )
-
+            target_resource_request = resource_request.to_client_resource_request()
 
             if target_resource_request.min_replica is None:
                 target_resource_request.min_replica = (
@@ -1882,24 +1864,7 @@ class ModelVersion:
             )
         else:
             resource_request.validate()
-
-            # Convert probe configs to client models if present
-            liveness_probe_client = None
-            readiness_probe_client = None
-            if resource_request.liveness_probe is not None:
-                liveness_probe_client = resource_request.liveness_probe.to_client_probe_config()
-            if resource_request.readiness_probe is not None:
-                readiness_probe_client = resource_request.readiness_probe.to_client_probe_config()
-
-            target_resource_request = client.ResourceRequest(
-                min_replica=resource_request.min_replica,
-                max_replica=resource_request.max_replica,
-                cpu_request=resource_request.cpu_request,
-                cpu_limit=resource_request.cpu_limit,
-                memory_request=resource_request.memory_request,
-                liveness_probe=liveness_probe_client,
-                readiness_probe=readiness_probe_client,
-            )
+            target_resource_request = resource_request.to_client_resource_request()
 
         target_env_vars: List[client.EnvVar] = []
         if transformer.env_vars is not None:

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1282,12 +1282,8 @@ class ModelVersion:
             readiness_probe_client = None
             if resource_request.liveness_probe is not None:
                 liveness_probe_client = resource_request.liveness_probe.to_client_probe_config()
-                print(f"DEBUG model.py: liveness_probe_client = {liveness_probe_client}")
-                print(f"DEBUG model.py: liveness_probe_client.to_dict() = {liveness_probe_client.to_dict()}")
             if resource_request.readiness_probe is not None:
                 readiness_probe_client = resource_request.readiness_probe.to_client_probe_config()
-                print(f"DEBUG model.py: readiness_probe_client = {readiness_probe_client}")
-                print(f"DEBUG model.py: readiness_probe_client.to_dict() = {readiness_probe_client.to_dict()}")
 
             target_resource_request = client.ResourceRequest(
                 min_replica=resource_request.min_replica,
@@ -1299,7 +1295,6 @@ class ModelVersion:
                 readiness_probe=readiness_probe_client,
             )
 
-            print(f"DEBUG model.py: target_resource_request.to_dict() = {target_resource_request.to_dict()}")
 
             if target_resource_request.min_replica is None:
                 target_resource_request.min_replica = (

--- a/python/sdk/merlin/model.py
+++ b/python/sdk/merlin/model.py
@@ -1276,13 +1276,30 @@ class ModelVersion:
 
         if resource_request is not None:
             resource_request.validate()
+
+            # Convert probe configs to client models if present
+            liveness_probe_client = None
+            readiness_probe_client = None
+            if resource_request.liveness_probe is not None:
+                liveness_probe_client = resource_request.liveness_probe.to_client_probe_config()
+                print(f"DEBUG model.py: liveness_probe_client = {liveness_probe_client}")
+                print(f"DEBUG model.py: liveness_probe_client.to_dict() = {liveness_probe_client.to_dict()}")
+            if resource_request.readiness_probe is not None:
+                readiness_probe_client = resource_request.readiness_probe.to_client_probe_config()
+                print(f"DEBUG model.py: readiness_probe_client = {readiness_probe_client}")
+                print(f"DEBUG model.py: readiness_probe_client.to_dict() = {readiness_probe_client.to_dict()}")
+
             target_resource_request = client.ResourceRequest(
                 min_replica=resource_request.min_replica,
                 max_replica=resource_request.max_replica,
                 cpu_request=resource_request.cpu_request,
                 cpu_limit=resource_request.cpu_limit,
                 memory_request=resource_request.memory_request,
+                liveness_probe=liveness_probe_client,
+                readiness_probe=readiness_probe_client,
             )
+
+            print(f"DEBUG model.py: target_resource_request.to_dict() = {target_resource_request.to_dict()}")
 
             if target_resource_request.min_replica is None:
                 target_resource_request.min_replica = (
@@ -1870,12 +1887,23 @@ class ModelVersion:
             )
         else:
             resource_request.validate()
+
+            # Convert probe configs to client models if present
+            liveness_probe_client = None
+            readiness_probe_client = None
+            if resource_request.liveness_probe is not None:
+                liveness_probe_client = resource_request.liveness_probe.to_client_probe_config()
+            if resource_request.readiness_probe is not None:
+                readiness_probe_client = resource_request.readiness_probe.to_client_probe_config()
+
             target_resource_request = client.ResourceRequest(
                 min_replica=resource_request.min_replica,
                 max_replica=resource_request.max_replica,
                 cpu_request=resource_request.cpu_request,
                 cpu_limit=resource_request.cpu_limit,
                 memory_request=resource_request.memory_request,
+                liveness_probe=liveness_probe_client,
+                readiness_probe=readiness_probe_client,
             )
 
         target_env_vars: List[client.EnvVar] = []

--- a/python/sdk/merlin/probe_config.py
+++ b/python/sdk/merlin/probe_config.py
@@ -44,7 +44,8 @@ class ProbeConfig:
         self._failure_threshold = failure_threshold
 
     @classmethod
-    def from_response(cls, response: client.ProbeConfig) -> Optional[ProbeConfig]:
+    def from_response(cls, response: client.ProbeConfig) -> Optional["ProbeConfig"]:
+        """Create a ProbeConfig from a client.ProbeConfig response object."""
         if response is None:
             return None
         return ProbeConfig(
@@ -59,6 +60,7 @@ class ProbeConfig:
         )
 
     def to_client_probe_config(self) -> client.ProbeConfig:
+        """Convert to a client.ProbeConfig object for API calls."""
         return client.ProbeConfig(
             path=self._path,
             port=self._port,

--- a/python/sdk/merlin/probe_config.py
+++ b/python/sdk/merlin/probe_config.py
@@ -1,0 +1,136 @@
+# Copyright 2020 The Merlin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from typing import Optional
+
+import client
+
+
+class ProbeConfig:
+    """
+    Configuration for Kubernetes liveness/readiness probes.
+    """
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        port: Optional[int] = None,
+        scheme: Optional[str] = None,
+        initial_delay_seconds: Optional[int] = None,
+        timeout_seconds: Optional[int] = None,
+        period_seconds: Optional[int] = None,
+        success_threshold: Optional[int] = None,
+        failure_threshold: Optional[int] = None,
+    ):
+        self._path = path
+        self._port = port
+        self._scheme = scheme
+        self._initial_delay_seconds = initial_delay_seconds
+        self._timeout_seconds = timeout_seconds
+        self._period_seconds = period_seconds
+        self._success_threshold = success_threshold
+        self._failure_threshold = failure_threshold
+
+    @classmethod
+    def from_response(cls, response: client.ProbeConfig) -> Optional[ProbeConfig]:
+        if response is None:
+            return None
+        return ProbeConfig(
+            path=response.path,
+            port=response.port,
+            scheme=response.scheme,
+            initial_delay_seconds=response.initial_delay_seconds,
+            timeout_seconds=response.timeout_seconds,
+            period_seconds=response.period_seconds,
+            success_threshold=response.success_threshold,
+            failure_threshold=response.failure_threshold,
+        )
+
+    def to_client_probe_config(self) -> client.ProbeConfig:
+        return client.ProbeConfig(
+            path=self._path,
+            port=self._port,
+            scheme=self._scheme,
+            initial_delay_seconds=self._initial_delay_seconds,
+            timeout_seconds=self._timeout_seconds,
+            period_seconds=self._period_seconds,
+            success_threshold=self._success_threshold,
+            failure_threshold=self._failure_threshold,
+        )
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        self._path = path
+
+    @property
+    def port(self) -> Optional[int]:
+        return self._port
+
+    @port.setter
+    def port(self, port):
+        self._port = port
+
+    @property
+    def scheme(self) -> Optional[str]:
+        return self._scheme
+
+    @scheme.setter
+    def scheme(self, scheme):
+        self._scheme = scheme
+
+    @property
+    def initial_delay_seconds(self) -> Optional[int]:
+        return self._initial_delay_seconds
+
+    @initial_delay_seconds.setter
+    def initial_delay_seconds(self, initial_delay_seconds):
+        self._initial_delay_seconds = initial_delay_seconds
+
+    @property
+    def timeout_seconds(self) -> Optional[int]:
+        return self._timeout_seconds
+
+    @timeout_seconds.setter
+    def timeout_seconds(self, timeout_seconds):
+        self._timeout_seconds = timeout_seconds
+
+    @property
+    def period_seconds(self) -> Optional[int]:
+        return self._period_seconds
+
+    @period_seconds.setter
+    def period_seconds(self, period_seconds):
+        self._period_seconds = period_seconds
+
+    @property
+    def success_threshold(self) -> Optional[int]:
+        return self._success_threshold
+
+    @success_threshold.setter
+    def success_threshold(self, success_threshold):
+        self._success_threshold = success_threshold
+
+    @property
+    def failure_threshold(self) -> Optional[int]:
+        return self._failure_threshold
+
+    @failure_threshold.setter
+    def failure_threshold(self, failure_threshold):
+        self._failure_threshold = failure_threshold
+

--- a/python/sdk/merlin/probe_config.py
+++ b/python/sdk/merlin/probe_config.py
@@ -44,7 +44,7 @@ class ProbeConfig:
         self._failure_threshold = failure_threshold
 
     @classmethod
-    def from_response(cls, response: client.ProbeConfig) -> Optional["ProbeConfig"]:
+    def from_response(cls, response) -> Optional["ProbeConfig"]:
         """Create a ProbeConfig from a client.ProbeConfig response object."""
         if response is None:
             return None
@@ -59,7 +59,7 @@ class ProbeConfig:
             failure_threshold=response.failure_threshold,
         )
 
-    def to_client_probe_config(self) -> client.ProbeConfig:
+    def to_client_probe_config(self):
         """Convert to a client.ProbeConfig object for API calls."""
         return client.ProbeConfig(
             path=self._path,

--- a/python/sdk/merlin/resource_request.py
+++ b/python/sdk/merlin/resource_request.py
@@ -151,3 +151,25 @@ class ResourceRequest:
 
         if self._max_replica < 1:
             raise Exception("Max replica must be greater than 0")
+
+    def to_client_resource_request(self):
+        """Convert to a client.ResourceRequest object for API calls."""
+        liveness_probe_client = None
+        readiness_probe_client = None
+        if self._liveness_probe is not None:
+            liveness_probe_client = self._liveness_probe.to_client_probe_config()
+        if self._readiness_probe is not None:
+            readiness_probe_client = self._readiness_probe.to_client_probe_config()
+
+        return client.ResourceRequest(
+            min_replica=self._min_replica,
+            max_replica=self._max_replica,
+            cpu_request=self._cpu_request,
+            cpu_limit=self._cpu_limit,
+            memory_request=self._memory_request,
+            gpu_name=self._gpu_name,
+            gpu_request=self._gpu_request,
+            liveness_probe=liveness_probe_client,
+            readiness_probe=readiness_probe_client,
+        )
+

--- a/python/sdk/merlin/resource_request.py
+++ b/python/sdk/merlin/resource_request.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Optional
 
 import client
+from merlin.probe_config import ProbeConfig
 
 
 class ResourceRequest:
@@ -32,6 +33,8 @@ class ResourceRequest:
         memory_request: Optional[str] = None,
         gpu_request: Optional[str] = None,
         gpu_name: Optional[str] = None,
+        liveness_probe: Optional[ProbeConfig] = None,
+        readiness_probe: Optional[ProbeConfig] = None,
     ):
         self._min_replica = min_replica
         self._max_replica = max_replica
@@ -40,10 +43,21 @@ class ResourceRequest:
         self._memory_request = memory_request
         self._gpu_request = gpu_request
         self._gpu_name = gpu_name
+        self._liveness_probe = liveness_probe
+        self._readiness_probe = readiness_probe
         self.validate()
 
     @classmethod
     def from_response(cls, response: client.ResourceRequest) -> ResourceRequest:
+        liveness_probe = None
+        readiness_probe = None
+
+        if hasattr(response, 'liveness_probe') and response.liveness_probe is not None:
+            liveness_probe = ProbeConfig.from_response(response.liveness_probe)
+
+        if hasattr(response, 'readiness_probe') and response.readiness_probe is not None:
+            readiness_probe = ProbeConfig.from_response(response.readiness_probe)
+
         return ResourceRequest(
             min_replica=response.min_replica,
             max_replica=response.max_replica,
@@ -52,6 +66,8 @@ class ResourceRequest:
             memory_request=response.memory_request,
             gpu_request=response.gpu_request,
             gpu_name=response.gpu_name,
+            liveness_probe=liveness_probe,
+            readiness_probe=readiness_probe,
         )
 
     @property
@@ -109,6 +125,22 @@ class ResourceRequest:
     @gpu_name.setter
     def gpu_name(self, gpu_name):
         self._gpu_name = gpu_name
+
+    @property
+    def liveness_probe(self) -> Optional[ProbeConfig]:
+        return self._liveness_probe
+
+    @liveness_probe.setter
+    def liveness_probe(self, liveness_probe):
+        self._liveness_probe = liveness_probe
+
+    @property
+    def readiness_probe(self) -> Optional[ProbeConfig]:
+        return self._readiness_probe
+
+    @readiness_probe.setter
+    def readiness_probe(self, readiness_probe):
+        self._readiness_probe = readiness_probe
 
     def validate(self):
         if self._min_replica is None and self._max_replica is None:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -2117,6 +2117,43 @@ components:
           type: string
         gpu_request:
           type: string
+        liveness_probe:
+          "$ref": "#/components/schemas/ProbeConfig"
+        readiness_probe:
+          "$ref": "#/components/schemas/ProbeConfig"
+    ProbeConfig:
+      type: object
+      properties:
+        path:
+          type: string
+          description: Path for HTTP probe
+        port:
+          type: integer
+          format: int32
+          description: Port for the probe
+        scheme:
+          type: string
+          description: Scheme for HTTP probe (HTTP or HTTPS)
+        initial_delay_seconds:
+          type: integer
+          format: int32
+          description: Initial delay before starting the probe (seconds)
+        timeout_seconds:
+          type: integer
+          format: int32
+          description: Timeout for the probe (seconds)
+        period_seconds:
+          type: integer
+          format: int32
+          description: Period between probe checks (seconds)
+        success_threshold:
+          type: integer
+          format: int32
+          description: Number of successes required to be considered healthy
+        failure_threshold:
+          type: integer
+          format: int32
+          description: Number of failures before considered unhealthy
     AutoscalingPolicy:
       type: object
       required:

--- a/ui/src/components/ResourcesConfigTable.js
+++ b/ui/src/components/ResourcesConfigTable.js
@@ -27,6 +27,8 @@ export const ResourcesConfigTable = ({
     max_replica,
     gpu_name,
     gpu_request,
+    liveness_probe,
+    readiness_probe,
   },
 }) => {
   const items = [
@@ -66,6 +68,40 @@ export const ResourcesConfigTable = ({
       title: "GPU Request",
       description: gpu_request,
     });
+  }
+
+  // Add liveness probe info if configured
+  if (liveness_probe && Object.keys(liveness_probe).some(k => liveness_probe[k])) {
+    const probeDetails = [];
+    if (liveness_probe.initial_delay_seconds) probeDetails.push(`delay: ${liveness_probe.initial_delay_seconds}s`);
+    if (liveness_probe.timeout_seconds) probeDetails.push(`timeout: ${liveness_probe.timeout_seconds}s`);
+    if (liveness_probe.period_seconds) probeDetails.push(`period: ${liveness_probe.period_seconds}s`);
+    if (liveness_probe.failure_threshold) probeDetails.push(`failures: ${liveness_probe.failure_threshold}`);
+    if (liveness_probe.success_threshold) probeDetails.push(`successes: ${liveness_probe.success_threshold}`);
+    if (liveness_probe.path) probeDetails.push(`path: ${liveness_probe.path}`);
+    if (probeDetails.length > 0) {
+      items.push({
+        title: "Liveness Probe",
+        description: probeDetails.join(", "),
+      });
+    }
+  }
+
+  // Add readiness probe info if configured
+  if (readiness_probe && Object.keys(readiness_probe).some(k => readiness_probe[k])) {
+    const probeDetails = [];
+    if (readiness_probe.initial_delay_seconds) probeDetails.push(`delay: ${readiness_probe.initial_delay_seconds}s`);
+    if (readiness_probe.timeout_seconds) probeDetails.push(`timeout: ${readiness_probe.timeout_seconds}s`);
+    if (readiness_probe.period_seconds) probeDetails.push(`period: ${readiness_probe.period_seconds}s`);
+    if (readiness_probe.failure_threshold) probeDetails.push(`failures: ${readiness_probe.failure_threshold}`);
+    if (readiness_probe.success_threshold) probeDetails.push(`successes: ${readiness_probe.success_threshold}`);
+    if (readiness_probe.path) probeDetails.push(`path: ${readiness_probe.path}`);
+    if (probeDetails.length > 0) {
+      items.push({
+        title: "Readiness Probe",
+        description: probeDetails.join(", "),
+      });
+    }
   }
 
   return (

--- a/ui/src/pages/version/components/forms/DeployModelVersionForm.js
+++ b/ui/src/pages/version/components/forms/DeployModelVersionForm.js
@@ -58,6 +58,19 @@ export const DeployModelVersionForm = ({
     if (versionEndpoint?.resource_request?.cpu_limit === "") {
       delete versionEndpoint.resource_request.cpu_limit;
     }
+    // Clean up empty probe configurations
+    if (versionEndpoint?.resource_request?.liveness_probe) {
+      const probe = versionEndpoint.resource_request.liveness_probe;
+      if (!Object.keys(probe).some(k => probe[k])) {
+        delete versionEndpoint.resource_request.liveness_probe;
+      }
+    }
+    if (versionEndpoint?.resource_request?.readiness_probe) {
+      const probe = versionEndpoint.resource_request.readiness_probe;
+      if (!Object.keys(probe).some(k => probe[k])) {
+        delete versionEndpoint.resource_request.readiness_probe;
+      }
+    }
     if (versionEndpoint?.image_builder_resource_request?.cpu_request === "") {
       delete versionEndpoint.image_builder_resource_request.cpu_request;
     }

--- a/ui/src/pages/version/components/forms/components/ProbesFormGroup.js
+++ b/ui/src/pages/version/components/forms/components/ProbesFormGroup.js
@@ -1,0 +1,201 @@
+import React, { Fragment } from "react";
+import { FormLabelWithToolTip, useOnChangeHandler } from "@caraml-dev/ui-lib";
+import {
+  EuiDescribedFormGroup,
+  EuiFieldNumber,
+  EuiFieldText,
+  EuiFormRow,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+} from "@elastic/eui";
+
+export const ProbesFormGroup = ({
+  resourcesConfig,
+  onChangeHandler,
+  errors = {},
+}) => {
+  const { onChange } = useOnChangeHandler(onChangeHandler);
+
+  const handleProbeChange = (probeType, field) => (e) => {
+    const value = e.target.value;
+    const currentProbe = resourcesConfig?.[probeType] || {};
+    onChange(probeType)({
+      ...currentProbe,
+      [field]: field === "path" || field === "scheme" ? value : (value === "" ? undefined : parseInt(value, 10)),
+    });
+  };
+
+  const renderProbeFields = (probeType, title, description) => (
+    <EuiDescribedFormGroup
+      title={<p>{title}</p>}
+      description={<Fragment>{description}</Fragment>}
+      fullWidth
+    >
+      <EuiFlexGroup direction="column" gutterSize="s">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s">
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Initial Delay (s)"
+                    content="Number of seconds after the container starts before the probe is initiated."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.initial_delay_seconds}
+                error={errors?.[probeType]?.initial_delay_seconds}
+                fullWidth
+              >
+                <EuiFieldNumber
+                  placeholder="30"
+                  value={resourcesConfig?.[probeType]?.initial_delay_seconds ?? ""}
+                  onChange={handleProbeChange(probeType, "initial_delay_seconds")}
+                  isInvalid={!!errors?.[probeType]?.initial_delay_seconds}
+                  min={0}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Timeout (s)"
+                    content="Number of seconds after which the probe times out."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.timeout_seconds}
+                error={errors?.[probeType]?.timeout_seconds}
+                fullWidth
+              >
+                <EuiFieldNumber
+                  placeholder="5"
+                  value={resourcesConfig?.[probeType]?.timeout_seconds ?? ""}
+                  onChange={handleProbeChange(probeType, "timeout_seconds")}
+                  isInvalid={!!errors?.[probeType]?.timeout_seconds}
+                  min={1}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s">
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Period (s)"
+                    content="How often (in seconds) to perform the probe."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.period_seconds}
+                error={errors?.[probeType]?.period_seconds}
+                fullWidth
+              >
+                <EuiFieldNumber
+                  placeholder="10"
+                  value={resourcesConfig?.[probeType]?.period_seconds ?? ""}
+                  onChange={handleProbeChange(probeType, "period_seconds")}
+                  isInvalid={!!errors?.[probeType]?.period_seconds}
+                  min={1}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Failure Threshold"
+                    content="Number of consecutive failures before the container is considered unhealthy."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.failure_threshold}
+                error={errors?.[probeType]?.failure_threshold}
+                fullWidth
+              >
+                <EuiFieldNumber
+                  placeholder="3"
+                  value={resourcesConfig?.[probeType]?.failure_threshold ?? ""}
+                  onChange={handleProbeChange(probeType, "failure_threshold")}
+                  isInvalid={!!errors?.[probeType]?.failure_threshold}
+                  min={1}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="s">
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Success Threshold"
+                    content="Number of consecutive successes before the container is considered healthy."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.success_threshold}
+                error={errors?.[probeType]?.success_threshold}
+                fullWidth
+              >
+                <EuiFieldNumber
+                  placeholder="1"
+                  value={resourcesConfig?.[probeType]?.success_threshold ?? ""}
+                  onChange={handleProbeChange(probeType, "success_threshold")}
+                  isInvalid={!!errors?.[probeType]?.success_threshold}
+                  min={1}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiFormRow
+                label={
+                  <FormLabelWithToolTip
+                    label="Path"
+                    content="HTTP path for the probe endpoint (optional, uses platform default if not set)."
+                  />
+                }
+                isInvalid={!!errors?.[probeType]?.path}
+                error={errors?.[probeType]?.path}
+                fullWidth
+              >
+                <EuiFieldText
+                  placeholder="/health"
+                  value={resourcesConfig?.[probeType]?.path ?? ""}
+                  onChange={handleProbeChange(probeType, "path")}
+                  isInvalid={!!errors?.[probeType]?.path}
+                  fullWidth
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiDescribedFormGroup>
+  );
+
+  return (
+    <Fragment>
+      {renderProbeFields(
+        "liveness_probe",
+        "Liveness Probe",
+        "Configure the liveness probe to determine if the container is running. Empty values use platform defaults."
+      )}
+      <EuiSpacer size="m" />
+      {renderProbeFields(
+        "readiness_probe",
+        "Readiness Probe",
+        "Configure the readiness probe to determine if the container is ready to receive traffic. Empty values use platform defaults."
+      )}
+    </Fragment>
+  );
+};
+

--- a/ui/src/pages/version/components/forms/steps/ModelStep.js
+++ b/ui/src/pages/version/components/forms/steps/ModelStep.js
@@ -14,6 +14,7 @@ import { LoggerPanel } from "../components/LoggerPanel";
 import { ResourcesPanel } from "../components/ResourcesPanel";
 import { ImageBuilderSection } from "../components/ImageBuilderSection";
 import { CPULimitsFormGroup } from "../components/CPULimitsFormGroup";
+import { ProbesFormGroup } from "../components/ProbesFormGroup";
 
 export const ModelStep = ({ version, isEnvironmentDisabled = false, maxAllowedReplica, setMaxAllowedReplica }) => {
   const { data, onChangeHandler } = useContext(FormContext);
@@ -52,6 +53,13 @@ export const ModelStep = ({ version, isEnvironmentDisabled = false, maxAllowedRe
                 onChangeHandler={onChange("resource_request")}
                 errors={get(errors, "resource_request")}
               />
+              <EuiSpacer size="m" />
+              <ProbesFormGroup
+                resourcesConfig={data.resource_request}
+                onChangeHandler={onChange("resource_request")}
+                errors={get(errors, "resource_request")}
+              />
+              <EuiSpacer size="m" />
               <ImageBuilderSection
                 imageBuilderResourceConfig={data.image_builder_resource_request}
                 onChangeHandler={onChange("image_builder_resource_request")}

--- a/ui/src/services/version_endpoint/VersionEndpoint.js
+++ b/ui/src/services/version_endpoint/VersionEndpoint.js
@@ -28,6 +28,8 @@ export class VersionEndpoint {
       cpu_request: "500m",
       cpu_limit: "",
       memory_request: "512Mi",
+      liveness_probe: null,
+      readiness_probe: null,
     };
 
     this.image_builder_resource_request = {


### PR DESCRIPTION
<!--
  Thanks for sending a pull request!
  Here are some tips for you:
  1. Run unit tests and ensure that they are passing
  2. If your change introduces any API changes, make sure to update the e2e tests
  3. Make sure documentation is updated for your PR!
-->

# Description
This PR adds support for configurable liveness and readiness probes in Merlin model deployments, allowing users to customize probe parameters through both the UI and Python SDK. This enhancement provides users with fine-grained control over health check behavior for their model deployments
<!--
  Briefly describe the motivation for the change.
  Please include illustrations where appropriate.
-->

# Modifications
<!--
  Summarize the key code changes.
-->
Sending the Liveness and Readiness probes config values from the UI. 

## Backend API changes
Extended ResourceRequest model to support two new optional fields:
 - liveness_probe
 - readiness_probe
 
Updated deployment templating so provided probes are rendered into Kubernetes resources

Relevant areas:
- api/service/deployment_service.go
- api/cluster/resource/templater.go

## UI changes
Added UI controls to configure liveness & readiness probe parameters.
Updated deployment details view to display saved probe configs after deployment (like CPU limits).

## Python SDK
Added liveness and readiness probe configuration support to the Python SDK, enabling programmatic probe customization

## Screenshot of Ui changes
<img width="1975" height="1198" alt="image" src="https://github.com/user-attachments/assets/cfec6199-cd8c-4657-824c-934b567fd800" />
