### PR TITLE
fix(sdk): bump python SDK docker base to slim-trixie

### DIFF
--- a/python/sdk/Dockerfile
+++ b/python/sdk/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.9
-FROM python:${PYTHON_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}-slim-trixie
 
 LABEL org.opencontainers.image.source https://github.com/caraml-dev/merlin
 


### PR DESCRIPTION
# Description
Debian buster reached EOL in 2024-06 and its repositories are now in the archive, so apt-get update in python/sdk/Dockerfile fails during the release / publish-python-sdk-docker job. Bump the base to trixie (current Debian stable) to unblock the release pipeline.

# Modifications
- `python/sdk/Dockerfile`: change base image from `python:${PYTHON_VERSION}-slim-buster` to `python:${PYTHON_VERSION}-slim-trixie` (one-line change).

# Tests
Tested building docker image locally

# Checklist
- [x] Added PR label
- [ ] Added unit test, integration, and/or e2e tests
- [x] Tested locally
- [ ] Updated documentation
- [ ] Update Swagger spec if the PR introduce API changes
- [ ] Regenerated Golang and Python client if the PR introduces API changes

# Release Notes
```release-note
NONE
```
