### PR TITLE
bug: fixing the endpoint msg string causing model in pending state

### DIFF
--- a/api/storage/deployment_storage.go
+++ b/api/storage/deployment_storage.go
@@ -16,9 +16,11 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 
 	"gorm.io/gorm"
 
+	"github.com/caraml-dev/merlin/log"
 	"github.com/caraml-dev/merlin/models"
 )
 
@@ -61,8 +63,21 @@ func (d *deploymentStorage) ListInModelVersion(modelID, versionID, endpointUUID 
 }
 
 func (d *deploymentStorage) Save(deployment *models.Deployment) (*models.Deployment, error) {
-	err := d.db.Save(deployment).Error
-	return deployment, err
+	// Ensure the error message is valid UTF-8 before persisting to avoid
+	// Postgres rejecting invalid byte sequences (SQLSTATE 22021).
+	deployment.Error = strings.ToValidUTF8(deployment.Error, "")
+
+	if err := d.db.Save(deployment).Error; err != nil {
+		if invalid := invalidUTF8Fields(map[string]string{
+			"status": string(deployment.Status),
+			"error":  deployment.Error,
+		}); len(invalid) > 0 {
+			log.Errorf("failed to save deployment (id: %d): invalid UTF-8 in column(s) %s: %v", deployment.ID, strings.Join(invalid, ", "), err)
+		}
+		return deployment, err
+	}
+
+	return deployment, nil
 }
 
 func (d *deploymentStorage) GetLatestDeployment(modelID models.ID, versionID models.ID) (*models.Deployment, error) {

--- a/api/storage/deployment_storage.go
+++ b/api/storage/deployment_storage.go
@@ -16,11 +16,9 @@ package storage
 
 import (
 	"fmt"
-	"strings"
 
 	"gorm.io/gorm"
 
-	"github.com/caraml-dev/merlin/log"
 	"github.com/caraml-dev/merlin/models"
 )
 
@@ -63,21 +61,8 @@ func (d *deploymentStorage) ListInModelVersion(modelID, versionID, endpointUUID 
 }
 
 func (d *deploymentStorage) Save(deployment *models.Deployment) (*models.Deployment, error) {
-	// Ensure the error message is valid UTF-8 before persisting to avoid
-	// Postgres rejecting invalid byte sequences (SQLSTATE 22021).
-	deployment.Error = strings.ToValidUTF8(deployment.Error, "")
-
-	if err := d.db.Save(deployment).Error; err != nil {
-		if invalid := invalidUTF8Fields(map[string]string{
-			"status": string(deployment.Status),
-			"error":  deployment.Error,
-		}); len(invalid) > 0 {
-			log.Errorf("failed to save deployment (id: %d): invalid UTF-8 in column(s) %s: %v", deployment.ID, strings.Join(invalid, ", "), err)
-		}
-		return deployment, err
-	}
-
-	return deployment, nil
+	err := d.db.Save(deployment).Error
+	return deployment, err
 }
 
 func (d *deploymentStorage) GetLatestDeployment(modelID models.ID, versionID models.ID) (*models.Deployment, error) {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -15,14 +15,11 @@
 package storage
 
 import (
-	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
-	"github.com/caraml-dev/merlin/log"
 	"github.com/caraml-dev/merlin/models"
 )
 
@@ -61,17 +58,6 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	sanitizeEndpoint(endpoint)
 
 	if err := v.db.Save(&endpoint).Error; err != nil {
-		if invalid := invalidUTF8Fields(map[string]string{
-			"status":                 string(endpoint.Status),
-			"url":                    endpoint.URL,
-			"service_name":           endpoint.ServiceName,
-			"inference_service_name": endpoint.InferenceServiceName,
-			"namespace":              endpoint.Namespace,
-			"environment_name":       endpoint.EnvironmentName,
-			"message":                endpoint.Message,
-		}); len(invalid) > 0 {
-			log.Errorf("failed to save version_endpoint (id: %s): invalid UTF-8 in column(s) %s: %v", endpoint.ID, strings.Join(invalid, ", "), err)
-		}
 		return err
 	}
 
@@ -82,19 +68,6 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	return nil
 }
 
-// invalidUTF8Fields returns the names of the given columns whose values are not
-// valid UTF-8. Postgres reports "invalid byte sequence for encoding UTF8"
-// (SQLSTATE 22021) without naming the offending column, so this pinpoints it.
-func invalidUTF8Fields(fields map[string]string) []string {
-	var invalid []string
-	for name, value := range fields {
-		if !utf8.ValidString(value) {
-			invalid = append(invalid, fmt.Sprintf("%s (len=%d)", name, len(value)))
-		}
-	}
-	return invalid
-}
-
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {
 	message := strings.ToValidUTF8(endpoint.Message, "")
 	if len(message) > maxMessageChar {
@@ -102,10 +75,6 @@ func sanitizeEndpoint(endpoint *models.VersionEndpoint) {
 		message = strings.ToValidUTF8(message, "")
 	}
 	endpoint.Message = message
-
-	// Status only ever holds controlled constants, but sanitize defensively to
-	// guarantee a valid UTF-8 byte sequence is persisted (avoids SQLSTATE 22021).
-	endpoint.Status = models.EndpointStatus(strings.ToValidUTF8(string(endpoint.Status), ""))
 }
 
 func (v *versionEndpointStorage) CountEndpoints(environment *models.Environment, model *models.Model) (int, error) {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -15,11 +15,14 @@
 package storage
 
 import (
+	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
+	"github.com/caraml-dev/merlin/log"
 	"github.com/caraml-dev/merlin/models"
 )
 
@@ -58,6 +61,17 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	sanitizeEndpoint(endpoint)
 
 	if err := v.db.Save(&endpoint).Error; err != nil {
+		if invalid := invalidUTF8Fields(map[string]string{
+			"status":                 string(endpoint.Status),
+			"url":                    endpoint.URL,
+			"service_name":           endpoint.ServiceName,
+			"inference_service_name": endpoint.InferenceServiceName,
+			"namespace":              endpoint.Namespace,
+			"environment_name":       endpoint.EnvironmentName,
+			"message":                endpoint.Message,
+		}); len(invalid) > 0 {
+			log.Errorf("failed to save version_endpoint (id: %s): invalid UTF-8 in column(s) %s: %v", endpoint.ID, strings.Join(invalid, ", "), err)
+		}
 		return err
 	}
 
@@ -68,6 +82,19 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 	return nil
 }
 
+// invalidUTF8Fields returns the names of the given columns whose values are not
+// valid UTF-8. Postgres reports "invalid byte sequence for encoding UTF8"
+// (SQLSTATE 22021) without naming the offending column, so this pinpoints it.
+func invalidUTF8Fields(fields map[string]string) []string {
+	var invalid []string
+	for name, value := range fields {
+		if !utf8.ValidString(value) {
+			invalid = append(invalid, fmt.Sprintf("%s (len=%d)", name, len(value)))
+		}
+	}
+	return invalid
+}
+
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {
 	message := strings.ToValidUTF8(endpoint.Message, "")
 	if len(message) > maxMessageChar {
@@ -75,6 +102,10 @@ func sanitizeEndpoint(endpoint *models.VersionEndpoint) {
 		message = strings.ToValidUTF8(message, "")
 	}
 	endpoint.Message = message
+
+	// Status only ever holds controlled constants, but sanitize defensively to
+	// guarantee a valid UTF-8 byte sequence is persisted (avoids SQLSTATE 22021).
+	endpoint.Status = models.EndpointStatus(strings.ToValidUTF8(string(endpoint.Status), ""))
 }
 
 func (v *versionEndpointStorage) CountEndpoints(environment *models.Environment, model *models.Model) (int, error) {

--- a/api/storage/version_endpoint_storage.go
+++ b/api/storage/version_endpoint_storage.go
@@ -15,6 +15,8 @@
 package storage
 
 import (
+	"strings"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
@@ -67,9 +69,10 @@ func (v *versionEndpointStorage) Save(endpoint *models.VersionEndpoint) error {
 }
 
 func sanitizeEndpoint(endpoint *models.VersionEndpoint) {
-	message := endpoint.Message
+	message := strings.ToValidUTF8(endpoint.Message, "")
 	if len(message) > maxMessageChar {
 		message = message[:maxMessageChar]
+		message = strings.ToValidUTF8(message, "")
 	}
 	endpoint.Message = message
 }

--- a/scripts/e2e/config/istio/clusterlocal-gateway.yaml
+++ b/scripts/e2e/config/istio/clusterlocal-gateway.yaml
@@ -15,6 +15,11 @@ resources:
     cpu: "1"
     memory: 1Gi
 
+securityContext:
+  runAsUser: 1337
+  runAsGroup: 1337
+  runAsNonRoot: true
+
 service:
   type: ClusterIP
   ports:

--- a/scripts/e2e/config/istio/ingress-gateway.yaml
+++ b/scripts/e2e/config/istio/ingress-gateway.yaml
@@ -5,3 +5,8 @@ resources:
   requests:
     cpu: 50m
     memory: 64Mi
+
+securityContext:
+  runAsUser: 1337
+  runAsGroup: 1337
+  runAsNonRoot: true

--- a/scripts/e2e/setup-cluster.sh
+++ b/scripts/e2e/setup-cluster.sh
@@ -23,7 +23,7 @@ KNATIVE_NET_ISTIO_VERSION=1.10.1
 CERT_MANAGER_VERSION=1.12.2
 MINIO_VERSION=3.6.3
 KSERVE_VERSION=0.11.0
-TIMEOUT=180s
+TIMEOUT=300s
 
 
 add_helm_repo() {
@@ -66,9 +66,33 @@ install_istio() {
     helm upgrade --install cluster-local-gateway istio/gateway -n istio-system --create-namespace \
         -f config/istio/clusterlocal-gateway.yaml --timeout=${TIMEOUT}
 
-    kubectl rollout status deployment/istio-ingressgateway -n istio-system -w --timeout=${TIMEOUT}
-    kubectl rollout status deployment/istiod -w -n istio-system --timeout=${TIMEOUT}
-    kubectl rollout status deployment/cluster-local-gateway -n istio-system -w --timeout=${TIMEOUT}
+    kubectl rollout status deployment/istio-ingressgateway -n istio-system -w --timeout=${TIMEOUT} || {
+        echo "::group::DEBUG istio-ingressgateway rollout failure"
+        kubectl get pods -n istio-system -o wide
+        kubectl describe pod -n istio-system -l app=istio-ingressgateway
+        kubectl logs -n istio-system -l app=istio-ingressgateway --tail=200 || true
+        kubectl get events -n istio-system --sort-by='.lastTimestamp'
+        echo "::endgroup::"
+        exit 1
+    }
+
+    kubectl rollout status deployment/istiod -w -n istio-system --timeout=${TIMEOUT} || {
+        echo "::group::DEBUG istiod rollout failure"
+        kubectl get pods -n istio-system -o wide
+        kubectl describe pod -n istio-system -l app=istiod
+        kubectl get events -n istio-system --sort-by='.lastTimestamp'
+        echo "::endgroup::"
+        exit 1
+    }
+
+    kubectl rollout status deployment/cluster-local-gateway -n istio-system -w --timeout=${TIMEOUT} || {
+        echo "::group::DEBUG cluster-local-gateway rollout failure"
+        kubectl get pods -n istio-system -o wide
+        kubectl describe pod -n istio-system -l app=cluster-local-gateway
+        kubectl get events -n istio-system --sort-by='.lastTimestamp'
+        echo "::endgroup::"
+        exit 1
+    }
 
     kubectl apply --server-side -f config/istio/ingress-class.yaml
 

--- a/scripts/e2e/setup-cluster.sh
+++ b/scripts/e2e/setup-cluster.sh
@@ -66,33 +66,9 @@ install_istio() {
     helm upgrade --install cluster-local-gateway istio/gateway -n istio-system --create-namespace \
         -f config/istio/clusterlocal-gateway.yaml --timeout=${TIMEOUT}
 
-    kubectl rollout status deployment/istio-ingressgateway -n istio-system -w --timeout=${TIMEOUT} || {
-        echo "::group::DEBUG istio-ingressgateway rollout failure"
-        kubectl get pods -n istio-system -o wide
-        kubectl describe pod -n istio-system -l app=istio-ingressgateway
-        kubectl logs -n istio-system -l app=istio-ingressgateway --tail=200 || true
-        kubectl get events -n istio-system --sort-by='.lastTimestamp'
-        echo "::endgroup::"
-        exit 1
-    }
-
-    kubectl rollout status deployment/istiod -w -n istio-system --timeout=${TIMEOUT} || {
-        echo "::group::DEBUG istiod rollout failure"
-        kubectl get pods -n istio-system -o wide
-        kubectl describe pod -n istio-system -l app=istiod
-        kubectl get events -n istio-system --sort-by='.lastTimestamp'
-        echo "::endgroup::"
-        exit 1
-    }
-
-    kubectl rollout status deployment/cluster-local-gateway -n istio-system -w --timeout=${TIMEOUT} || {
-        echo "::group::DEBUG cluster-local-gateway rollout failure"
-        kubectl get pods -n istio-system -o wide
-        kubectl describe pod -n istio-system -l app=cluster-local-gateway
-        kubectl get events -n istio-system --sort-by='.lastTimestamp'
-        echo "::endgroup::"
-        exit 1
-    }
+    kubectl rollout status deployment/istio-ingressgateway -n istio-system -w --timeout=${TIMEOUT}
+    kubectl rollout status deployment/istiod -w -n istio-system --timeout=${TIMEOUT}
+    kubectl rollout status deployment/cluster-local-gateway -n istio-system -w --timeout=${TIMEOUT}
 
     kubectl apply --server-side -f config/istio/ingress-class.yaml
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->
## What

Fix Postgres `invalid byte sequence for encoding "UTF8" (SQLSTATE 22021)` error when saving a version endpoint's deployment message.

## Why

When a deployment fails, the Kubernetes error text (which often contains multi-byte box-drawing chars like `─` = `0xe2 0x94 0x80`) is stored in `version_endpoints.message`. `sanitizeEndpoint` truncated it to `maxMessageChar` by **byte** slicing, which could cut a multi-byte character in half, leaving an invalid trailing sequence (e.g. `0xe2 0x94`). Postgres then rejected the write, so the endpoint status/message never updated:


## Error example  
``` 
merlin {"level":"error","ts":1783331067.766427,"caller":"work/model_service_deployment.go:164","msg":"unable to update endpoint status for model: external-demo, version: 16, reason: ERROR: invalid byte sequence for encoding \"UTF8\": 0xe2 0x94 (SQLSTATE 22021)","stacktrace":"github.com/caraml-dev/merlin/queue/work.(*ModelServiceDeployment).Deploy.func1\n\t/src/api/queue/work/model_service_deployment.go:164\ngithub.com/caraml-dev/merlin/queue/work.(*ModelServiceDeployment).Deploy\n\t/src/api/queue/work/model_service_deployment.go:189\ngithub.com/caraml-dev/merlin/queue.(*worker).processJob\n\t/src/api/queue/worker.go:81"}

```

